### PR TITLE
Remove usernames as Unicode use example

### DIFF
--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -356,8 +356,7 @@ Creating a Unicode-encoded CSV File
 ====================================
 
 Make sure the .csv files that you upload are encoded as UTF-8, so that any
-Unicode characters (for example, in usernames) are correctly saved and
-displayed.
+Unicode characters are correctly saved and displayed.
 
 .. note:: Some spreadsheet applications (for example, MS Excel) do not allow you
    to specify encoding when you save a spreadsheet as a .csv file. To ensure that


### PR DESCRIPTION
Amendment to https://github.com/edx/edx-documentation/pull/45
Turns out we do not support Unicode characters in usernames, though we still require UTF-8 encoded CSV files. This change removes "for example, usernames" in the "Creating a Unicode-encoded CSV File" topic so that we don't seem to imply that we support usernames with Unicode characters.
@explorerleslie @dan-f @lamagnifica please give thumbs if OK. I'd like to merge this today. Thanks!
FYI @WatsonEmily 
