### PR TITLE
Fixes DOC-975, need straight quotes in code blocks

### DIFF
--- a/en_us/course_authors/source/Format Cheat Sheet.rstnouse
+++ b/en_us/course_authors/source/Format Cheat Sheet.rstnouse
@@ -41,9 +41,10 @@ To set text in a "Code format"
         ::
 -or-
 
-.. code-block:: xml
+.. code-block:: python
 
-(text in code-block:: xml is in different colors)
+(text in code-block:: python is in different colors)
+(DO NOT USE .. code-block:: xml as the Sphinx template changes "straight" quotes to "smart")
 
 ****************
 Table Formatting

--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -47,6 +47,7 @@ release = ''
 
 # Prevent single quotes (unicode U+0027) from being output as right single
 # quotes (U+2019) in the PDF.
-latex_preamble = """
+latex_elements
+    preamble = """
     \usepackage{upquote}
     """

--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -50,3 +50,7 @@ release = ''
 latex_elements = {
     'preamble': '\usepackage{upquote}'
     }
+
+def setup(app):
+    from sphinx.util.texescape import tex_replacements
+    tex_replacements += [(u'’', u''')]

--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -47,7 +47,6 @@ release = ''
 
 # Prevent single quotes (unicode U+0027) from being output as right single
 # quotes (U+2019) in the PDF.
-latex_elements
-    preamble = """
-    \usepackage{upquote}
-    """
+latex_elements = {
+    'preamble': '\usepackage{upquote}'
+    }

--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -44,3 +44,9 @@ copyright = u'2014, edX'
 version = ''
 # The full version, including alpha/beta/rc tags.
 release = ''
+
+# Prevent single quotes (unicode U+0027) from being output as right single
+# quotes (U+2019) in the PDF.
+latex_preamble = """
+    \usepackage{upquote}
+    """

--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -50,7 +50,3 @@ release = ''
 latex_elements = {
     'preamble': '\usepackage{upquote}'
     }
-
-def setup(app):
-    from sphinx.util.texescape import tex_replacements
-    tex_replacements += [(u'’', u''')]

--- a/en_us/course_authors/source/creating_content/create_problem.rst
+++ b/en_us/course_authors/source/creating_content/create_problem.rst
@@ -45,12 +45,12 @@ All problems on the edX platform have several component parts.
 
 #. **Problem text.** The problem text can contain any standard HTML formatting.
 
-#. **Response field with the student’s answer.** Students enter answers
+#. **Response field with the student's answer.** Students enter answers
    in *response fields*. The appearance of the response field depends on
    the type of the problem.
 
 #. **Rendered answer.** For some problem types, Studio uses MathJax to
-   render plain text as “beautiful math.”
+   render plain text as "beautiful math."
 
 #. **Check button.** The student clicks **Check** to submit a response
    or find out if his answer is correct. If the answer is correct, a green
@@ -102,7 +102,7 @@ All problems on the edX platform have several component parts.
 #. **Hide Answer button.**
 
    .. image:: ../Images//AnatomyOfExercise3.png
-    :alt: Image of a problem in the course accordian
+    :alt: Image of a problem in the course accordion
 
 #. **Grading.** The instructor may specify whether a group of problems
    is graded. If a group of problems is graded, a clock icon appears for
@@ -147,7 +147,7 @@ editing problem components: the Simple Editor and the Advanced Editor.
 *  The **Simple Editor** allows you to edit problems visually, without
    having to work with XML.
 
-*  The **Advanced Editor** converts the problem to edX’s XML standard and
+*  The **Advanced Editor** converts the problem to the edX XML standard and
    allows you to edit that XML directly.
 
 You can switch at any time from the Simple Editor to the Advanced Editor by
@@ -242,7 +242,7 @@ The following problem templates open in the Advanced Editor.
   input or multiple choice problems.
 
 * :ref:`Problem Written in LaTeX` This problem type allows you to convert
-  problems that you’ve already written in LaTeX into the edX format. Note that
+  problems that are already written in LaTeX into the edX format. Note that
   this problem type is still a prototype, however, and may not be supported in
   the future.
 
@@ -303,7 +303,7 @@ Problem Weight
 ==============================
 
 .. note:: Studio stores scores for all problems, but scores only count 
-          toward a student’s final grade if they are in a subsection that is
+          toward a student's final grade if they are in a subsection that is
           graded.
 
 This setting specifies the maximum number of points possible for the
@@ -313,7 +313,7 @@ problem. The problem weight appears next to the problem title.
  :alt: Image of a problem from a student's point of view, with the possible 
        points circled
 
-By default, each response field, or “answer space,” in a Problem
+By default, each response field, or "answer space," in a Problem
 component is worth one point. Any Problem component can have multiple
 response fields. For example, the Problem component above
 contains one dropdown problem that has three separate questions for students
@@ -335,7 +335,7 @@ following formula:
 
 *  **Score** is the point score that the student receives.
 
-*  **Weight** is the problem’s maximum possible point score.
+*  **Weight** is the problem's maximum possible point score.
 
 *  **Correct answers** is the number of response fields that contain correct
    answers.
@@ -348,27 +348,27 @@ The following are some examples of computing scores.
 
 *Example 1*
 
-A problem’s **Weight** setting is left blank. The problem has two
+A problem's **Weight** setting is left blank. The problem has two
 response fields. Because the problem has two response fields, the
 maximum score is 2.0 points.
 
 If one response field contains a correct answer and the other response
-field contains an incorrect answer, the student’s score is 1.0 out of 2
+field contains an incorrect answer, the student's score is 1.0 out of 2
 points.
 
 *Example 2*
 
-A problem’s weight is set to 12. The problem has three response fields.
+A problem's weight is set to 12. The problem has three response fields.
 
-If a student’s response includes two correct answers and one incorrect
-answer, the student’s score is 8.0 out of 12 points.
+If a student's response includes two correct answers and one incorrect
+answer, the student's score is 8.0 out of 12 points.
 
 *Example 3*
 
-A problem’s weight is set to 2. The problem has four response fields.
+A problem's weight is set to 2. The problem has four response fields.
 
-If a student’s response contains one correct answer and three incorrect
-answers, the student’s score is 0.5 out of 2 points.
+If a student's response contains one correct answer and three incorrect
+answers, the student's score is 0.5 out of 2 points.
 
 .. _Randomization:
 
@@ -514,7 +514,7 @@ Modifying a Released Problem
  experience in the course and analysis of course data.
 
 After a student submits a response to a problem, the edX Learning Management
-System (LMS) stores the student’s response, the score that the student
+System (LMS) stores the student's response, the score that the student
 received, and the maximum score for the problem. For problems with a **Maximum
 Attempts** setting greater than 1, the LMS updates these values each time the
 student submits a new response to a problem. However, if an instructor changes
@@ -524,8 +524,8 @@ not automatically updated.
 For example, you may release a problem and specify that its answer is 3.
 After some students have submitted responses, you notice that the answer
 should be 2 instead of 3. When you update the problem with the correct
-answer, the LMS doesn’t update scores for students who answered 2 for the
-original problem and thus received the wrong score.
+answer, the LMS does not update scores for students who answered 2 for the
+original problem (and therefore received the wrong score).
 
 For another example, you may change the number of response fields to
 three. Students who submitted answers before the change have a score of
@@ -584,7 +584,7 @@ problems can be different types.
 To create multiple problems in one component, create a new Blank Advanced
 Problem component, and then add the XML for each problem in the component
 editor. You only need to include the XML for the problem and its answers. You
-don’t have to include the code for other elements, such as the **Check**
+do not have to include the code for other elements, such as the **Check**
 button.
 
 Elements such as the **Check**, **Show Answer**, and **Reset** buttons, as well
@@ -694,7 +694,7 @@ Create Randomized Problems
    the URL names of the components. For example, the following file contains
    four Problem components.
 
-   .. code-block:: xml
+   .. code-block:: python
      
        <vertical display_name="Test Unit">
           <problem url_name="d9d0ceb3ffc74eacb29501183e26ad6e"/>
@@ -706,7 +706,7 @@ Create Randomized Problems
 #. Add ``<randomize> </randomize>`` tags around the components for the problems
    that you want to randomize.
 
-   .. code-block:: xml
+   .. code-block:: python
       
        <vertical display_name="Test Unit">
          <randomize>

--- a/en_us/course_authors/source/developing_course/course_components.rst
+++ b/en_us/course_authors/source/developing_course/course_components.rst
@@ -250,7 +250,7 @@ shown in Studio above.
 
 The XML for the unit is:
 
-.. code-block:: xml
+.. code-block:: python
 
     <vertical display_name="Unit 1">
         <html url_name="6a5cf0ea41a54b209e0815147896d1b2"/>
@@ -260,7 +260,7 @@ The XML for the unit is:
 The ``<vertical url_name="131a499ddaa3474194c1aa2eced34455"/>`` element above
 references the parent component file that contains the child components:
  
-.. code-block:: xml
+.. code-block:: python
 
     <vertical display_name="Parent Component">
         <vertical url_name="2758bbc495dd40d59050da15b40bd9a5"/>
@@ -270,14 +270,14 @@ references the parent component file that contains the child components:
 The two verticals referenced by the parent component refer to the child
 components, which contain the actual content of your course:
 
-.. code-block:: xml
+.. code-block:: python
 
     <vertical display_name="Child Component A">
         <html url_name="4471618afafb45bfb86cbe511973e225"/>
         <video url_name="fbd800d0bdbd4cb69ac70c47c9f699e1"/>
     </vertical>
 
-.. code-block:: xml
+.. code-block:: python
 
     <vertical display_name="Child Component B">
         <html url_name="dd6ef295fda74a639842e1a49c66b2c7"/>

--- a/en_us/course_authors/source/getting_started/accessibility.rst
+++ b/en_us/course_authors/source/getting_started/accessibility.rst
@@ -10,7 +10,7 @@ We intend for these guidelines to help the course teams understand the importanc
 *Accessibility* in online instruction refers to the degree to which information and activities are available to all students equally, regardless of physical or other disabilities.
 
 Our guidance is based on international standards and principles for web accessibility (W3C WCAG 2.0) and universal design (usable by all, to the greatest extent possible, without the need for adaptation or specialized design). 
-Instructors who build courses based on these principles promote the opportunity to create an inclusive experience that considers the diverse set of learning styles and needs of all learners—including learners with disabilities, learners who speak English as a second language, learners with technical issues such as low bandwidth internet or no access to audio, and learners with age-related capability issues. For purposes of these guidelines, we have assumed that end users will be equipped with the appropriate adaptive technology and compatible software.
+Instructors who build courses based on these principles promote the opportunity to create an inclusive experience that considers the diverse set of learning styles and needs of all learners, including learners with disabilities, learners who speak English as a second language, learners with technical issues such as low bandwidth Internet or no access to audio, and learners with age-related capability issues. For purposes of these guidelines, we have assumed that end users will be equipped with the appropriate adaptive technology and compatible software.
 
 Occasionally, unanticipated accessibility barriers will arise. 
 To supplement the accessibility you can achieve within the edX platform, we recommend that you engage the resources available at your institution to support learners with disabilities. 
@@ -135,18 +135,18 @@ To produce content that is more readable by all students:
 * Make the names of elements such as course sections, subsections, units, components, and discussion topics descriptive 
   and easy to skim by putting the important information first in the name. 
   These names are used in navigation menus, page headings, and section headings and are signposts that help learners navigate your course and read course content. 
-  “Front-loading” menus and headings particularly helps screen reader users, who can more quickly assess the relevance of a link or heading.
+  "Front-loading" menus and headings particularly helps screen reader users, who can more quickly assess the relevance of a link or heading.
 
 * When creating written learning resources, break text into sections by using HTML elements, such as headings, paragraphs, and lists. 
   Long blocks of unbroken text are a barrier to most readers. Segmented content is more inviting and is easier to navigate and search. 
   See :ref:`Best Practices for HTML Markup` for guidance on creating accessible HTML.
 
 * Avoid jargon. If unfamiliar words or phrases are relevant to the subject, explain them when they are first used, and include a glossary with your course materials. 
-  When using an abbreviation or acronym, write out the phrase the first time it appears: for example, “National Aeronautics and Space Administration (NASA).”
+  When using an abbreviation or acronym, write out the phrase the first time it appears: for example, "National Aeronautics and Space Administration (NASA)."
 
-* Use link text that clearly explains the link destination (for example, “Review the Course Syllabus”). 
-  Avoid using constructs like “You can review the Course Syllabus here.” For links that point to documents rather than web pages, 
-  include the document type in the link (e.g., “Course Syllabus (PDF)”).
+* Use link text that clearly explains the link destination (for example, "Review the Course Syllabus"). 
+  Avoid using constructs like "You can review the Course Syllabus here." For links that point to documents rather than web pages, 
+  include the document type in the link (for example, "Course Syllabus (PDF)").
 
 **Resources**
 
@@ -167,7 +167,7 @@ and working with third-party suppliers.
 +++++++++++++++++++++++++++++++++++++++++++++
 Converting Microsoft Office documents to PDF
 +++++++++++++++++++++++++++++++++++++++++++++
-The teaching materials that you will convert to PDFs may use different formats—for example, your syllabus may be in Word, 
+The teaching materials that you will convert to PDFs may use different formats. For example, your syllabus may be in Word, 
 your presentation slides in PowerPoint, and your textbooks in publisher-supplied PDF. 
 Use the tools available in the applicable software to create well-structured source documents. 
 This early step helps minimize issues that may be difficult or impossible to address later in the conversion process.
@@ -175,30 +175,30 @@ This early step helps minimize issues that may be difficult or impossible to add
 **Preparing Word documents**
 
 * Keep formatting simple. Use headings, paragraphs, lists, images, and captions, and tables for tabular data. 
-  Don’t add unnecessary indents, rules, columns, blank lines, and typographic variation. The simpler the formatting, the easier it will be to make an accessible PDF document.
+  do not add unnecessary indents, rules, columns, blank lines, and typographic variation. The simpler the formatting, the easier it will be to make an accessible PDF document.
 
 * Use styles for formatting your text, such as Normal, Heading 1, and Heading 2, rather than manually formatting text using bold and indents. 
-  Add alternative text to images (see :ref:`Best Practices for Describing Images`) using Word’s picture formatting options.
+  Add alternative text to images (see :ref:`Best Practices for Describing Images`) using Word's picture formatting options.
 
 **Preparing PowerPoint documents**
 
 * To help make your content accessible and comprehensible to learners who use screen reading software, start in Outline view and include all of your content as text. 
-  Add design elements and images after completing the outline, and use PowerPoint’s picture formatting options to include detailed descriptions of images that convey information. Avoid adding animations or transitions, as they will not be saved with the PDF format.
+  Add design elements and images after completing the outline, and use PowerPoint's picture formatting options to include detailed descriptions of images that convey information. Avoid adding animations or transitions, as they will not be saved with the PDF format.
 
 * Use the Home > Drawing > Arrange > Selection Pane option to view the reading order of objects on each slide. If the reading order is not logical, reorder the objects.
 
 * Use the Home > Slides > Reset option to give each slide a unique and informative title. The title can be hidden if preferred.
 
-* Identify column headers for any data table using PowerPoint’s table formatting options (Tables > Table Options > Header Row), 
+* Identify column headers for any data table using PowerPoint's table formatting options (Tables > Table Options > Header Row), 
   and ensure that each header contains informative text describing the data in that column.
 
 **Preparing Excel spreadsheets**
 
 * Use a unique and informative title for each worksheet tab.
 
-* Include text alternatives for images (see :ref:`Best Practices for Describing Images`) using Excel’s picture formatting options.
+* Include text alternatives for images (see :ref:`Best Practices for Describing Images`) using Excel's picture formatting options.
 
-* Identify column headers using Excel’s table formatting options (Table > Table Options > Header Row), and include in each header cell informative text describing the data in that column.
+* Identify column headers using Excel's table formatting options (Table > Table Options > Header Row), and include in each header cell informative text describing the data in that column.
 
 * Do not use blank cells for formatting.
 
@@ -214,12 +214,12 @@ Note that PDFs generated from Windows versions of Office will be more accessible
 Working with third-party supplied PDFs
 +++++++++++++++++++++++++++++++++++++++++++++
 
-When you control the creation of a PDF, you have greater control over the document’s accessibility. 
-If you use PDFs provided by third parties, including textbooks supplied by publishers, the document’s accessibility may be unknown.
+When you control the creation of a PDF, you have greater control over the document's accessibility. 
+If you use PDFs provided by third parties, including textbooks supplied by publishers, the document's accessibility may be unknown.
 
 **Asking the right questions about accessible PDFs**
 
-Where possible, ask the supplier of the PDF if the PDF is accessible. If it isn’t, ask whether the supplier can provide an accessible version. Questions to ask include:
+Where possible, ask the supplier of the PDF if the PDF is accessible. If it isn't, ask whether the supplier can provide an accessible version. Questions to ask include:
 
 * Can screen readers read the document text?
 * Do images in the document include text descriptions?
@@ -239,7 +239,7 @@ You may need to update your existing teaching materials in PDF format to improve
 
 In such cases, you need special software, such as Adobe Acrobat Professional, to enhance the accessibility of the PDF. 
 PDFs that are created from scanned documents require a preliminary Optical Character Recognition (OCR) step to generate a text version of the document. 
-The procedure checks documents for accessibility barriers, adds properties and tags for document structure, sets the document’s language, and adds alternative text for images.
+The procedure checks documents for accessibility barriers, adds properties and tags for document structure, sets the document's language, and adds alternative text for images.
 
 **Resources**
 
@@ -249,7 +249,7 @@ The procedure checks documents for accessibility barriers, adds properties and t
 * Adobe provides a detailed accessibility PDF repair workflow using Acrobat XI: 
   http://www.adobe.com/content/dam/Adobe/en/accessibility/products/acroba t/pdfs/acrobat-xi-pdf-accessibility-repair-workflow.pdf
 
-* Adobe Accessibility (Adobe) is a comprehensive collection of resources on PDF authoring and repair, using Adobe’s products: 
+* Adobe Accessibility (Adobe) is a comprehensive collection of resources on PDF authoring and repair, using Adobe's products: 
   http://www.adobe.com/accessibility.html
 
 * PDF Accessibility (University of Washington) provides a step-by-step guide to creating accessible PDFs from different sources and using different applications: 
@@ -258,7 +258,7 @@ The procedure checks documents for accessibility barriers, adds properties and t
 * PDF Accessibility (WebAIM) provides a detailed and illustrated guide on creating accessible PDFs: 
   http://webaim.org/techniques/acrobat/
 
-* The National Center of Disability and Access to Education has a collection of one- page “cheat sheets” on accessible document authoring: 
+* The National Center of Disability and Access to Education has a collection of one- page "cheat sheets" on accessible document authoring: 
   http://ncdae.org/resources/cheatsheets/
 
 * The Accessible Digital Office Document (ADOD) Project provides guidance on creating accessible Office documents: 
@@ -297,7 +297,7 @@ Math images cannot be modified by people who need a high-contrast display and ca
 EdX uses MathJax to render math content in a format that is clear, readable, and accessible to people who use screen readers. 
 MathJax works together with math notation, like LaTeX and MathML, to render mathematical equations as text instead of images. 
 We recommend that you use MathJax to display your math content. 
-You can learn more about using MathJax in the MathJax documentation on accessibility (see the link in “Resources” below). 
+You can learn more about using MathJax in the MathJax documentation on accessibility (see the link in "Resources" below). 
 We will update these guidelines as improvements to MathJax are developed.
 
 ++++++++++++++++++++++++++++++++++++++++++++
@@ -308,13 +308,13 @@ Simulations, including animated or gamified content, can enhance the learning ex
 In particular, they benefit learners who may have difficulty acquiring knowledge from reading and processing textual content alone. 
 However, simulations can also present some groups of learners with difficulties. 
 To minimize barriers, consider the intended learning outcome of the simulation. 
-Is it to reinforce understanding that can also come from textual content or a video lecture, or is it to convey new knowledge that other course resources can’t cover? 
+Is it to reinforce understanding that can also come from textual content or a video lecture, or is it to convey new knowledge that other course resources can't cover? 
 Providing alternative resources will help mitigate the impact of any barriers.
 
 Although you can design simulations to avoid many accessibility barriers, some barriers, particularly in simulations supplied by third parties, 
 may be difficult or impossible to address for technical or pedagogic reasons. 
 Understanding the nature of these barriers can help you provide workarounds for learners who are affected. 
-Keep in mind that attempted workarounds for simulations supplied by third parties may require the supplier’s consent if copyrighted material is involved.
+Keep in mind that attempted workarounds for simulations supplied by third parties may require the supplier's consent if copyrighted material is involved.
 
 Consider the following questions when creating simulations, keeping in mind that as the course instructor, 
 you enjoy considerable freedom in selecting course objectives and outcomes. 
@@ -340,7 +340,7 @@ keeping in mind that some of the end users have disabilities.
 Focus on activities that allow students to complete the activity and submit their work without difficulties.
 
 Some students take longer to read information and input responses, such as students with visual or mobility impairments and students who need time to comprehend the information. 
-If an exercise has a time limit, consider whether it’s long enough to allow students to respond. Advanced planning may help cut down on the number of students requesting 
+If an exercise has a time limit, consider whether it's long enough to allow students to respond. Advanced planning may help cut down on the number of students requesting 
 time extensions.
 
 Some online exercise question types may be difficult for students who have vision or mobility impairments. For example:
@@ -372,7 +372,7 @@ for guidance on creating accessible HTML.
   charts, diagrams, and illustrations: 
   http://ncam.wgbh.org/experience_learn/educational_media/stemdx
 
-* The University of Washington’s DO-IT project provides guidance on creating accessible math content: 
+* The University of Washington's DO-IT project provides guidance on creating accessible math content: 
   http://www.washington.edu/doit/Faculty/articles?465
 
 * AccessSTEM provides guidance on creating accessible science, technology, engineering and math educational content: 
@@ -392,26 +392,26 @@ Best Practices for Describing Images
 
 Pictures, diagrams, maps, charts, and icons can present information very effectively. 
 However, some visually impaired students, including people who use screen reader software, need text alternatives to understand the information conveyed by these images. 
-The text alternative for an image depends on the image’s context and purpose, and may not be a straight description of the image’s visual characteristics.
+The text alternative for an image depends on the image's context and purpose, and may not be a straight description of the image's visual characteristics.
 
 Use the following guidelines when you include images in your course:
 
 * Provide a short text description that conveys the purpose of the image, unless the image conveys a concept or is the only source for the information it presents, 
-  in which case a long text description is appropriate. Note that you don’t need to provide a long description if the information appears elsewhere on the page. 
-  For example, you don’t need to describe a chart if the same data appears as text in a data table.
+  in which case a long text description is appropriate. Note that you do not need to provide a long description if the information appears elsewhere on the page. 
+  For example, you do not need to describe a chart if the same data appears as text in a data table.
   
   * For a representative image, such as a photograph of Ponte Vecchio, a short
-    description could be “Photo of Ponte Vecchio.” If the photograph’s purpose is to provide detailed information about the location, the long description should be more specific: “Photo of Ponte Vecchio showing its three stone arches and the Arno River.”
+    description could be "Photo of Ponte Vecchio." If the photograph's purpose is to provide detailed information about the location, the long description should be more specific: "Photo of Ponte Vecchio showing its three stone arches and the Arno River."
 
-  * For a chart, diagram, or illustration, the short description might be “Diagram of Ponte Vecchio.” The long description should include the details conveyed visually, such as dimensions and materials used.
+  * For a chart, diagram, or illustration, the short description might be "Diagram of Ponte Vecchio." The long description should include the details conveyed visually, such as dimensions and materials used.
 
-  * For a map, a short description might be “Map showing location of Ponte Vecchio.” If the map is intended to provide directions to the bridge, the long description should provide text directions.
+  * For a map, a short description might be "Map showing location of Ponte Vecchio." If the map is intended to provide directions to the bridge, the long description should provide text directions.
   
-  * For icons, the short description should be the equivalent to the information that the icon provides. For example, for a Course Syllabus link containing a PDF icon, the text equivalent for the icon would be “PDF,” which would be read as “Course Syllabus PDF.”
+  * For icons, the short description should be the equivalent to the information that the icon provides. For example, for a Course Syllabus link containing a PDF icon, the text equivalent for the icon would be "PDF," which would be read as "Course Syllabus PDF."
 
-  * For an image that serves primarily as a link to another web page, the short description should describe the link’s destination, not the image. For example, an image of a question mark that serves as a link to a Help page should be described as “help,” not “question mark.”
+  * For an image that serves primarily as a link to another web page, the short description should describe the link's destination, not the image. For example, an image of a question mark that serves as a link to a Help page should be described as "help", not "question mark".
 
-  * Images that don’t provide information don’t need text descriptions. For example, a PDF icon that is followed by link text reading “Course Syllabus (PDF)” does not need a description. Another example is a banner graphic whose function is purely aesthetic.
+  * Images that accompany descriptive text, or that are decorative, do not need text descriptions. For example, a PDF icon that is followed by link text reading "Course Syllabus (PDF)" does not need a description. Another example is a banner graphic whose function is purely aesthetic.
   
 * Include the short description in the alt attribute of the HTML image element, as follows (see :ref:`Add an Image to an HTML Component` for more information about adding images):
 
@@ -448,21 +448,21 @@ Best Practices for Accessible Media
 
 Media-based course materials help convey concepts and bring course information to life. 
 We require all edX courses to use videos with interactive, screen-reader- accessible transcripts. 
-This built-in universal design mechanism helps enhance your course’s accessibility. 
+This built-in universal design mechanism helps enhance your course's accessibility. 
 When you create your course, you need to factor in time and resources for creating these transcripts.
 
 ++++++++++++++++++++++++++++++++++++++++++++  
 Audio transcription
 ++++++++++++++++++++++++++++++++++++++++++++  
 
-Audio transcripts are essential for presenting audible content to students who can’t hear and are helpful to students who are not native English speakers. 
-Synchronized transcripts allow students who can’t hear to follow along with the video and navigate to a specific section of the video by clicking the transcript text. 
+Audio transcripts are essential for presenting audible content to students who can't hear and are helpful to students who are not native English speakers. 
+Synchronized transcripts allow students who can't hear to follow along with the video and navigate to a specific section of the video by clicking the transcript text. 
 Additionally, all students can use transcripts of media-based learning materials for study and review.
 
-A transcript starts with a text version of the video’s spoken content. 
+A transcript starts with a text version of the video's spoken content. 
 If you created your video using a script, you have a great start on creating the transcript. 
 Just review the recorded video and update the script as needed. 
-Otherwise, you’ll need to transcribe the video yourself or engage someone to do it. 
+Otherwise, you'll need to transcribe the video yourself or engage someone to do it. 
 There are many companies that will create timed video transcripts (i.e., transcripts that synchronize the text with the video using time codes) for a fee.
 
 The edX platform supports the use of transcripts in .srt format. 
@@ -474,7 +474,7 @@ See :ref:`Working with Video Components` for details on how to add timed transcr
 Video description
 ++++++++++++++++++++++++++++++++++++++++++++
 
-When creating video segments, consider how to convey information to learners who can’t see. 
+When creating video segments, consider how to convey information to learners who can't see. 
 For many topics, you can fully cover concepts in the spoken presentation. 
 If practical, you might also describe visual information, for example, by speaking as you are writing on a tablet.
 
@@ -502,11 +502,11 @@ the information in the markup helps assistive technologies, such as screen reade
 
 To make it easier for our course teams to create content with good HTML markup, we are working to make all templates in edX Studio conform to the best practices set forth below. 
 In the interim, we recommend that you manually add the appropriate HTML tagging. 
-Depending on the type of component you are adding to your course in edX Studio, the raw HTML data will be available either automatically or by selecting the “Advanced Editor” or “HTML” views.
+Depending on the type of component you are adding to your course in edX Studio, the raw HTML data will be available either automatically or by selecting the "Advanced Editor" or "HTML" views.
 
 Keep the following guidelines in mind when you create HTML content:
 
-* Use HTML to describe your content’s *meaning* rather than its *appearance*. A phrase marked as a level 1 heading (<h1>) clearly indicates the topic of the page, 
+* Use HTML to describe your content's *meaning* rather than its *appearance*. A phrase marked as a level 1 heading (<h1>) clearly indicates the topic of the page, 
   while a phrase marked as bold text (<bold> or <strong>) may be a heading or may just be text that the instructor wants to emphasize. 
   A group of items marked up as a list are related in the code, without relying on visual cues such as bullets and indents. 
   Coding meaning into content is particularly useful for students using screen readers, which, for example, can read through headings or announce the number of items in a list.
@@ -519,7 +519,7 @@ Keep the following guidelines in mind when you create HTML content:
   #. Ordered lists, where each item is listed with a number.
   #. Definition lists, where each item is represented using term and description pairs (like a dictionary).
 
-* Use table elements to mark up data sets—that is, information that works best in a grid format—with descriptive rows and columns. 
+* Use table elements to mark up data sets (that is, information that works best in a grid format) with descriptive rows and columns. 
   Mark up row and column headers using the <th> element so screen readers can effectively describe the content in the table.
 
 **Resources**
@@ -538,5 +538,5 @@ Conclusion
 
 At edX, the heart of our mission is to provide global access to higher-level learning with only a computer and the Internet. 
 We have designed a platform that enables course creators to reach thousands of learners, some of whom will lack the typical backgrounds and resources of resident students taking traditional courses on college campuses. 
-We hope that these guidelines prove useful to you as you work with your institution’s disability support services and information technology resources to comply with applicable accessibility laws. 
+We hope that these guidelines prove useful to you as you work with your institution's disability support services and information technology resources to comply with applicable accessibility laws. 
 As we are all on this learning venture together, we encourage you to share your thoughts with us at accessibility@edx.org.

--- a/en_us/developers/source/extending_platform/javascript.rst
+++ b/en_us/developers/source/extending_platform/javascript.rst
@@ -83,7 +83,7 @@ optionally to provide feedback as a formative assessment.
 #. Edit the XML of the component to remove grading information and refer to the
    HTML file you uploaded:
 
-.. code-block:: xml
+.. code-block:: python
 
     <customresponse>
         <jsinput
@@ -95,7 +95,7 @@ optionally to provide feedback as a formative assessment.
 
 For example:
 
-.. code-block:: xml
+.. code-block:: python
 
     <customresponse>
         <jsinput
@@ -139,7 +139,7 @@ attribute of the ``jsinput`` element for the problem.
 
 For example:
 
-.. code-block::  xml
+.. code-block::  python
 
     <customresponse cfn="vglcfn">
         <jsinput get_statefn="JSObject.getState"
@@ -163,7 +163,7 @@ attribute of the ``jsinput`` element for the problem.
 
 For example:
 
-.. code-block::  xml
+.. code-block::  python
 
     <customresponse cfn="vglcfn">
         <jsinput set_statefn="JSObject.setState"
@@ -188,7 +188,7 @@ attribute of the ``jsinput`` element for the problem.
 
 For example:
 
-.. code-block::  xml
+.. code-block::  python
 
     <customresponse cfn="vglcfn">
         <jsinput gradefn="JSObject.getGrade"
@@ -223,7 +223,7 @@ In the Python code, you must:
 
 The structure of the Python code in the problem is:
 
-.. code-block:: xml
+.. code-block:: python
 
     <problem>
         <script type="loncapa/python">
@@ -245,7 +245,7 @@ XML for Custom JavaScript Applications
 The problem component XML that you define in Studio to provide students with a
 JavaScript application has the following structure:
 
-.. code-block::
+.. code-block:: python
 
     <problem>
         <!-- Optional script tag for summative assessments -->

--- a/en_us/developers/source/extending_platform/js_template_example.rst
+++ b/en_us/developers/source/extending_platform/js_template_example.rst
@@ -152,7 +152,7 @@ XML Problem Structure
 
 The XML problem for the sample template is:
 
-.. code-block:: xml
+.. code-block:: python
 
     <problem display_name="webGLDemo">
         <script type="loncapa/python">

--- a/en_us/shared/exercises_tools/annotation.rst
+++ b/en_us/shared/exercises_tools/annotation.rst
@@ -58,7 +58,7 @@ problem.
     #. Paste the following code in the Advanced Problem component, replacing
        placeholders with your own information.
 
-        .. code-block:: xml
+        .. code-block:: python
 
           <problem>
               <annotationresponse>

--- a/en_us/shared/exercises_tools/checkbox.rst
+++ b/en_us/shared/exercises_tools/checkbox.rst
@@ -47,7 +47,7 @@ Simple Editor
 For the example problem above, the text in the Problem component is the
 following.
 
-.. code-block:: xml
+.. code-block:: python
 
     Learning about the benefits of preventative healthcare can be particularly 
     difficult. >>Check all of the reasons below why this may be the case.<<
@@ -68,7 +68,7 @@ Advanced Editor
 
 To create this problem in the Advanced Editor, click the **Advanced** tab in the Problem component editor, and then replace the existing code with the following code.
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p>Learning about the benefits of preventative healthcare can be particularly difficult. Check all of the reasons below why this may be the case.</p>
@@ -100,7 +100,7 @@ Checkbox Problem XML
 Template
 ============
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p>Question text</p>

--- a/en_us/shared/exercises_tools/chemical_equation.rst
+++ b/en_us/shared/exercises_tools/chemical_equation.rst
@@ -27,7 +27,7 @@ To create the above chemical equation problem:
 Sample Chemical Equation Problem Code
 ==========================================
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <startouttext/>
@@ -75,7 +75,7 @@ Chemical Equation Problem XML
 Template
 ============
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <startouttext/>

--- a/en_us/shared/exercises_tools/circuit_schematic_builder.rst
+++ b/en_us/shared/exercises_tools/circuit_schematic_builder.rst
@@ -24,7 +24,7 @@ Create a Circuit Schematic Builder Problem
 
 To create the problem in the image above, paste the following code into the Advanced Editor.
 
-.. code-block:: xml
+.. code-block:: python
 
  <problem>
     <p>Make a voltage divider that splits the provided voltage evenly.</p>

--- a/en_us/shared/exercises_tools/conditional_module.rst
+++ b/en_us/shared/exercises_tools/conditional_module.rst
@@ -10,7 +10,7 @@ Format description
 
 The main tag of conditional module input is:
 
-.. code-block:: xml
+.. code-block:: python
 
     <conditional> ... </conditional>
 
@@ -23,7 +23,7 @@ conditional tag
 The main container for a single instance of a conditional module. The following attributes can
 be specified for this tag:
 
-.. code-block:: xml
+.. code-block:: python
 
     sources - location id of required modules, separated by ';'
     [message | ""] - message for case, where one or more are not passed. Here you can use variable {link}, which generate link to required module.
@@ -43,7 +43,7 @@ show tag
 Symlink to some set of xmodules. The following attributes can
 be specified for this tag:
 
-.. code-block:: xml
+.. code-block:: python
 
     sources - location id of modules, separated by ';'
 
@@ -55,7 +55,7 @@ Example
 Examples of conditional depends on poll
 ========================================
 
-.. code-block:: xml
+.. code-block:: python
 
     <conditional sources="i4x://MITx/0.000x/poll_question/first_real_poll_seq_with_reset" poll_answer="man"
     message="{link} must be answered for this to become visible.">
@@ -68,7 +68,7 @@ Examples of conditional depends on poll
 Examples of conditional depends on poll (use <show> tag)
 ========================================================
 
-.. code-block:: xml
+.. code-block:: python
 
     <conditional sources="i4x://MITx/0.000x/poll_question/first_real_poll_seq_with_reset" poll_answer="man"
     message="{link} must be answered for this to become visible.">
@@ -81,7 +81,7 @@ Examples of conditional depends on poll (use <show> tag)
 Examples of conditional depends on problem
 ================================================
 
-.. code-block:: xml
+.. code-block:: python
 
     <conditional sources="i4x://MITx/0.000x/problem/Conditional:lec27_Q1" attempted="True">
         <html display_name="HTML for attempted problem">You see this, cause "lec27_Q1" is attempted.</html>

--- a/en_us/shared/exercises_tools/custom_javascript.rst
+++ b/en_us/shared/exercises_tools/custom_javascript.rst
@@ -8,7 +8,7 @@ Custom JavaScript display and grading problems (also called *custom JavaScript p
 or *JS Input problems*) allow you to create a custom problem or tool that uses JavaScript
 and then add the problem or tool directly into Studio. When you create a JS Input problem,
 Studio embeds the problem in an inline frame (IFrame) so that your students can interact with
-it in the LMS. You can grade your students’ work using JavaScript and some basic Python, and
+it in the LMS. You can grade your students' work using JavaScript and some basic Python, and
 the grading is integrated into the edX grading system.
 
 The JS Input problem that you create must use HTML, JavaScript, and cascading style sheets
@@ -73,7 +73,7 @@ To download these files in a .zip archive, go to http://files.edx.org/JSInput.zi
 JavaScript Input Problem Code
 ================================
 
-.. code-block:: xml
+.. code-block:: python
 
     <problem display_name="webGLDemo">
     In the image below, click the cone.
@@ -143,7 +143,7 @@ Template
 
 The following is the basic format of a JSInput problem:
 
-.. code-block:: xml
+.. code-block:: python
 
  <problem>
         <script type="loncapa/python">
@@ -200,7 +200,12 @@ Optional Attributes
 
 * **set_statefn**
 
-  Sometimes a problem author will want information about a student's previous answers ("state") to be saved and reloaded. If the attribute **set_statefn** is used, the function given as its value will be passed the state as a string argument whenever there is a state, and the student returns to a problem. The function has the responsibility to then use this state approriately.
+  Sometimes a problem author will want information about a student's previous
+  answers ("state") to be saved and reloaded. If the attribute **set_statefn**
+  is used, the function given as its value will be passed the state as a
+  string argument whenever there is a state, and the student returns to a
+  problem. The function has the responsibility to then use this state
+  appropriately.
 
   The state that is passed is:
 
@@ -214,7 +219,7 @@ Optional Attributes
   Sometimes the state and the answer are quite different. For instance, a problem that involves using a javascript program that allows the student to alter a molecule may grade based on the molecule's hydrophobicity, but from the hydrophobicity it might be incapable of restoring the state. In that case, a
   *separate* state may be stored and loaded by **set_statefn**. Note that if **get_statefn** is defined, the answer (i.e., what is passed to the enclosing response type) will be a json string with the following format:
 
-  .. code-block:: xml
+  .. code-block:: python
 
       {
           answer: `[answer string]`

--- a/en_us/shared/exercises_tools/custom_python.rst
+++ b/en_us/shared/exercises_tools/custom_python.rst
@@ -39,7 +39,7 @@ Answer Tag Format
 
 The answer tag format encloses the Python script in an ``<answer>`` tag:
 
-.. code-block:: xml
+.. code-block:: python
 
   <answer>
   if answers[0] == expect:
@@ -74,7 +74,7 @@ To create a custom Python-evaluated input problem using an ``<answer>`` tag:
 #. In the component editor, replace the example code with the following code.
 #. Click **Save**.
 
-.. code-block:: xml
+.. code-block:: python
 
     <problem>
         <p>What is the sum of 2 and 3?</p>
@@ -104,7 +104,7 @@ Script Tag Format
 
 The script tag format encloses a Python script that contains a "check function" in a ``<script>`` tag, and adds the ``cfn`` attribute of the ``<customresponse>`` tag to reference that function:
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
 
@@ -149,7 +149,7 @@ The **check** function can return any of the following to indicate whether the s
   If the dictionary's value for ``ok`` is set to ``True``, all response fields are marked correct; if it is set to ``False``, all response fields are marked incorrect. The ``msg`` is displayed beneath all response fields, and it may contain XHTML markup.
 * A dictionary of the form 
 
-.. code-block:: xml
+.. code-block:: python
       
     
     { 'overall_message': 'Overall message',
@@ -191,7 +191,7 @@ To create a custom Python-evaluated input problem using a ``<script>`` tag:
 
 **Problem Code**:
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>This question has two parts.</p>
@@ -236,7 +236,7 @@ To create a custom Python-evaluated input problem using a ``<script>`` tag:
 
 The following template includes answers that appear when the student clicks **Show Answer**. 
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
 
@@ -263,7 +263,7 @@ The following template includes answers that appear when the student clicks **Sh
 
 The following template does not return answers when the student clicks **Show Answer**. If your problem doesn't include answers for the student to see, make sure to set **Show Answer** to **Never** in the problem component.
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
 
@@ -308,7 +308,7 @@ input problem.
 .. note::
  This example uses the method ``random.randint`` to generate random numbers.  You can use any standard Python library for this purpose.
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p>Some problems in the course will utilize randomized parameters.

--- a/en_us/shared/exercises_tools/drag_and_drop.rst
+++ b/en_us/shared/exercises_tools/drag_and_drop.rst
@@ -51,7 +51,7 @@ then create a Problem component.
     image, the code would resemble the following (where 2 is the ID for the
     Sweden label):
 
-    .. code-block:: xml
+    .. code-block:: python
 
         correct-answer = {
                 '1':    [[50, 50], 75]
@@ -87,10 +87,10 @@ page, and then add the code for the problem to a Problem component.
 
 **Problem Code**:
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
-    <p> Allopurinol is a drug used to treat and prevent gout, a very painful form of arthritis. Once only a “rich man’s disease”, gout has become more and more common in recent decades – affecting about 3 million people in the United States alone. Deposits of needle-like crystals of uric acid in connective tissue or joint spaces cause the symptoms of swelling, stiffness and intense pain. Individuals with gout overproduce uric acid because they cannot eliminate it efficiently. Allopurinol treats and prevents gout by stopping the overproduction of uric acid through inhibition of an enzyme required for the synthesis of uric acid. </p>
+    <p> Allopurinol is a drug used to treat and prevent gout, a very painful form of arthritis. Once only a "rich man's disease", gout has become more and more common in recent decades – affecting about 3 million people in the United States alone. Deposits of needle-like crystals of uric acid in connective tissue or joint spaces cause the symptoms of swelling, stiffness and intense pain. Individuals with gout overproduce uric acid because they cannot eliminate it efficiently. Allopurinol treats and prevents gout by stopping the overproduction of uric acid through inhibition of an enzyme required for the synthesis of uric acid. </p>
     <p> You are shown one of many possible molecules. On the structure of allopurinol below, identify the functional groups that are present by dragging the functional group name listed onto the appropriate target boxes on the structure. If you want to change an answer, you have to drag off the name as well. You may need to scroll through the names of functional groups to see all options. </p>
     <customresponse>
       <drag_and_drop_input no_labels="true" one_per_target="true" target_outline="true" img="/static/Allopurinol.gif">
@@ -127,7 +127,7 @@ page, and then add the code for the problem to a Problem component.
 Drag and Drop Problem XML
 *********************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     Here's an example of a "Drag and Drop" question set. Click and drag each word in the scrollbar below, up to the numbered bucket which matches the number of letters in the word.
@@ -232,7 +232,7 @@ Tags
          single target. It can be either 'true' or 'false'. If not specified,
          the default value is 'true'.
      * - no_labels (required)
-       - default is false, in default behaviour if label is not set, label is
+       - default is false, in default behavior if label is not set, label is
          obtained from id. If no_labels is true, labels are not automatically
          populated from id, and one can not set labels and obtain only icons.
 

--- a/en_us/shared/exercises_tools/dropdown.rst
+++ b/en_us/shared/exercises_tools/dropdown.rst
@@ -70,7 +70,7 @@ To create this problem in the Advanced Editor, click the **Advanced** tab in the
 
 **Problem Code:**
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>
@@ -101,7 +101,7 @@ Dropdown Problem XML
 Template
 ========
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>
@@ -117,7 +117,7 @@ Template
     </solution>
   </problem>
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
    <p>Problem text</p>

--- a/en_us/shared/exercises_tools/external_graders.rst
+++ b/en_us/shared/exercises_tools/external_graders.rst
@@ -215,6 +215,10 @@ Note the following about the XML definition:
 
 * **queuename**: The value of the queuename attribute of the <coderesponse> element maps to an XQueue that edX sets up for the course.  You get this name from your edX Program Manager. You must use this exact name in order for the problem to communicate with the correct XQueue.
 
-* **Input Type**: In this example, the input type is specificed by the **<textbox>** element.  When you use <textbox>, the student enters code in a browser field when viewing the course unit.  The other element you can use to specify the input type is <filesubmission>, which enables the student to attach and submit a code file in the unit.
+* **Input Type**: In this example, the input type is specified by the
+  **<textbox>** element. When you use <textbox>, the student enters code in a
+  browser field when viewing the course unit. The other element you can use
+  to specify the input type is <filesubmission>, which enables the student to
+  attach and submit a code file in the unit.
 
 * **<grader_payload>**: You can use the <grader_payload> element to send information to the external grader in the form of a JSON object. For example, you can use <grader_payload> to tell the grader which tests to run for this problem.

--- a/en_us/shared/exercises_tools/full_screen_image.rst
+++ b/en_us/shared/exercises_tools/full_screen_image.rst
@@ -51,7 +51,7 @@ Create a Full Screen Image
 
    * Ensure that the value of the href and src attributes are the same, and that you do not change the class attribute. Your sample code should look like the following:
 
-   .. code-block:: xml
+   .. code-block:: python
 
      <h2>Sample Image Modal</h2>
      <a href="/static/Image1.jpg" class="modal-content">

--- a/en_us/shared/exercises_tools/gene_explorer.rst
+++ b/en_us/shared/exercises_tools/gene_explorer.rst
@@ -24,7 +24,7 @@ For more information about the Gene Explorer, see `The Gene Explorer <http://int
 Gene Explorer Code
 ********************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>Make a single base pair substitution mutation in the gene below that results in a protein that is longer than the protein produced by the original gene. When you are satisfied with your change and its effect, click the <b>SUBMIT</b> button.</p>

--- a/en_us/shared/exercises_tools/image_mapped_input.rst
+++ b/en_us/shared/exercises_tools/image_mapped_input.rst
@@ -24,7 +24,7 @@ To create a image mapped input problem:
 
 **Problem Code**:
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p><b>Example Problem</b></p>
@@ -47,7 +47,7 @@ Image Mapped Input Problem XML
 Template
 ==========
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <startouttext/>

--- a/en_us/shared/exercises_tools/lti_component.rst
+++ b/en_us/shared/exercises_tools/lti_component.rst
@@ -15,11 +15,11 @@ version 1.1.1 specifications.
 
 You can use an LTI component in several ways.
 
-* You can add external LTI content that is displayed only, such as textbook
-  content that doesn’t require a student response.
+* You can add external LTI content that only displays. An example is textbook
+  content that does not require a student response.
 
 * You can add external LTI content that requires a student response. An external
-  provider will grade student responses.
+  provider grades the student responses.
 
 * You can use the component as a placeholder for syncing with an external
   grading system.
@@ -41,7 +41,7 @@ unit, you need the following information.
 -  The **launch URL** (if the LTI component requires a student response
    that will be graded). You obtain the launch URL from the LTI
    provider. The launch URL is the URL that Studio sends to the external
-   LTI provider so that the provider can send back students’ grades.
+   LTI provider so that the provider can send back students' grades.
 
 - The **LTI Passports** policy key. This policy key has three parts: an LTI ID,
   a client key, and a client secret.
@@ -96,7 +96,7 @@ Step 1. Add LTI to the Advanced Module List Policy Key
 #. In the field for the **Advanced Module List** policy key, place your cursor
    between the brackets.
 
-#. Enter ``“lti”``. Make sure to include the quotation marks, but not the
+#. Enter ``"lti"``. Make sure to include the quotation marks, but not the
    period.
 
    .. image:: /Images/LTIPolicyKey.png
@@ -105,7 +105,7 @@ Step 1. Add LTI to the Advanced Module List Policy Key
 
 .. note:: If the **Advanced Module List** field already contains text, place your cursor directly
    after the closing quotation mark for the final item, and then enter a comma
-   followed by ``“lti”`` (make sure that you include the quotation marks).
+   followed by ``"lti"`` (make sure that you include the quotation marks).
 
 4. At the bottom of the page, click **Save Changes**.
 
@@ -116,7 +116,7 @@ you see a notification that your changes have been saved.
 Step 2. Register the External LTI Provider
 ==========================================
 
-To register the external LTI provider, you’ll add the **LTI Passports** policy
+To register the external LTI provider, you add the **LTI Passports** policy
 key to the course's advanced settings.
 
 #. On the **Advanced Settings** page, locate the **LTI Passports**
@@ -134,7 +134,7 @@ key to the course's advanced settings.
    Passports** policy key with a comma. Make sure to surround each entry with
    quotation marks.
 
-   .. code-block:: xml
+   .. code-block:: python
 
       "test_lti_id:b289378-f88d-2929-ctools.umich.edu:secret",
       "id_21441:b289378-f88d-2929-ctools.school.edu:23746387264",
@@ -199,6 +199,9 @@ LTI Component Settings
    * - Scored
      - Indicates whether the LTI component receives a numerical score from the external LTI system. By default, this value is set to **False**.
    * - Weight
-     - Specifies the number of points possible for the problem. By default, if an external LTI provider grades the problem, the problem is worth 1 point, and a student’s score can be any value between 0 and 1. This setting is applicable when **Scored** is set to **True**.
+     - Specifies the number of points possible for the problem. By default, if
+       an external LTI provider grades the problem, the problem is worth 1
+       point, and a student's score can be any value between 0 and 1. This
+       setting is applicable when **Scored** is set to **True**.
 
        For more information about problem weights and computing point scores, see :ref:`Problem Weight`.

--- a/en_us/shared/exercises_tools/math_expression_input.rst
+++ b/en_us/shared/exercises_tools/math_expression_input.rst
@@ -32,7 +32,7 @@ To create a math expression input problem:
 
 **Sample Problem Code**
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p>Some problems may ask for a mathematical expression. Practice creating mathematical expressions by answering the questions below.</p>
@@ -74,7 +74,7 @@ Math Expression Input Problem XML
 Templates
 ============
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p>Write an expression for the product of R_1, R_2, and the inverse of R_3.</p>
@@ -84,7 +84,7 @@ Templates
     </formularesponse>
   </problem>
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p>Problem text</p>

--- a/en_us/shared/exercises_tools/molecule_editor.rst
+++ b/en_us/shared/exercises_tools/molecule_editor.rst
@@ -55,7 +55,7 @@ To create the molecule editor, you need an HTML component and a Problem componen
 HTML Component Code
 ***************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <h2>Molecule Editor</h2>
   <p>The molecule editor makes creating and visualizing molecules easy. A chemistry professor may have you build and submit a molecule as part of an exercise.</p>
@@ -104,7 +104,7 @@ HTML Component Code
 Problem Component Code
 ***************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>The dopamine molecule, as shown, cannot make ionic bonds. Edit the dopamine molecule so it can make ionic bonds.</p>

--- a/en_us/shared/exercises_tools/mult_choice_num_input.rst
+++ b/en_us/shared/exercises_tools/mult_choice_num_input.rst
@@ -32,7 +32,7 @@ To create a multiple choice and numerical input problem:
 Multiple Choice and Numerical Input Problem Code
 ************************************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   The numerical value of pi, rounded to two decimal points, is 3.24.

--- a/en_us/shared/exercises_tools/multiple_choice.rst
+++ b/en_us/shared/exercises_tools/multiple_choice.rst
@@ -81,7 +81,7 @@ Advanced Editor
 
 To create this problem in the Advanced Editor, click the **Advanced** tab in the Problem component editor, and then replace the existing code with the following code.
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>Lateral inhibition, as was first discovered in the horsehoe crab...</p>
@@ -179,7 +179,7 @@ You can configure the problem to shuffle answers through XML in :ref:`Advanced E
 
 For example, the following XML defines a multiple choice problem, before shuffling is enabled:
 
-.. code-block:: xml
+.. code-block:: python
 
  <p>What Apple device competed with the portable CD player?</p>
  <multiplechoiceresponse>
@@ -194,7 +194,7 @@ For example, the following XML defines a multiple choice problem, before shuffli
 
 To add shuffling to this problem, add ``shuffle="true"`` to the ``<choicegroup>`` element:
 
-.. code-block:: xml
+.. code-block:: python
 
  <p>What Apple device competed with the portable CD player?</p>
  <multiplechoiceresponse>
@@ -208,7 +208,7 @@ To add shuffling to this problem, add ``shuffle="true"`` to the ``<choicegroup>`
 
 To fix an answer's location in the list, add ``fixed="true"`` to the ``choice`` element for the answer:
 
-.. code-block:: xml
+.. code-block:: python
 
  <p>What Apple device competed with the portable CD player?</p>
  <multiplechoiceresponse>
@@ -247,7 +247,7 @@ Follow these XML guidelines:
 
 For example, the XML for the multiple choice problem is:
 
-.. code-block:: xml
+.. code-block:: python
 
    <p>What Apple device competed with the portable CD player?</p>
    <multiplechoiceresponse targeted-feedback="">
@@ -261,7 +261,7 @@ For example, the XML for the multiple choice problem is:
  
 This is followed by XML that defines the targeted feedback:
 
-.. code-block:: xml
+.. code-block:: python
 
    <targetedfeedbackset>
      <targetedfeedback explanation-id="feedback1">
@@ -318,7 +318,7 @@ Follow these XML guidelines:
 
 For example, for the following multiple choice problem, a student will see four choices, and in each set one of the choices will be one of the two correct ones. The explanation shown for the correct answer is the one with the same explanation ID.
 
-.. code-block:: xml
+.. code-block:: python
 
  <problem>
    <p>What Apple devices let you carry your digital music library in your pocket?</p>
@@ -360,7 +360,7 @@ Multiple Choice Problem XML
 Template
 ================
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>Question text</p>

--- a/en_us/shared/exercises_tools/numerical_input.rst
+++ b/en_us/shared/exercises_tools/numerical_input.rst
@@ -94,7 +94,7 @@ To create this problem in the Advanced Editor, click the **Advanced** tab in the
 
 **Problem Code**:
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
     <p><b>Example Problem</b></p>
@@ -155,7 +155,7 @@ The following templates represent problems with and without a decimal or percent
 Problem with no tolerance
 ***************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <p>TEXT OF PROBLEM
       <numericalresponse answer="ANSWER (NUMBER)">
@@ -173,7 +173,7 @@ Problem with no tolerance
 Problem with a decimal tolerance
 ************************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
    
@@ -194,7 +194,7 @@ Problem with a decimal tolerance
 Problem with a percentage tolerance
 ************************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
    
@@ -215,7 +215,7 @@ Problem with a percentage tolerance
 Answer created with a script
 ************************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
 

--- a/en_us/shared/exercises_tools/poll.rst
+++ b/en_us/shared/exercises_tools/poll.rst
@@ -58,7 +58,7 @@ Create a Poll
 
    The file contains a list of all the components in the unit, together with the URL names of the components. For example, the following file contains an HTML component followed by a Discussion component.
 
-   .. code-block:: xml
+   .. code-block:: python
      
        <vertical display_name="Test Unit">
         <html url_name="b59c54e2f6fc4cf69ba3a43c49097d0b"/>
@@ -67,7 +67,7 @@ Create a Poll
 
 #. Add the following poll code in the location where you want the poll. Change the text of the prompt to the text that you want.
 
-   .. code-block:: xml
+   .. code-block:: python
       
     <poll_question display_name="Poll Question">
       <p>Text of the prompt</p>
@@ -77,7 +77,7 @@ Create a Poll
 
    In the example above, if you wanted your poll to appear between the HTML component and the Discussion component in the unit, your code would resemble the following.
 
-   .. code-block:: xml
+   .. code-block:: python
 
      <vertical display_name="Test Unit">
       <html url_name="b59c54e2f6fc4cf69ba3a43c49097d0b"/>
@@ -111,7 +111,7 @@ Format description
 
 The main tag of Poll module input is:
 
-.. code-block:: xml
+.. code-block:: python
 
     <poll_question> ... </poll_question>
 
@@ -148,7 +148,7 @@ Example
 Example of poll
 ==================
 
-.. code-block:: xml
+.. code-block:: python
 
     <poll_question name="second_question" display_name="Second question">
         <h3>Age</h3>

--- a/en_us/shared/exercises_tools/problem_with_hint.rst
+++ b/en_us/shared/exercises_tools/problem_with_hint.rst
@@ -22,7 +22,7 @@ To create the above problem:
 #. In the component editor, replace the example code with the code below.
 #. Click **Save**.
 
-.. code-block:: xml
+.. code-block:: python
 
     <problem>
 	    <text>
@@ -67,7 +67,7 @@ Problem with Adaptive Hint XML
 Template
 ========
 
-.. code-block:: xml
+.. code-block:: python
 
 	<problem>
 	  <text>

--- a/en_us/shared/exercises_tools/protein_builder.rst
+++ b/en_us/shared/exercises_tools/protein_builder.rst
@@ -29,7 +29,7 @@ To create the protein builder:
 Protein Builder Tool Code
 *************************
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
       <p>The protein builder allows you string together the building blocks of proteins, amino acids, and see how that string will form into a structure. You are presented with a goal protein shape, and your task is to try to re-create it. In the example below, the shape that you are asked to form is a simple line.</p> 

--- a/en_us/shared/exercises_tools/text_input.rst
+++ b/en_us/shared/exercises_tools/text_input.rst
@@ -70,7 +70,7 @@ Advanced Editor
 
 To create this problem in the Advanced Editor, click the **Advanced** tab in the Problem component editor, and then replace the existing code with the following code.
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
   <p>
@@ -136,7 +136,7 @@ Advanced Editor
 
 To specify additional correct responses in the Advanced Editor, add an ``<additional_answer>``  for each correct response inside the opening and closing ``<stringresponse>`` tags.
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
 
@@ -225,7 +225,7 @@ Text Input Problem XML
 Template
 ==============
 
-.. code-block:: xml
+.. code-block:: python
 
   <problem>
       <p>Problem text</p>

--- a/en_us/students/source/SFD_ORA.rst
+++ b/en_us/students/source/SFD_ORA.rst
@@ -36,9 +36,7 @@ Here, we'll walk you through the process of completing an open response assessme
 #. Assess your own response to the question.
 #. Receive your score and provide feedback on the peer assessment.
 
-At any time during the assessment, you can see your progress through the assignment at the bottom of the page under **Your Grade**. A message tells you the steps that you still have to perform before you can receive your grade. For example, you may see the following message:
-
-.. code-block:: xml
+At any time during the assessment, you can see your progress through the assignment at the bottom of the page under **Your Grade**. A message tells you the steps that you still have to perform before you can receive your grade. For example, you may see the following message::
 
   Not Completed
   You have not completed the peer assessment step and self assessment step of this problem.
@@ -55,9 +53,7 @@ Type your response into the field under **Your Response**, and then click **Subm
 
 After you submit your response, if other students have already submitted responses, the peer assessment step starts immediately. However, you don't have to start grading right away. If you want to stop working and come back later, just refresh or reopen your browser when you come back. New peer responses will be available for you to grade.
 
-If no other students have submitted responses yet, you'll see the following message:
-
-.. code-block:: xml
+If no other students have submitted responses yet, you'll see the following message::
 
   Waiting for Peer Responses
   All submitted peer responses have been assessed. Check back later to see if more students
@@ -109,21 +105,19 @@ After you submit your response, one of the sample responses opens, together with
 
 * If any option that you select is not the same as the instructor's selection, you'll see the response again, and the following message appears above the response:
 
-.. code-block:: xml
+::
 
   Learning to Assess Responses
   Your assessment differs from the instructor's assessment of this response. Review the
   response and consider why the instructor may have assessed it differently. Then, try 
   the assessment again.
 
-For each of the criteria, you'll see one of the following two messages, depending on whether your selections matched those of the instructor:
-
-.. code-block:: xml
+For each of the criteria, you'll see one of the following two messages, depending on whether your selections matched those of the instructor::
 
   Selected Options Agree
   The option you selected is the option that the instructor selected.
 
-.. code-block:: xml
+::
 
   Selected Options Differ
   The option you selected is not the option that the instructor selected.
@@ -188,7 +182,7 @@ Receive Your Score and Provide Feedback
 
 After you submit your self assessment, if other students are still assessing your response, you'll see the following message under the **Assess Your Response** step.
 
-.. code-block:: xml
+::
 
   Your Grade: Waiting for Peer Assessment
 


### PR DESCRIPTION
@JAAkana , @mhoeber , @catong , @srpearce 
It seems that the Sphinx template automatically applies the typographically "correct" smart quotes to untagged text but ALSO TO text tagged as an XML code block. It does NOT do so for text tagged as a Python code block or only with the :: formatting identifier. 
However, I have only tested this locally in HTML output. This will need to be merged (or a subset) for us to confirm that the HTML and PDF output actually produced by RTD leaves the quotes alone.  
This PR includes changes to files in the course_authors, shared, and students directories. 
There's no rush on this, but the error was reported back in September.
PS I spell checked the files that needed a change. If I changed a word or character I wrapped the paragraph. Other changes to the files are outside the scope of this bug.
