### PR TITLE
Reorg of cohorts and discussion topics

### DIFF
--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -4,11 +4,11 @@
 Enabling and Configuring the Cohort Feature
 ############################################
 
-To support discussions that are divided by cohort, you select a strategy
-for assigning your students to cohort groups: automated assignment, manual
-assignment, or a hybrid approach. See :ref:`Options for Assigning Students to
-Cohorts`. You also decide whether to change any of the course-wide discussion
-topics so that they are divided by cohort instead of unified for all students. 
+To support cohorts in your course, you select a strategy for assigning your
+students to cohort groups: automated assignment, manual assignment, or a hybrid
+approach. See :ref:`Options for Assigning Students to Cohorts`. You also decide
+whether to change any of the course-wide discussion topics so that they are
+divided by cohort instead of unified for all students.
 
 After you select a strategy, you complete these configuration steps (as
 applicable):
@@ -86,8 +86,9 @@ of the cohort group they are assigned to. The message "This post is visible
 only to {cohort name}" appears with each post in discussion topics that are
 divided by cohort. See :ref:`Read the Cohort Indicator in Posts`.
 
-.. note:: You cannot delete cohort groups or change their names. If you need 
- to make changes to the way you have configured the cohort feature while your course is running, please see :ref:`Altering Cohort Configuration`.
+.. note:: You cannot delete cohort groups or change their names. If you need
+   to make changes to the way you have configured the cohort feature while your
+   course is running, please see :ref:`Altering Cohort Configuration`.
 
 #. Open the course in Studio. 
 
@@ -222,102 +223,6 @@ For a report that includes the cohort group assignment for every enrolled
 student, review the student profile information for your course. See
 :ref:`View and download student data`.
 
-.. _Identifying Private CourseWide Discussion Topics:
-
-*****************************************************************
-Configuring Course-Wide Discussion Topics As Divided
-*****************************************************************
-
-When you enable the cohort feature for a course, all of the course-wide
-discussion topics provide unified access to posts for all students. You can
-configure one or more of the course-wide topics to be divided by cohort
-instead.
-
-.. note:: The content-specific discussion topics in the course, which are 
- added to units as discussion components, are always divided by cohort.
-
-For more information about content-specific and course-wide discussion topics,
-see :ref:`Organizing_discussions`.
-
-Before you configure course-wide discussion topics to be divided by cohort, you
-add the topics in Studio. See :ref:`Create CourseWide Discussion Topics`. 
-
-In the example given for creating course-wide discussion topics, a single
-topic, Course Q&A, is added to the system-supplied General topic. The steps in
-the following procedure expand on that example: you have now decided to enable
-the cohort feature for your course. The posts that you intend to make to the
-Course Q&A and General topics, and the subjects you expect students to explore
-there, are appropriate for a unified student audience. However, you also want
-to give students some course-wide topics that are divided by cohort. You define
-two more course-wide discussion topics, Announcements and Brainstorming.
-
-You also decide to apply a naming convention so that students will know 
-the audience for their posts before they add them. See :ref:`Apply Naming
-Conventions to Discussion Topics`. 
-
-.. image:: ../Images/Discussion_Add_cohort_topics.png
- :alt: Discussion Topic Mapping field with four course-wide discussion topics 
-       defined
-
-.. _Configure CourseWide Discussion Topics as Private:
-
-======================================================
-Identify Divided Course-Wide Discussion Topics
-======================================================
-
-In the steps that follow, you configure two topics so that they are divided by
-cohort. On the Studio **Advanced Settings** page, the two topics appear as
-follows in the **Discussion Topic Mapping** field:
-
-.. code::
-
-      "Brainstorming (private)": {
-          "id": "i4x-edX-Open-edx_demo_course_brainstorming"
-      },
-      "Announcements (private)": {
-          "id": "i4x-edX-Open-edx_demo_course_announcements"
-      }
-
-#. Open the course in Studio. 
-
-#. Select **Settings**, then **Advanced Settings**.
-
-#. In the **Cohort Configuration** field, place your cursor after the opening
-   brace character (``{``) and press Enter.
-
-#. On the new line, you define the ``"cohorted_discussions":`` policy key,
-   followed by one or more course-wide discussion topic IDs enclosed by
-   square brackets (``[ ]``). You can define a set of discussion topics or just
-   one.
-
-   To define a set of topics, you type the value of the "id" for each
-   discussion topic on a new line, enclose it within quotation marks (``" "``),
-   and separate the quoted "id" values with commas. For example:
-
- .. code:: 
-
-   "cohorted_discussions": [
-       "i4x-edX-Open-edx_demo_course_announcements",
-       "i4x-edX-Open-edx_demo_course_brainstorming"
-   ]
-   
-.. this comment is here only to force allow indented formatting of next line
-
-  To specify a single discussion topic, type ``"cohorted_discussions": ["i4x-
-  test_doc-SB101-course-2014_Jan_announcements"]`` and then press Enter again.
-   
-5. Type a comma after the closing square bracket character (``],``). You must
-   include a comma to separate each of the policy keys that you define.
-   
-#. Click **Save Changes**. Studio resequences and reformats your entry. Scroll
-   back to the **Cohort Configuration** field to verify that your entry was
-   saved as you expect. Entries that do not contain all of the required
-   punctuation characters revert to the previous value when you save, and no
-   warning is presented.
-
- .. image:: ../Images/Configure_cohort_topic.png
-  :alt: Cohort Configuration dictionary field with the cohorted_discussions key
-        defined
 
 .. _Altering Cohort Configuration:
 

--- a/en_us/course_authors/source/cohorts/cohorts_manage_discussions.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_manage_discussions.rst
@@ -1,10 +1,11 @@
 .. _Moderating Discussions for Cohorts:
 
+
 ##########################################################
-Managing Discussions in a Course with Student Cohorts
+Managing Discussions in Courses with Student Cohorts
 ##########################################################
 
-In a course that has the cohort feature enabled, every post has an indicator of
+In courses that have the cohort feature enabled, every post has an indicator of
 who can read it: either everyone, or only the members of a single cohort group.
 For students, this is the only noticeable difference between discussions in
 courses that include cohorts when compared to courses that don't. You can share

--- a/en_us/course_authors/source/cohorts/cohorts_overview.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_overview.rst
@@ -8,6 +8,13 @@ Cohorts create smaller communities of students within a course. Students who
 are in a cohort can communicate and share experiences privately within course
 discussion topics.
 
+By :ref:`enabling the cohort feature<Enabling and Configuring Cohorts>` in a
+course, you provide students with the ability to ask questions of, and have
+conversations with, other members of their cohort. Cohort-only discussion
+opportunities can help students develop a sense of community, provide
+specialized experiences, and encourage deeper, more meaningful course
+involvement.
+
 When you enable the cohort feature for your course, the discussion topics that
 you include in units by adding discussion components are divided by cohort.
 This means that each post that a student makes to those content-specific topics
@@ -115,7 +122,7 @@ your course determines which assignment option you will use for your course.
 .. _All Automated Assignment:
 
 =============================================================
-Making MOOC Discussions Manageable: Automated Assignment
+Automated Assignment: Making MOOC Discussions Manageable
 =============================================================
 
 In very large courses, the number of posts made to course discussion topics can
@@ -160,7 +167,7 @@ Strategy`.
 .. _All Manual Assignment:
 
 ==========================================================
-Grouping by Common Characteristic: Manual Assignment
+Manual Assignment: Grouping by Common Characteristics
 ==========================================================
 
 In SPOCs and other courses with small- to medium-sized enrollments, known
@@ -189,7 +196,7 @@ For more information, see :ref:`Implementing the Manual Assignment Strategy`.
 .. _Hybrid Assignment:
 
 =============================================================
-Accomodating Small Groups Within a Course: Hybrid Assignment
+Hybrid Assignment: Accommodating Small Groups Within a Course
 =============================================================
 
 For some courses, the manual assignment strategy isn't feasible to execute, and
@@ -228,7 +235,7 @@ Strategy` and :ref:`Implementing the Manual Assignment Strategy`.
 .. _Default Cohort Group:
 
 ==================================================================
-Assuring That All Students Are Assigned: The Default Cohort Group
+Ensuring That All Students Are Assigned: The Default Cohort Group
 ==================================================================
 
 In a course that has the cohort feature enabled, all students must be assigned

--- a/en_us/course_authors/source/cohorts/cohorts_setup_discussions.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_setup_discussions.rst
@@ -1,0 +1,127 @@
+.. _Set up Discussions in Cohorted Courses:
+
+
+##########################################################
+Setting up Discussions in Courses with Student Cohorts
+##########################################################
+
+
+When you first enable cohorts in your course, all course-wide discussion topics
+provide unified access to posts for all students. You can configure one or more
+of the course-wide topics to be divided by cohort instead.
+
+.. note:: The content-specific discussion topics in the course, which are 
+ added to units as discussion components, are always divided by cohort.
+
+For overview information about discussions in a course, see :ref:`Discussions`.
+For information about setting up cohorts in a course, see :ref:`Enabling and
+Configuring Cohorts`.
+
+******************************************
+Course-Wide Discussion Topics and Cohorts
+******************************************
+
+When you first :ref:`create a course-wide discussion topic<Create CourseWide
+Discussion Topics>`, it is unified, and all students in the course can post,
+read, respond, and comment in the topic without regard to their cohort group
+assignments. After you add a course-wide topic, you can configure it so that it
+is divided by cohort instead.
+
+
+.. _Identifying Private CourseWide Discussion Topics:
+
+=============================================================
+Example: Configuring Course-Wide Discussion Topics As Divided
+=============================================================
+
+This example assumes that you have added three course-wide discussion topics
+called Course Q&A, Announcements, and Brainstorming, to your course, so that in
+addition to the system-supplied General topic, you have four course-wide
+discussion topics. 
+
+.. image:: ../Images/Discussion_Add_cohort_topics.png
+ :alt: Discussion Topic Mapping field with four course-wide discussion topics 
+       defined
+
+You have now enabled cohorts for your course and would like
+to take advantage of that feature as it applies to discussion topics.
+
+The posts that you intend to make to the Course Q&A and General topics, and the
+subjects you expect students to explore there, are appropriate for a unified
+student audience. However, you also want to give students some course-wide
+topics that are divided by cohort. You decide that the Announcements and
+Brainstorming course-wide topics should be divided by cohort.
+
+You also decide to apply a naming convention so that students will know the
+audience for the discussion topics before they add any posts. For information on
+how to achieve this, see :ref:`Apply Naming Conventions to Discussion Topics`.
+
+
+.. _Configure CourseWide Discussion Topics as Private:
+
+======================================================
+Define Divided Course-Wide Discussion Topics
+======================================================
+
+This procedure shows how to configure the Brainstorming and Announcements
+course-wide discussion topics (from the example in :ref:`Identifying Private
+CourseWide Discussion Topics`) so that they are divided by cohort.
+
+On the Studio **Advanced Settings** page, details of the two topics appear as
+follows in the **Discussion Topic Mapping** field. You use the ID for each
+discussion topic to identify it in the steps that follow.
+
+.. code::
+
+      "Brainstorming (private)": {
+          "id": "i4x-edX-Open-edx_demo_course_brainstorming"
+      },
+      "Announcements (private)": {
+          "id": "i4x-edX-Open-edx_demo_course_announcements"
+      }
+
+#. Open the course in Studio. 
+
+#. Select **Settings**, then **Advanced Settings**.
+
+#. In the **Cohort Configuration** field, place your cursor after the opening
+   brace character (``{``) and press **Enter**.
+
+#. On the new line, you define the ``"cohorted_discussions":`` policy key,
+   followed by one or more course-wide discussion topic IDs enclosed by    square
+   brackets (``[ ]``). You can define just one discussion topic or a set of
+   discussion topics.
+
+   For example, to define a single discussion topic, type
+   ``"cohorted_discussions": ["discussion-topic-ID"]``, replacing "discussion-
+   topic-ID" with your discussion topic's ID, and then press Enter.
+
+   To define a set of topics, type the value of the "id" for each discussion
+   topic on a new line, enclose it within quotation marks (``" "``), and
+   separate the quoted "id" values with commas. For example:
+
+ .. code:: 
+
+   "cohorted_discussions": [
+       "i4x-edX-Open-edx_demo_course_announcements",
+       "i4x-edX-Open-edx_demo_course_brainstorming"
+   ]
+   
+5. If "cohorted_discussions" is followed by other policy keys within the
+   **Cohort Configuration** field, make sure there is a comma after the closing
+   square bracket character (``],``). You must include a comma to separate each of
+   the policy keys that you define.
+
+.. Adding a line to force a line space
+
+6. Click **Save Changes**. Studio resequences and reformats your entry.
+
+ .. image:: ../Images/Configure_cohort_topic.png
+  :alt: Cohort Configuration dictionary field with the cohorted_discussions key
+        defined
+
+7. Scroll back to the **Cohort Configuration** field to verify that your entry
+   was saved as you expect. Entries that do not contain all of the required
+   punctuation characters revert to the previous value when you save, and no
+   warning is presented.
+

--- a/en_us/course_authors/source/cohorts/index.rst
+++ b/en_us/course_authors/source/cohorts/index.rst
@@ -9,4 +9,5 @@ Including Student Cohorts
    
    cohorts_overview
    cohort_config
-   cohorts_discussions
+   cohorts_setup_discussions
+   cohorts_manage_discussions


### PR DESCRIPTION
Pulled the reorg of cohort and discussion topics out of previous branch DOC-1077 so that it is no longer dependent on that open source PR. Topics about setting up and managing discussion now separated from the cohort configuration section.
@mhoeber @lamagnifica @srpearce @explorerleslie please give thumbs if you're OK with the reorg.
Would like to create new doc for cohorted courseware on top of this file organization.
