### PR TITLE
Assign students to cohorts by uploading a csv file

### DIFF
--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -339,8 +339,9 @@ The results file provides the following information:
     * - Students Added
       - The number of students added to the cohort group during the row by row
         processing of the .csv file.             
-    * - Students Not Found      
-      - The number of students who could not be matched by either email address
+    * - Students Not Found
+      - A list of email addresses or usernames (if email addresses were not
+        supplied) of students who could not be matched by either email address
         or username and who were therefore not added to the cohort group.
              
 For a report that includes the cohort group assignment for every enrolled

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -269,17 +269,22 @@ The requirements for the .csv file are summarized in this table.
     * - Header row
       - Must have a header row, with column names exactly as
         specified in "Columns" below.
-    * - Columns 
-  
-      - Must have at least 2 columns: 1) "email" or "username", or both; 2)
-        "cohort".
+    * - One or two columns identifying students      
+      - Must have at least one column identifying students: 
+        
+        either "email" or "username", or both. 
 
-        * If both the username and an email address are provided for a
-          student, the email address has precedence. In other words, if an email address
-          is present, an incorrect or non-matching username is ignored.
+        If both the username and an email address are provided for a student,
+        the email address has precedence. 
 
-        * Cohort names must already have been created in Studio.       
-        * Columns other than "Email", "Username" and "Cohort" are ignored.
+        In other words, if an email address is present, an incorrect or non-
+        matching username is ignored.
+
+    * - One column identifying the cohort group      
+      - The column must be named "cohort", containing cohort groups already
+        existing in Studio.     
+    * -             
+      - Columns other than "Email", "Username" and "Cohort" are ignored.
 
 Follow these steps to assign students to cohort groups by uploading a .csv file.     
       

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -235,13 +235,23 @@ email addresses directly on the Membership page in the Instructor Dashboard, you
 can also upload a .csv file containing a list of students and the cohort groups
 you want to assign them to.
 
-.. note:: Any assignments to cohort groups that you specify in the .csv files
-  you upload will overwrite or change existing cohort group assignments. The
-  configuration of your cohort groups should be complete and stable before your
-  course begins. You should also complete manual cohort assignments as soon as
-  possible after any student enrolls, including any enrollments that occur while
-  your course is running. To understand the effects of changing cohort assignments
-  after your course has started, see :ref:`Altering Cohort Configuration`.
+Any assignments to cohort groups that you specify in the .csv files you upload
+will overwrite or change existing cohort group assignments. The configuration of
+your cohort groups should be complete and stable before your course begins. You
+should also complete manual cohort assignments as soon as possible after any
+student enrolls, including any enrollments that occur while your course is
+running. To understand the effects of changing cohort assignments after your
+course has started, see :ref:`Altering Cohort Configuration`.
+
+.. note:: Be aware that the contents of the .csv file are processed row by row,
+ from top to bottom, and each row is treated independently. For example, if your
+ .csv file contains conflicting information such as Student A being first
+ assigned to Cohort Group 1, then later in the spreadsheet being assigned to
+ Cohort Group 2, the end result of your .csv upload is that Student A is assigned
+ to Cohort Group 2. However, the upload results file will count  Student A twice
+ in the "Students Added" count, once when they are added to  Cohort Group 1, and
+ again when they are added to Cohort Group 2. Before submitting a file for
+ upload, check it carefully for errors.
 
 The requirements for the .csv file are summarized in this table.
 
@@ -256,7 +266,9 @@ The requirements for the .csv file are summarized in this table.
 
         * The file extension is .csv.
         * Every row must have the same number of commas, whether or not there
-          are values in each cell.          
+          are values in each cell. 
+    * - File size
+      - The file size of .csv files for upload is limited to a maximum of 2MB.               
     * - UTF-8 encoded
       
       - You must save the file with UTF-8 encoding so that Unicode characters
@@ -280,7 +292,8 @@ The requirements for the .csv file are summarized in this table.
     * - One column identifying the cohort group
             
       - You must include one column named "Cohort" to identify the cohort group
-        to which you are assigning each student. 
+        to which you are assigning each student.
+
         The specified cohort groups must already exist in Studio.
 
     * -                        
@@ -323,9 +336,9 @@ The results file provides the following information:
       
         If the cohort group was not found (value is FALSE), no action is taken for students you assigned to that group in the .csv file.
 
-    * - Students Added   
-      - The number of students added to the cohort group as a result of the .csv
-        upload.     
+    * - Students Added
+      - The number of students added to the cohort group during the row by row
+        processing of the .csv file.             
     * - Students Not Found      
       - The number of students who could not be matched by either email address
         or username and who were therefore not added to the cohort group.

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -224,7 +224,6 @@ student, review the student profile information for your course. See
 :ref:`View and download student data`.
 
 
-=======
 .. _Assign Students to Cohort Groups by uploading CSV:
 
 ========================================================

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -248,8 +248,8 @@ course has started, see :ref:`Altering Cohort Configuration`.
  .csv file contains conflicting information such as Student A being first
  assigned to Cohort Group 1, then later in the spreadsheet being assigned to
  Cohort Group 2, the end result of your .csv upload is that Student A is assigned
- to Cohort Group 2. However, the upload results file will count  Student A twice
- in the "Students Added" count, once when they are added to  Cohort Group 1, and
+ to Cohort Group 2. However, the upload results file will count Student A twice
+ in the "Students Added" count: once when they are added to Cohort Group 1, and
  again when they are added to Cohort Group 2. Before submitting a file for
  upload, check it carefully for errors.
 

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -235,15 +235,13 @@ email addresses directly on the Membership page in the Instructor Dashboard, you
 can also upload a .csv file containing a list of students and the cohort groups
 you want to assign them to.
 
-.. note:: Any assignments to cohort groups that you specify in .csv files you
-   upload will overwrite or change existing cohort group assignments. Ideally, the
-   configuration of your cohort groups should be complete and stable before your
-   course begins, and you should complete manual cohort assignments as soon as
-   possible after any student enrolls, including any enrollments that occur
-   while your course is running. To understand the impacts of changing cohort
-   assignments after your course has started, see :ref:`Altering Cohort
-   Configuration`.
-
+.. note:: Any assignments to cohort groups that you specify in the .csv files
+  you upload will overwrite or change existing cohort group assignments. The
+  configuration of your cohort groups should be complete and stable before your
+  course begins. You should also complete manual cohort assignments as soon as
+  possible after any student enrolls, including any enrollments that occur while
+  your course is running. To understand the effects of changing cohort assignments
+  after your course has started, see :ref:`Altering Cohort Configuration`.
 
 The requirements for the .csv file are summarized in this table.
 
@@ -254,23 +252,23 @@ The requirements for the .csv file are summarized in this table.
       - **Notes**
     * - Valid .csv file
 
-      - Must be a properly formatted comma-separated values file: 
+      - The file must be a properly formatted comma-separated values file: 
 
         * The file extension is .csv.
         * Every row must have the same number of commas, whether or not there
           are values in each cell.          
     * - UTF-8 encoded
       
-      - Must be saved with UTF-8 encoding so that Unicode characters
+      - You must save the file with UTF-8 encoding so that Unicode characters
         display correctly. 
 
         See :ref:`Creating a Unicode Encoded CSV File`.
 
     * - Header row
-      - Must have a header row, with column names exactly as
+      - You must include a header row, with column names exactly as
         specified in "Columns" below.
     * - One or two columns identifying students      
-      - Must have at least one column identifying students: 
+      - You must include at least one column identifying students: 
         
         either "email" or "username", or both. 
 
@@ -280,9 +278,13 @@ The requirements for the .csv file are summarized in this table.
         In other words, if an email address is present, an incorrect or non-
         matching username is ignored.
 
-    * - One column identifying the cohort group      
-      - The column must be named "cohort", containing cohort groups already
-        existing in Studio.     
+    * - One column identifying the cohort group
+            
+      - You must include one column named "cohort" to identify the cohort group
+        to which you are assigning each student. 
+
+        The specified cohort groups must already exist in Studio.
+
     * -             
       - Columns other than "Email", "Username" and "Cohort" are ignored.
 

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -224,6 +224,85 @@ student, review the student profile information for your course. See
 :ref:`View and download student data`.
 
 
+=======
+.. _Assign Students to Cohort Groups by uploading CSV:
+
+========================================================
+Assign Students to Cohort Groups by Uploading a CSV File
+========================================================
+
+In addition to assigning students to cohort groups by entering usernames or
+email addresses directly on the Membership page in the Instructor Dashboard, you
+can also upload a .csv file containing a list of students and the cohort groups
+you want to assign them to.
+
+.. note:: Any assignments to cohort groups that you specify in .csv files you
+   upload will overwrite or change existing cohort group assignments.
+
+.. note:: In the .csv file, each student must be identified by either a username
+   or an email address that can be matched with existing registration information.
+   If both a username and email address are provided for a student, only the email
+   address is used for matching and the username is ignored. The specified cohort
+   group names must already exist.
+
+The requirements for the .csv file are summarized in this table.
+
+.. list-table::
+    :widths: 15 30
+
+    * - **Requirement**
+      - **Notes**
+    * - Valid .csv file
+      - Must be a properly formatted comma-separated values file, with a file
+        extension of .csv and extra commas to indicate empty cells in columns.
+    * - UTF-8 encoded      
+      - Save your file with UTF-8 encoding so that Unicode characters are saved
+        and displayed correctly.
+    * - Header row      
+      - The csv file must have a header row, with column names exactly as
+        specified in "Columns" below.
+    * - Columns 
+      - At least 2 columns: 1) "email" or "username", or both; 2) "cohort". If
+        both the username and an email address are provided for a student, the
+        email address has precedence. In other words, if an email address is
+        present, an incorrect or non-matching username is ignored. Cohort names
+        must already have been created in Studio. Columns other than "Email",
+        "Username" and "Cohort" are ignored.
+
+Follow these steps to assign students to cohort groups by uploading a .csv file.     
+      
+#. View the live version of your course. For example, in Studio click **View
+   Live**.
+
+#. Click **Instructor**, then click **Membership**. 
+
+#. Scroll to the **Cohort Management** section at the bottom.
+
+#. Under **Assign Students to Cohort Groups by Uploading a CSV File**, click
+   **Browse** to navigate to the .csv file you want to upload. 
+
+#. Click **Upload File and Assign Students**. A status message is displayed
+   above the **Browse** button.
+
+#. Verify your upload results on the Data Download page. Under
+   **Reports Available for Download**, locate the link to a csv file named
+   "<CourseName>-cohort_results<DateTime>.csv" where <CourseName> is the name of
+   the course, and <DateTime> is the date and time of your file upload. 
+
+In the results file, for each cohort group specified in your uploaded file, a
+count is provided of the number of students added to the cohort group who were
+not previously in a cohort group, transferred from other cohort groups, or
+already present in the cohort group. The results file also indicates whether a
+cohort group exists: if it does not (a value of FALSE in the "Exists" column)
+then no action is taken for students you assigned to that group in the .csv
+file. "Students unknown" is the count of students who could not be matched by
+either username or email address.
+
+For a report that includes the cohort group assignment for every enrolled
+student, review the student profile information for your course. See
+:ref:`View and download student data`.
+
+
 .. _Altering Cohort Configuration:
 
 *****************************************************************

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -244,11 +244,6 @@ you want to assign them to.
    assignments after your course has started, see :ref:`Altering Cohort
    Configuration`.
 
-.. note:: In the .csv file, each student must be identified by either a username
-   or an email address that can be matched with existing registration information.
-   If both a username and email address are provided for a student, only the email
-   address is used for matching and the username is ignored. The specified cohort
-   group names must already exist.
 
 The requirements for the .csv file are summarized in this table.
 
@@ -258,54 +253,93 @@ The requirements for the .csv file are summarized in this table.
     * - **Requirement**
       - **Notes**
     * - Valid .csv file
-      - Must be a properly formatted comma-separated values file, with a file
-        extension of .csv and extra commas to indicate empty cells in columns.
-    * - UTF-8 encoded      
-      - Save your file with UTF-8 encoding so that Unicode characters are saved
-        and displayed correctly.
-    * - Header row      
-      - The csv file must have a header row, with column names exactly as
+
+      - Must be a properly formatted comma-separated values file: 
+
+        * The file extension is .csv.
+        * Empty cells in columns are indicated using extra commas.
+          
+    * - UTF-8 encoded
+      
+      - Must be saved with UTF-8 encoding so that Unicode characters
+        display correctly. 
+
+        See :ref:`Creating a Unicode Encoded CSV File`.
+
+    * - Header row
+      - Must have a header row, with column names exactly as
         specified in "Columns" below.
     * - Columns 
-      - At least 2 columns: 1) "email" or "username", or both; 2) "cohort". If
-        both the username and an email address are provided for a student, the
-        email address has precedence. In other words, if an email address is
-        present, an incorrect or non-matching username is ignored. Cohort names
-        must already have been created in Studio. Columns other than "Email",
-        "Username" and "Cohort" are ignored.    
+  
+      - Must have at least 2 columns: 1) "email" or "username", or both; 2)
+        "cohort".
+
+        * If both the username and an email address are provided for a
+          student, the email address has precedence. In other words, if an email address
+          is present, an incorrect or non-matching username is ignored.
+
+        * Cohort names must already have been created in Studio.       
+        * Columns other than "Email", "Username" and "Cohort" are ignored.
 
 Follow these steps to assign students to cohort groups by uploading a .csv file.     
       
-#. View the live version of your course. For example, in Studio click **View
+#. View the live version of your course. For example, in Studio, click **View
    Live**.
 
 #. Click **Instructor**, then click **Membership**. 
 
 #. Scroll to the **Cohort Management** section at the bottom.
 
-#. Under **Assign Students to Cohort Groups by Uploading a CSV File**, click
+#. Under **Assign students to cohort groups by uploading a CSV file**, click
    **Browse** to navigate to the .csv file you want to upload. 
 
 #. Click **Upload File and Assign Students**. A status message is displayed
    above the **Browse** button.
 
-#. Verify your upload results on the Data Download page. Under
-   **Reports Available for Download**, locate the link to a csv file named
-   "<CourseName>-cohort_results<DateTime>.csv" where <CourseName> is the name of
-   the course, and <DateTime> is the date and time of your file upload. 
+#. Verify your upload results on the **Data Download** page. 
 
-In the results file, for each cohort group specified in your uploaded file, a
-count is provided of the number of students added to the cohort group who were
-not previously in a cohort group, transferred from other cohort groups, or
-already present in the cohort group. The results file also indicates whether a
-cohort group exists: if it does not (a value of FALSE in the "Exists" column)
-then no action is taken for students you assigned to that group in the .csv
-file. "Students unknown" is the count of students who could not be matched by
-either username or email address.
+   Under **Reports Available for Download**, locate the link to a csv file with
+   "cohort_results" and the date and time of your upload in the filename. The
+   list of available reports is sorted chronologically, with the most recently
+   generated files at the top.
 
+The results file provides the following information:  
+
+.. list-table::
+    :widths: 15 30
+
+    * - **Column**
+      - **Description**
+    * - Cohort Group
+      - The name of the cohort group to which you are assigning students.
+    * - Exists
+      - Whether the cohort group was found in the system. TRUE/FALSE. 
+      
+        If the cohort group was not found (value is FALSE), no action is taken for students you assigned to that group in the .csv file.
+
+    * - Students Added
+      - The number of students added to the cohort group as a result of the .csv upload.
+    * - Students Not Found
+      - The number of students who could not be matched by either email address or username and therefore were not added to the cohort group.          
 For a report that includes the cohort group assignment for every enrolled
 student, review the student profile information for your course. See
 :ref:`View and download student data`.
+
+
+.. _Creating a Unicode Encoded CSV File:
+
+====================================
+Creating a Unicode-encoded CSV File
+====================================
+
+Make sure .csv files that you upload are encoded as UTF-8, so that any Unicode
+characters (for example, in usernames) are correctly saved and displayed.
+
+.. note:: Some spreadsheet applications (for example, MS Excel) do not allow you
+   to specify encoding when you save a spreadsheet as a .csv file. To ensure that
+   you are able to create a .csv file that is UTF-8 encoded, use a spreadsheet
+   application such as Google Sheets, LibreOffice, or Apache OpenOffice.
+
 
 
 .. _Altering Cohort Configuration:

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -354,8 +354,9 @@ student, review the student profile information for your course. See
 Creating a Unicode-encoded CSV File
 ====================================
 
-Make sure .csv files that you upload are encoded as UTF-8, so that any Unicode
-characters (for example, in usernames) are correctly saved and displayed.
+Make sure the .csv files that you upload are encoded as UTF-8, so that any
+Unicode characters (for example, in usernames) are correctly saved and
+displayed.
 
 .. note:: Some spreadsheet applications (for example, MS Excel) do not allow you
    to specify encoding when you save a spreadsheet as a .csv file. To ensure that

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -257,8 +257,8 @@ The requirements for the .csv file are summarized in this table.
       - Must be a properly formatted comma-separated values file: 
 
         * The file extension is .csv.
-        * Empty cells in columns are indicated using extra commas.
-          
+        * Every row must have the same number of commas, whether or not there
+          are values in each cell.          
     * - UTF-8 encoded
       
       - Must be saved with UTF-8 encoding so that Unicode characters
@@ -298,7 +298,7 @@ Follow these steps to assign students to cohort groups by uploading a .csv file.
 
 #. Verify your upload results on the **Data Download** page. 
 
-   Under **Reports Available for Download**, locate the link to a csv file with
+   Under **Reports Available for Download**, locate the link to a .csv file with
    "cohort_results" and the date and time of your upload in the filename. The
    list of available reports is sorted chronologically, with the most recently
    generated files at the top.
@@ -317,10 +317,13 @@ The results file provides the following information:
       
         If the cohort group was not found (value is FALSE), no action is taken for students you assigned to that group in the .csv file.
 
-    * - Students Added
-      - The number of students added to the cohort group as a result of the .csv upload.
-    * - Students Not Found
-      - The number of students who could not be matched by either email address or username and therefore were not added to the cohort group.          
+    * - Students Added   
+      - The number of students added to the cohort group as a result of the .csv
+        upload.     
+    * - Students Not Found      
+      - The number of students who could not be matched by either email address
+        or username and who were therefore not added to the cohort group.
+             
 For a report that includes the cohort group assignment for every enrolled
 student, review the student profile information for your course. See
 :ref:`View and download student data`.

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -269,24 +269,23 @@ The requirements for the .csv file are summarized in this table.
         specified in "Columns" below.
     * - One or two columns identifying students      
       - You must include at least one column identifying students: 
-        
-        either "email" or "username", or both. 
+        either "Email" or "Username", or both. 
 
         If both the username and an email address are provided for a student,
         the email address has precedence. 
-
+        
         In other words, if an email address is present, an incorrect or non-
         matching username is ignored.
 
     * - One column identifying the cohort group
             
-      - You must include one column named "cohort" to identify the cohort group
+      - You must include one column named "Cohort" to identify the cohort group
         to which you are assigning each student. 
-
         The specified cohort groups must already exist in Studio.
 
-    * -             
-      - Columns other than "Email", "Username" and "Cohort" are ignored.
+    * -                        
+      - Columns with headings other than "Email", "Username" and "Cohort" are
+        ignored.
 
 Follow these steps to assign students to cohort groups by uploading a .csv file.     
       
@@ -300,7 +299,7 @@ Follow these steps to assign students to cohort groups by uploading a .csv file.
 #. Under **Assign students to cohort groups by uploading a CSV file**, click
    **Browse** to navigate to the .csv file you want to upload. 
 
-#. Click **Upload File and Assign Students**. A status message is displayed
+#. Click **Upload File and Assign Students**. A status message displays
    above the **Browse** button.
 
 #. Verify your upload results on the **Data Download** page. 

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -237,7 +237,13 @@ can also upload a .csv file containing a list of students and the cohort groups
 you want to assign them to.
 
 .. note:: Any assignments to cohort groups that you specify in .csv files you
-   upload will overwrite or change existing cohort group assignments.
+   upload will overwrite or change existing cohort group assignments. Ideally, the
+   configuration of your cohort groups should be complete and stable before your
+   course begins, and you should complete manual cohort assignments as soon as
+   possible after any student enrolls, including any enrollments that occur
+   while your course is running. To understand the impacts of changing cohort
+   assignments after your course has started, see :ref:`Altering Cohort
+   Configuration`.
 
 .. note:: In the .csv file, each student must be identified by either a username
    or an email address that can be matched with existing registration information.
@@ -267,7 +273,7 @@ The requirements for the .csv file are summarized in this table.
         email address has precedence. In other words, if an email address is
         present, an incorrect or non-matching username is ignored. Cohort names
         must already have been created in Studio. Columns other than "Email",
-        "Username" and "Cohort" are ignored.
+        "Username" and "Cohort" are ignored.    
 
 Follow these steps to assign students to cohort groups by uploading a .csv file.     
       


### PR DESCRIPTION
First draft of doc: course authors can use a csv upload to assign students to cohorts.
Will continue to update if additional info surfaces about UTF-8 and other requirements/limitations.
