### PR TITLE
Cohorted courseware: Reword cohorts and content experiment overview/config in preparation

### DIFF
--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -15,13 +15,15 @@ applicable):
 
 #. :ref:`Enable the cohort feature<Enable Cohorts>`.
 
-#. Based on the strategy you select for assigning students to cohort groups:
+#. Determine the strategy you want to use to assign students to cohort groups:
 
-  * :ref:`Define the auto cohort groups<Define Auto Cohort Groups>`.
-  * :ref:`Define the manual cohort groups<Define the Manual Cohort Groups>` and
-    then :ref:`assign students<Assign Students to Cohort Groups
-    Manually>` to them.
-  * Do both. 
+  * :ref:`Define automatic cohort groups<Define Auto Cohort Groups>`
+
+  * :ref:`Define manual cohort groups<Define the Manual Cohort Groups>` and
+    :ref:`manually assign students<Assign Students to Cohort Groups Manually>`
+    to them
+
+  * Do both.
 
 3. Optionally, identify the discussion topics that you want to be divided by
    cohort.
@@ -36,8 +38,9 @@ applicable):
     topics to be unified<Make ContentSpecific Discussion Topics Unified>`.
 
 You complete these procedures in Studio and on the Instructor Dashboard. For an
-optimal student experience, configuration of the cohort feature should be as
-complete as possible prior to the start date of your course. 
+optimal student experience, you should make sure that configuration of the
+cohort feature is as complete as possible prior to the start date of your
+course.
 
 If you need to make changes to the way you have configured the cohort feature
 while your course is running, please see :ref:`Altering Cohort Configuration`.
@@ -117,9 +120,9 @@ divided by cohort. See :ref:`Read the Cohort Indicator in Posts`.
    it within quotation marks (``" "``), and separate the quoted name values
    with commas. For example:
    
- .. code:: 
+   .. code:: 
 
-   "auto_cohort_groups": [
+  "auto_cohort_groups": [
        "Example Group Name A",
        "Example Group Name B",
        "Example Group Name C"
@@ -232,8 +235,8 @@ Assign Students to Cohort Groups Manually
    another cohort group was changed by this procedure.
 
 For a report that includes the cohort group assignment for every enrolled
-student, review the student profile information for your course. See
-:ref:`View and download student data`.
+student, review the student profile information for your course. See :ref:`View
+and download student data`.
 
 
 .. _Assign Students to Cohort Groups by uploading CSV:

--- a/en_us/course_authors/source/cohorts/cohort_config.rst
+++ b/en_us/course_authors/source/cohorts/cohort_config.rst
@@ -15,15 +15,17 @@ applicable):
 
 #. :ref:`Enable the cohort feature<Enable Cohorts>`.
 
-#. Determine the strategy you want to use to assign students to cohort groups:
 
+#. Determine the method you want to use to assign students to cohort groups:
+   
   * :ref:`Define automatic cohort groups<Define Auto Cohort Groups>`
 
   * :ref:`Define manual cohort groups<Define the Manual Cohort Groups>` and
     :ref:`manually assign students<Assign Students to Cohort Groups Manually>`
     to them
 
-  * Do both.
+  * :ref:`Use a combination of automatic and manual assignment<Hybrid
+    Assignment>`.
 
 3. Optionally, identify the discussion topics that you want to be divided by
    cohort.

--- a/en_us/course_authors/source/cohorts/cohorts_overview.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_overview.rst
@@ -8,10 +8,10 @@ Using Cohort Groups in your Courses
 By :ref:`setting up cohort groups<Enabling and Configuring Cohorts>` in a
 course, you create smaller communities of students. You can design different
 course experiences for students in different cohort groups. In discussion topics
-that are divided by cohorts, students can also communicate and share experiences
-privately within the cohort group that they are assigned to. Cohort-only
-discussion opportunities can help students develop a sense of community, provide
-specialized experiences, and encourage deeper, more meaningful course
+that are divided by cohort group, students can also communicate and share
+experiences privately within the cohort group that they are assigned to. Cohort-
+only discussion opportunities can help students develop a sense of community,
+provide specialized experiences, and encourage deeper, more meaningful course
 involvement.
 
 If you use cohort groups in your course, you define a set of cohort groups to
@@ -33,7 +33,7 @@ For more information about using cohort groups in courses, see:
 
 * :ref:`Enabling and Configuring Cohorts`
 
-* :ref:`Setting Up Discussions in Cohorted Courses<Set up Discussions in Cohorted Courses>`
+* :ref:`Setting Up Discussions in Courses with Cohort Groups<Set up Discussions in Cohorted Courses>`
 
 * :ref:`Moderating Discussions for Cohorts`
 

--- a/en_us/course_authors/source/cohorts/cohorts_overview.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_overview.rst
@@ -14,23 +14,18 @@ discussion opportunities can help students develop a sense of community, provide
 specialized experiences, and encourage deeper, more meaningful course
 involvement.
 
-
-=======
-If you decide to use cohort groups in your course, you define a set of cohort
-groups to reflect communities of students, then select a strategy for
-:ref:`assigning students to cohort groups<Options for Assigning Students to
-Cohorts>`. 
->>>>>>> Changes to cohort and content experiments doc to prepare for cohorted
+If you use cohort groups in your course, you define a set of cohort groups to
+reflect communities of students, then select a strategy for :ref:`assigning
+students to cohort groups<Options for Assigning Students to Cohorts>`.
 
 .. note:: 
-
    * Every student must be assigned to a cohort group. This ensures that every
      student has the ability to read and contribute to course discussion topics.
 
    * Each student can be in one and only one cohort group. 
 
-   To provide students with a consistent experience throughout the course    run,
-   do not change a student's assignment to a cohort group after  the course
+   To provide students with a consistent experience throughout the course run,
+   do not change a student's assignment to a cohort group after the course
    begins.
 
 
@@ -132,19 +127,13 @@ each student to one of the manual cohort groups. Every student who enrolls,
 including those who enroll after the course starts, must be assigned to a
 cohort group.
 
-<<<<<<< HEAD
+
 .. note:: To ensure that every student is assigned to a cohort group, you can
    set up a single automatic cohort group, as described for the :ref:`hybrid  assignment
    strategy<Hybrid Assignment>`. If you do not create an automatic cohort  group,
    the system automatically creates a :ref:`default cohort group<Default  Cohort
    Group>` and assigns students to it if necessary.
-=======
-.. note:: To ensure that every student is assigned to a cohort group, you can 
- set up a single auto cohort group, as described for the :ref:`hybrid
- assignment strategy<Hybrid Assignment>`. If you do not create an auto cohort
- group, the system automatically creates a :ref:`default cohort group<Default
- Cohort Group>` and assigns students to it if necessary.
->>>>>>> Changes to cohort and content experiments doc to prepare for cohorted
+
 
 For more information, see :ref:`Implementing the Manual Assignment Strategy`.
 

--- a/en_us/course_authors/source/cohorts/cohorts_overview.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_overview.rst
@@ -2,52 +2,47 @@
 
 
 ##########################################
-Using Cohorts to Build Course Communities
+Using Cohort Groups in your Courses
 ##########################################
 
-Cohorts create smaller communities of students within a course. Students who
-are in a cohort can communicate and share experiences privately within course
-discussion topics.
-
-By :ref:`enabling the cohort feature<Enabling and Configuring Cohorts>` in a
-course, you provide students with the ability to ask questions of, and have
-conversations with, other members of their cohort. Cohort-only discussion
-opportunities can help students develop a sense of community, provide
+By :ref:`setting up cohort groups<Enabling and Configuring Cohorts>` in a
+course, you create smaller communities of students. You can design different
+course experiences for students in different cohort groups. In discussion topics
+that are divided by cohorts, students can also communicate and share experiences
+privately within the cohort group that they are assigned to. Cohort-only
+discussion opportunities can help students develop a sense of community, provide
 specialized experiences, and encourage deeper, more meaningful course
 involvement.
 
-When you enable the cohort feature for your course, discussion topics within
-units (added as discussion components) are by default divided by cohort. This
-means that when a student in a cohort group creates a post on a content-specific
-topic, only members of that same cohort group can read and respond to the post.
-In contrast, any course-wide discussion topics that you set up for your course
-are by default unified. This means that every student, regardless of their
-cohort group, can read and respond to all posts in course-wide discussions. You
-can configure your course-wide or content-specific topics so that some, or all,
-of the discussion topics at either level are divided by cohort or unified. See
-:ref:`Set up Discussions in Cohorted Courses`.
 
-This section also describes your options for :ref:`assigning students to cohort
-groups<Options for Assigning Students to Cohorts>`. When you enable the cohort
-feature, you define a set of cohort groups to reflect communities of students,
-and select a strategy for assigning students to those groups. Note that:
+=======
+If you decide to use cohort groups in your course, you define a set of cohort
+groups to reflect communities of students, then select a strategy for
+:ref:`assigning students to cohort groups<Options for Assigning Students to
+Cohorts>`. 
+>>>>>>> Changes to cohort and content experiments doc to prepare for cohorted
 
-* Every student must be assigned to a cohort group. This assures that every
-  student has the ability to read and contribute to all of the course
-  discussion topics.
+.. note:: 
 
-* Each student is in one and only one cohort group. 
+   * Every student must be assigned to a cohort group. This ensures that every
+     student has the ability to read and contribute to course discussion topics.
 
-To provide a consistent experience throughout the course run, each student's
-assignment to a cohort group should remain unchanged after the course begins.
+   * Each student can be in one and only one cohort group. 
 
-For more information, see:
+   To provide students with a consistent experience throughout the course    run,
+   do not change a student's assignment to a cohort group after  the course
+   begins.
+
+
+For more information about using cohort groups in courses, see:
 
 * :ref:`Enabling and Configuring Cohorts`
-* :ref:`Set up Discussions in Cohorted Courses`
+
+* :ref:`Setting Up Discussions in Cohorted Courses<Set up Discussions in Cohorted Courses>`
+
 * :ref:`Moderating Discussions for Cohorts`
 
-For information about discussions, see :ref:`Discussions`.
+For information about discussions in general, see :ref:`Discussions`.
 
 
 .. _Options for Assigning Students to Cohorts:
@@ -137,11 +132,19 @@ each student to one of the manual cohort groups. Every student who enrolls,
 including those who enroll after the course starts, must be assigned to a
 cohort group.
 
+<<<<<<< HEAD
 .. note:: To ensure that every student is assigned to a cohort group, you can
    set up a single automatic cohort group, as described for the :ref:`hybrid  assignment
    strategy<Hybrid Assignment>`. If you do not create an automatic cohort  group,
    the system automatically creates a :ref:`default cohort group<Default  Cohort
    Group>` and assigns students to it if necessary.
+=======
+.. note:: To ensure that every student is assigned to a cohort group, you can 
+ set up a single auto cohort group, as described for the :ref:`hybrid
+ assignment strategy<Hybrid Assignment>`. If you do not create an auto cohort
+ group, the system automatically creates a :ref:`default cohort group<Default
+ Cohort Group>` and assigns students to it if necessary.
+>>>>>>> Changes to cohort and content experiments doc to prepare for cohorted
 
 For more information, see :ref:`Implementing the Manual Assignment Strategy`.
 

--- a/en_us/course_authors/source/cohorts/cohorts_setup_discussions.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_setup_discussions.rst
@@ -3,75 +3,34 @@
 
 
 ######################################################
-Setting up Discussions in Courses with Student Cohorts
+Setting up Discussions in Courses with Cohort Groups
 ######################################################
 
-
 In courses that have cohorts enabled, you can set up discussion topics to be
-either divided by cohort, or unified and accessible to all students.
+either divided by cohort group, or unified and accessible to all students.
 
 When you first enable cohorts in your course, the initial behavior for course-
 wide discussion topics is different from the behavior of content-specific
-(inline) discussion topics. By default, course-wide discussion topics are
-unified, but content-specific discussion topics are divided by cohort. You can
-configure either type of discussion to be divided or unified.
+(inline) discussion topics. 
+
+By default, course-wide discussion topics are unified, but content-specific
+discussion topics are divided by cohort group. You can configure either type of
+discussion to be divided or unified.
 
 For overview information about discussions in a course, see :ref:`Discussions`.
 For information about using cohort groups in a course, see :ref:`Cohorts
 Overview` and :ref:`Enabling and Configuring Cohorts`.
 
 
-**************************************************
-Course-Wide Discussion Topics Are Configurable
-**************************************************
-
-To create course-wide discussion topics, you add them on the **Advanced
-Settings** page in Studio. By default, each of these topics is unified. All of
-the students in the course can post, read, respond, and comment in course-wide
-discussion topics without regard to their cohort group assignments. After you
-add a course-wide topic, you can configure it so that it is divided by cohort
-instead.
-
-For example, in addition to the General topic, which is supplied by default,
-you create these additional course-wide topics: Course Q&A, Announcements, and
-Brainstorming. You want all students to be able to read and contribute to all
-of the posts in the General and Course Q&A topics. However, you want the
-Announcements and Brainstorming topics to be divided, so that students will
-only be able to read and respond to contributions by the members of their own
-cohorts. You complete the additional configuration step for the Announcements
-and Brainstorming topics only.
-
-For information about course-wide discussion topics, see
-:ref:`Organizing_discussions`. For information about configuring these topics, 
-see :ref:`Configure CourseWide Discussion Topics as Private`.
-
-
-**************************************************
-All Content-Specific Discussion Topics Are Divided
-**************************************************
-
-Each of the content-specific discussion topics is divided by cohort. A student
-who is assigned to one cohort group cannot read or add to the posts, responses,
-or comments contributed by the members of another cohort group.
-
-To create content-specific discussion topics in a course, you add units that
-include discussion components. In a course with the cohort feature enabled, you
-do not have the option to change these topics to be unified for all students.
-
-For more information about content-specific discussion topics,
-see :ref:`Organizing_discussions`.
-
-
-
-******************************************
-Course-Wide Discussion Topics and Cohorts
-******************************************
+***********************************************
+Course-Wide Discussion Topics and Cohort Groups
+***********************************************
 
 When you first :ref:`create a course-wide discussion topic<Create CourseWide
 Discussion Topics>`, it is unified, and all students in the course can post,
 read, respond, and comment in the topic without regard to their cohort group
 assignments. After you add a course-wide topic, you can configure it so that it
-is divided by cohort instead.
+is divided by cohort group instead.
 
 
 .. _Identifying Private CourseWide Discussion Topics:
@@ -89,14 +48,14 @@ discussion topics.
  :alt: Discussion Topic Mapping field with four course-wide discussion topics 
        defined
 
-You now enable cohorts for your course to take advantage of that feature as it
-applies to discussion topics.
+You have enabled cohort groups for your course to take advantage of that feature
+as it applies to discussion topics.
 
 The posts that you intend to make to the Course Q&A and General topics, and the
 subjects you expect students to explore there, are appropriate for a unified
 student audience. However, you also want to give students some course-wide
-topics that are divided by cohort. You decide that the Announcements and
-Brainstorming course-wide topics should be divided by cohort.
+topics that are divided by cohort group. You decide that the Announcements and
+Brainstorming course-wide topics should be divided by cohort group.
 
 You also decide to apply a naming convention so that students will know the
 audience for the discussion topics before they add any posts. For information on
@@ -111,7 +70,7 @@ Configure Course-Wide Discussion Topics as Divided
 
 This procedure describes how you configure the Brainstorming and Announcements
 course-wide discussion topics (from the example in :ref:`Identifying Private
-CourseWide Discussion Topics`) so that they are divided by cohort.
+CourseWide Discussion Topics`) so that they are divided by cohort group.
 
 On the Studio **Advanced Settings** page, details of the two topics appear as
 follows in the **Discussion Topic Mapping** field. 
@@ -181,14 +140,15 @@ Content-Specific Discussion Topics and Cohort Groups
 When you enable the cohort feature for a course, and :ref:`create content-
 specific discussion topics<Create ContentSpecific Discussion Topics>` by adding
 discussion components to units in Studio, these content-specific discussion
-topics are divided by cohort by default. A student who is assigned to one cohort
-group cannot read or add to the posts, responses, or comments contributed by the
-members of another cohort group.
+topics are divided by cohort group by default. A student who is assigned to one
+cohort group cannot read or add to the posts, responses, or comments contributed
+by the members of another cohort group.
 
 If you want all content-specific discussion topics in your course to remain
 divided by cohort group, you do not need to take any further action. However, if
-you want one or more content-specific discussion topics to be accessible to all
-students regardless of cohort group, you must complete some configuration tasks.
+you want one or more content-specific discussion topics to be unified
+(accessible to all students regardless of cohort group), you must complete some
+configuration tasks.
 
 
 =====================================================================
@@ -251,7 +211,7 @@ Specify Exceptions to Unified Discussion Topics
 If you have made all content-specific discussion topics in your course unified
 by default, this procedure describes how you can specify exceptions and
 configure particular content-specific discussion topics in your course as
-divided by cohort.
+divided by cohort group.
 
 #. Open your course in Studio. 
    
@@ -270,16 +230,16 @@ divided by cohort.
 #. Between these opening and closing square brackets (``[ ]``) add one or more IDs
    for the discussion topics that you want to specify as being unified. 
 
-   If you are specifying only one discussion topic as divided by cohort, your
-   entry looks like this example.
+   If you are specifying only one discussion topic as divided by cohort group,
+   your entry looks like this example.
 
    .. code::
 
       "cohorted_discussions": [c2293fa2538a41eca7224b8a07c3d09d] 
 
 
-   If you are specifying multiple discussion topics as divided by cohort, use a
-   new line for each discussion topic ID that you add, and enclose each ID
+   If you are specifying multiple discussion topics as divided by cohort group,
+   use a new line for each discussion topic ID that you add, and enclose each ID
    within double quotation marks (``"``), followed by a comma if there are
    additional IDs following.
  

--- a/en_us/course_authors/source/cohorts/cohorts_setup_discussions.rst
+++ b/en_us/course_authors/source/cohorts/cohorts_setup_discussions.rst
@@ -1,9 +1,11 @@
+
 .. _Set up Discussions in Cohorted Courses:
 
 
-##########################################################
+######################################################
 Setting up Discussions in Courses with Student Cohorts
-##########################################################
+######################################################
+
 
 In courses that have cohorts enabled, you can set up discussion topics to be
 either divided by cohort, or unified and accessible to all students.
@@ -15,12 +17,50 @@ unified, but content-specific discussion topics are divided by cohort. You can
 configure either type of discussion to be divided or unified.
 
 For overview information about discussions in a course, see :ref:`Discussions`.
-For information about setting up cohorts in a course, see :ref:`Enabling and
-Configuring Cohorts`.
+For information about using cohort groups in a course, see :ref:`Cohorts
+Overview` and :ref:`Enabling and Configuring Cohorts`.
 
-For overview information about discussions in a course, see :ref:`Discussions`.
-For information about setting up cohorts in a course, see :ref:`Enabling and
-Configuring Cohorts`.
+
+**************************************************
+Course-Wide Discussion Topics Are Configurable
+**************************************************
+
+To create course-wide discussion topics, you add them on the **Advanced
+Settings** page in Studio. By default, each of these topics is unified. All of
+the students in the course can post, read, respond, and comment in course-wide
+discussion topics without regard to their cohort group assignments. After you
+add a course-wide topic, you can configure it so that it is divided by cohort
+instead.
+
+For example, in addition to the General topic, which is supplied by default,
+you create these additional course-wide topics: Course Q&A, Announcements, and
+Brainstorming. You want all students to be able to read and contribute to all
+of the posts in the General and Course Q&A topics. However, you want the
+Announcements and Brainstorming topics to be divided, so that students will
+only be able to read and respond to contributions by the members of their own
+cohorts. You complete the additional configuration step for the Announcements
+and Brainstorming topics only.
+
+For information about course-wide discussion topics, see
+:ref:`Organizing_discussions`. For information about configuring these topics, 
+see :ref:`Configure CourseWide Discussion Topics as Private`.
+
+
+**************************************************
+All Content-Specific Discussion Topics Are Divided
+**************************************************
+
+Each of the content-specific discussion topics is divided by cohort. A student
+who is assigned to one cohort group cannot read or add to the posts, responses,
+or comments contributed by the members of another cohort group.
+
+To create content-specific discussion topics in a course, you add units that
+include discussion components. In a course with the cohort feature enabled, you
+do not have the option to change these topics to be unified for all students.
+
+For more information about content-specific discussion topics,
+see :ref:`Organizing_discussions`.
+
 
 
 ******************************************
@@ -66,7 +106,7 @@ how to achieve this, see :ref:`Apply Naming Conventions to Discussion Topics`.
 .. _Configure CourseWide Discussion Topics as Private:
 
 ======================================================
-Define Divided Course-Wide Discussion Topics
+Configure Course-Wide Discussion Topics as Divided
 ======================================================
 
 This procedure describes how you configure the Brainstorming and Announcements

--- a/en_us/course_authors/source/content_experiments/content_experiments_configure.rst
+++ b/en_us/course_authors/source/content_experiments/content_experiments_configure.rst
@@ -93,8 +93,8 @@ Experiment group assignments are:
 * Evenly distributed
   
   The edX Platform keeps track of the size of experiment groups, and assigns new
-  students to groups evenly. For example, if there are two experiment groups in
-  a configuration, each group includes 50% of the students in the course; if you
+  students to groups evenly. For example, if you have two experiment groups in a
+  configuration, each group includes 50% of the students in the course; if you
   have four experiment groups, each group includes 25% of the students.
 
 * Permanent
@@ -147,7 +147,7 @@ content experiments. Students do not see the group configuration name.
    least one group.
 
   * Modify group names as needed. You see group names in the unit page in
-    Studio; students do not see group names.       
+    Studio, but group names are not visible to students.       
   * Click **Add another group** to include another group as part of
     the configuration. 
   * Click the **X** to the right of an existing group to remove it from the
@@ -236,17 +236,17 @@ View a Group Configuration from an Experiment
 ===============================================
 
 When working with a content experiment, you can view details about the group
-configuration used by that experiment.
+configuration used by that experiment in two ways:
 
-In a unit that contains a content experiment, in the content experiment block,
-click the name of the group configuration.
+* In a unit that contains a content experiment, in the content experiment block,
+  click the name of the group configuration.
 
 .. image:: ../Images/content_experiment_group_config_link.png
  :alt: Content experiment in the unit page with the group configuration link
      circled
 
-Or, at the top of the content experiment page, click the name of the group
-configuration.
+* At the top of the content experiment page, click the name of the group
+  configuration.
 
 .. image:: ../Images/content_experiment_page_group_config_link.png
  :alt: Content experiment page with the group configuration link circled

--- a/en_us/course_authors/source/content_experiments/content_experiments_configure.rst
+++ b/en_us/course_authors/source/content_experiments/content_experiments_configure.rst
@@ -170,11 +170,10 @@ in use in the course:
 Edit a Group Configuration
 =============================
 
-.. important:: 
-  You can change the name of a group configuration at any time. However, before
-  you modify any other characteristics of a group that is inside a group
-  configuration currently being used in a running course, review `Guidelines
-  for Modifying Group Configurations`_.
+.. important:: You can change the name of a group configuration at any time.
+   However, before you modify any other characteristics of a group configuration
+   that is currently used in a running course, review `Guidelines for Modifying
+   Group Configurations`_.
 
 #. On the **Group Configurations** page, hover over the group configuration and
    click **Edit**.

--- a/en_us/course_authors/source/content_experiments/content_experiments_configure.rst
+++ b/en_us/course_authors/source/content_experiments/content_experiments_configure.rst
@@ -66,40 +66,42 @@ during your course. In one content experiment, students either see a video or
 complete a reading assignment. You can then include problems so that you can
 see which group learned the material more completely. For this content
 experiment, you need a group configuration that assigns your students to two
-groups.
+experiment groups.
 
 In the other content experiment, you can present the same question using four 
-different types of problem. For this content experiment, you need a
-group configuration that assigns your students to four groups.
+different types of problems. For this content experiment, you need a
+group configuration that assigns your students to four experiment groups.
 
-=============================
-Assigning Students to Groups
-=============================
+=======================================
+Assigning Students to Experiment Groups
+=======================================
 
-The edX Platform assigns students to each group in a group configuration. 
+The edX Platform assigns students to each experiment group in a group
+configuration.
 
-Group assignments are:
+Experiment group assignments are:
 
 * Dynamic
 
-  The edX Platform assigns a student to a group the first time he or she views
-  a content experiment that uses the group configuration.
+  The edX Platform assigns a student to an experiment group the first time he or
+  she views a content experiment that uses the group configuration.
 
 * Random
   
-  You cannot control which students are assigned to which group. 
+  You cannot control which students are assigned to which experiment group. 
   
 * Evenly distributed
   
-  The edX Platform keeps track of the size of groups and assigns new students
-  to groups evenly. For example, when there are two groups in a configuration,
-  each group will include 50% of the students in the course; when you have four
-  groups, each group will include 25%.
+  The edX Platform keeps track of the size of experiment groups, and assigns new
+  students to groups evenly. For example, if there are two experiment groups in
+  a configuration, each group includes 50% of the students in the course; if you
+  have four experiment groups, each group includes 25% of the students.
 
 * Permanent
   
-  Students remain in their assigned groups regardless of how many content
-  experiments you set up that use the same group configuration.
+  Students remain in their assigned experiment groups regardless of how many
+  content experiments you set up that use the same group configuration.
+
 
 .. _Set up Group Configurations in edX Studio:
 
@@ -112,11 +114,7 @@ Set up Group Configurations in edX Studio
   you can set up group configurations.
 
 To set up group configurations, on the **Settings** menu, select **Group
-Configurations**. The **Group Configurations** page opens:
-
-.. image:: ../Images/group_configurations.png
- :width: 800
- :alt: The Group Configurations page
+Configurations**. The **Group Configurations** page opens.
 
 From this page you can :ref:`create<Create a Group Configuration>`,
 :ref:`edit<Edit a Group Configuration>`, and :ref:`delete<Delete a Group
@@ -131,25 +129,27 @@ Create a Group Configuration
 
 You can create a group configuration at any time.
 
-#. On the **Group Configurations** page, click **Add Your First Group
-   Configuration**. The following page opens:
+#. On the **Group Configurations** page, under **Experiment Groups**, click
+   **New Experiment Group**. The following page opens:
 
   .. image:: ../Images/create-group-config.png
    :width: 800
    :alt: Create a New Group Configuration page
 
 2. Enter a name in the **Group Configuration Name** field. Use a meaningful
-   name, as you select from group configuration names when creating content
-   experiments. Students will not see the name.
+name, because you will select from group configuration names when you create
+content experiments. Students do not see the group configuration name.
 
 #. Optionally, enter a description for the new group configuration.
+   
 #. By default, a new configuration already contains two groups. Modify the
-   names of those groups or add new groups as needed:
+   groups or add and delete groups as needed. A group configuration must have at
+   least one group.
 
-  * Modify the group names as needed. You see group names in the unit page in
-    Studio; students do not see group names.
-  * Click **Add another group** to include another group as part of the
-    configuration.
+  * Modify group names as needed. You see group names in the unit page in
+    Studio; students do not see group names.       
+  * Click **Add another group** to include another group as part of
+    the configuration. 
   * Click the **X** to the right of an existing group to remove it from the
     configuration. A group configuration must have at least one group.
 
@@ -162,6 +162,7 @@ in use in the course:
 .. image:: ../Images/group_configurations_one_listed.png
  :width: 800
  :alt: The Group Configurations page with one group configuration
+
   
 .. _Edit a Group Configuration:
 
@@ -172,7 +173,7 @@ Edit a Group Configuration
 .. important:: 
   You can change the name of a group configuration at any time. However, before
   you modify any other characteristics of a group that is inside a group
-  configuration that is currently used in a running course, review `Guidelines
+  configuration currently being used in a running course, review `Guidelines
   for Modifying Group Configurations`_.
 
 #. On the **Group Configurations** page, hover over the group configuration and
@@ -212,23 +213,23 @@ Delete a Group Configuration
 
 2. When prompted to confirm the deletion, click **Delete**.
 
+
 .. _View Experiments that Use a Group Configuration:
 
 ===============================================
 View Experiments that Use a Group Configuration
 ===============================================
 
-When working with group configurations, you can view the experiments that use
-each configuration.
+You can view the experiments that use each of your group configurations.
 
-On the **Group Configurations** page, click the name of a group to expand the
-group and see its details. You see links to experiments that use the group
-configuration:
+On the **Group Configurations** page, click the name of a group to see its
+details. You see links to experiments that use the group configuration:
 
 .. image:: ../Images/group_configurations_experiments.png
  :alt: A group configuration with the experiments using it circled
 
 Click a link to go to the unit page that contains the experiment.
+
 
 ===============================================
 View a Group Configuration from an Experiment
@@ -237,14 +238,14 @@ View a Group Configuration from an Experiment
 When working with a content experiment, you can view details about the group
 configuration used by that experiment.
 
-On the unit page for a unit that contains a content experiment, click the name
-of the group configuration.
+In a unit that contains a content experiment, in the content experiment block,
+click the name of the group configuration.
 
 .. image:: ../Images/content_experiment_group_config_link.png
  :alt: Content experiment in the unit page with the group configuration link
      circled
 
-Or at the top of the content experiment page, click the name of the group
+Or, at the top of the content experiment page, click the name of the group
 configuration.
 
 .. image:: ../Images/content_experiment_page_group_config_link.png

--- a/en_us/shared/subsections/content_experiments/content_experiments_group_modify_guidelines.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_group_modify_guidelines.rst
@@ -32,11 +32,11 @@ You can change experiment group names at any time.
 Removing Experiment Groups from Group Configurations
 ==========================================================
 
-After a course in which you are running a content experiment has started, you
-may find that students in a specific experiment group are having difficulties or
-a poor experience. In this situation, you can remove the experiment group from
-the group configuration. Content that was specified for that experiment group is
-then no longer visible to students.
+After a course in which you are running a content experiment has started,
+students in a specific experiment group might have difficulties with the content
+or with the course experience. In this situation, you can remove the experiment
+group from the group configuration. Content that was specified for that
+experiment group is then no longer visible to students.
 
 Students in the removed experiment group are reassigned evenly to one of the
 other experiment groups in the group configuration. Any problems that these

--- a/en_us/shared/subsections/content_experiments/content_experiments_group_modify_guidelines.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_group_modify_guidelines.rst
@@ -19,29 +19,31 @@ After the course starts, **do not**:
 
 * Change the ``id`` value of a group configuration.
 
-=================
-Modifying Groups
-=================
+============================
+Modifying Experiment Groups
+============================
 
-After the course starts, **do not** change the ``id`` value of a group.
+After the course starts, **do not** change the ``id`` value of an experiment
+group.
   
-You can change group names at any time.
+You can change experiment group names at any time.
 
 ==========================================================
-Removing Groups from Group Configurations
+Removing Experiment Groups from Group Configurations
 ==========================================================
 
-After a course has started, you may find that students in a specific group are
-having difficulties or a poor experience. In this situation, you can remove the
-group from the group configuration. Content that was specified for that
-group is then no longer visible to students.
+After a course in which you are running a content experiment has started, you
+may find that students in a specific experiment group are having difficulties or
+a poor experience. In this situation, you can remove the experiment group from
+the group configuration. Content that was specified for that experiment group is
+then no longer visible to students.
 
-Students in the removed group are reassigned evenly to one of the other groups
-in the group configuration. Any problems that these students completed in the
-removed group content do not count toward the students' grades. The students
-must begin the problem set again and complete all the problems in the group
-content to which they've been reassigned.
+Students in the removed experiment group are reassigned evenly to one of the
+other experiment groups in the group configuration. Any problems that these
+students completed in the removed experiment group content do not count toward
+their grades. The students must begin the problem set again and complete all the
+problems in the experiment group content to which they are reassigned.
 
-Removing a group affects the course event data. Ensure that researchers
-evaluating your course results are aware of the group you removed and the
-date you removed it.
+Removing an experiment group affects event data for the course. Ensure that
+researchers who are evaluating your course results are aware of the experiment
+group that you removed and the date on which you removed it.

--- a/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
@@ -4,10 +4,8 @@
 Overview of Content Experiments
 #################################
 
-You use content experiments to show different course content to different
-groups of students.
-
-Also known as A/B or split tests, content experiments enable you to
+You use content experiments to show different course content to different groups
+of students. Also known as A/B or split tests, content experiments enable you to
 research and compare the performance of students in different groups to gain
 insight into the relative effectiveness of your course content.
 
@@ -35,7 +33,7 @@ experiment to be independent and use a different grouping.
 .. important::
 
   If your course has multiple experiments, it is critical that you decide
-  up front if the experiments share the same groups of students or if each
+  in advance if the experiments share the same groups of students or if each
   experiment has its own unique grouping. If two experiments share the same
   grouping, then any student that is in Group A for the first experiment will
   also be in Group A for the second one. If you want the experiments to be

--- a/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
@@ -5,9 +5,9 @@ Overview of Content Experiments
 #################################
 
 You use content experiments to show different course content to different groups
-of students. Also known as A/B or split tests, content experiments enable you to
-research and compare the performance of students in different groups to gain
-insight into the relative effectiveness of your course content.
+of students. Also known as "A/B tests" or "split tests", content experiments
+enable you to research and compare the performance of students in different
+groups to gain insight into the relative effectiveness of your course content.
 
 Information on analyzing events from content experiments is included in the
 `edX Researcher Guide`_.
@@ -41,9 +41,9 @@ experiment to be independent and use a different grouping.
   students are randomly assigned for each experiment.
 
 To determine the available groupings of students, you :ref:`set up group
-configurations in Studio <Set up Group Configurations in edX Studio>` or
-:ref:`in XML <Set Up Group Configuration for OLX Courses>`.
+configurations using Studio <Set up Group Configurations in edX Studio>` or
+:ref:`using XML <Set Up Group Configuration for OLX Courses>`.
 
 You then select which group configuration to use when you :ref:`add a content
-experiment in Studio <Add a Content Experiment in Studio>` or :ref:`in XML <Add
-a Content Experiment in OLX>`.
+experiment using Studio <Add a Content Experiment in Studio>` or :ref:`using XML
+<Add a Content Experiment in OLX>`.

--- a/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
@@ -44,5 +44,6 @@ To determine the available groupings of students, you :ref:`set up group
 configurations in Studio <Set up Group Configurations in edX Studio>` or
 :ref:`in XML <Set Up Group Configuration for OLX Courses>`.
 
-You then select which grouping to use when you :ref:`add a content experiment
-in Studio <Add a Content Experiment in Studio>` or :ref:`in XML <Add a Content Experiment in OLX>`.
+You then select which group configuration to use when you :ref:`add a content
+experiment in Studio <Add a Content Experiment in Studio>` or :ref:`in XML <Add
+a Content Experiment in OLX>`.

--- a/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_overview.rst
@@ -40,10 +40,10 @@ experiment to be independent and use a different grouping.
   independent, then the experiments must use different groupings so that
   students are randomly assigned for each experiment.
 
-To determine the available groupings of students, you :ref:`set up group
-configurations using Studio <Set up Group Configurations in edX Studio>` or
-:ref:`using XML <Set Up Group Configuration for OLX Courses>`.
+To determine the available groupings of students, you set up group
+configurations :ref:`using Studio <Set up Group Configurations in edX Studio>`
+or :ref:`using XML <Set Up Group Configuration for OLX Courses>`.
 
-You then select which group configuration to use when you :ref:`add a content
-experiment using Studio <Add a Content Experiment in Studio>` or :ref:`using XML
-<Add a Content Experiment in OLX>`.
+You then select which group configuration to use when you add a content
+experiment :ref:`using Studio <Add a Content Experiment in Studio>` or
+:ref:`using XML <Add a Content Experiment in OLX>`.

--- a/en_us/shared/subsections/content_experiments/content_experiments_policies.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_policies.rst
@@ -17,7 +17,7 @@ To specify group configurations, you modify the value for the
   configurations.
 
 The value for ``user_partitions`` is a JSON collection of group configurations,
-each of which defines the groups of students. 
+each of which defines the experiment groups of students.
 
 .. note:: 
   Use names for group configurations that are meaningful. You select from the
@@ -29,8 +29,8 @@ See the following examples for more information.
 Example: One Group Configuration
 =============================================
 
-The following is an example JSON object that defines an group configuration
-with two student segments.
+The following code shows an example JSON object that defines a group
+configuration with two student segments.
 
 .. code-block:: json
 
@@ -52,17 +52,17 @@ In this example:
 * The ``"id": 0`` identifies the group configuration. For XML courses, the
   value is referenced in the ``user_partition`` attribute of the
   ``<split_test>`` element in the content experiment file.
-* The ``groups`` array identifies the groups to which students are randomly
-  assigned. For XML courses, each group ``id`` value is referenced in the
-  ``group_id_to_child`` attribute of the ``<split_test>`` element.
+* The ``groups`` array identifies the experiment groups to which students are
+  randomly assigned. For XML courses, each group ``id`` value is referenced in
+  the ``group_id_to_child`` attribute of the ``<split_test>`` element.
 
 ==========================================================
 Example: Multiple Group Configurations
 ==========================================================
 
-The following is an example JSON object that defines two group configurations.
-The first group configuration divides students into two groups, and the second
-divides students into three groups.
+The following code shows an example JSON object that defines two group
+configurations. The first group configuration divides students into two
+experiment groups, and the second divides students into three experiment groups.
 
 .. code-block:: json
 

--- a/en_us/shared/subsections/content_experiments/content_experiments_test.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_test.rst
@@ -5,11 +5,11 @@ Test Content Experiments
 ##########################################
 
 You should test content experiments in your course before the course starts, to
-ensure that content is delivered to groups as you intended.
+ensure that content is delivered to experiment groups as you intended.
 
 When you view a unit containing a content experiment in the LMS in the Staff
-view, you can select one of the groups from a drop-down list. The unit page then
-shows the content as the selected group of students sees it.
+view, you can select one of the experiment groups from a drop-down list. The
+unit page then shows the content as the selected group of students sees it.
 
 For example, in the following page, Group 0 is selected, and the HTML component
 and video that is part of Group 0 is displayed:
@@ -17,8 +17,8 @@ and video that is part of Group 0 is displayed:
 .. image:: ../Images/a-b-test-lms-group-0.png
  :alt: Image of a unit page with Group 0 selected
 
-You can change the group selection to view the content that a different group of
-students sees:
+You can change the experiment group selection to view the content that a
+different experiment group of students sees:
 
 .. image:: ../Images/a-b-test-lms-group-2.png
  :alt: Image of a unit page with Group 1 selected

--- a/en_us/shared/subsections/content_experiments/content_experiments_test.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_test.rst
@@ -4,12 +4,12 @@
 Test Content Experiments
 ##########################################
 
-You should test content experiments in your course before the course starts to
+You should test content experiments in your course before the course starts, to
 ensure that content is delivered to groups as you intended.
 
-When you view a unit that contains a content experiment in the LMS in the Staff
-view, you select one of the groups from a drop-down list. The unit page then shows the
-content for that group of students.
+When you view a unit containing a content experiment in the LMS in the Staff
+view, you can select one of the groups from a drop-down list. The unit page then
+shows the content as the selected group of students sees it.
 
 For example, in the following page, Group 0 is selected, and the HTML component
 and video that is part of Group 0 is displayed:
@@ -17,7 +17,7 @@ and video that is part of Group 0 is displayed:
 .. image:: ../Images/a-b-test-lms-group-0.png
  :alt: Image of a unit page with Group 0 selected
 
-You can change the group selection to view the problem that a different group of
+You can change the group selection to view the content that a different group of
 students sees:
 
 .. image:: ../Images/a-b-test-lms-group-2.png

--- a/en_us/shared/subsections/content_experiments/content_experiments_test.rst
+++ b/en_us/shared/subsections/content_experiments/content_experiments_test.rst
@@ -7,24 +7,23 @@ Test Content Experiments
 You should test content experiments in your course before the course starts, to
 ensure that content is delivered to experiment groups as you intended.
 
-When you view a unit containing a content experiment in the LMS in the Staff
-view, you can select one of the experiment groups from a drop-down list. The
-unit page then shows the content as the selected group of students sees it.
+When you view a unit that contains a content experiment in the LMS Staff view,
+you can select one of the experiment groups from a drop-down list. The unit page
+then shows the content as the selected group of students sees it.
 
 For example, in the following page, Group 0 is selected, and the HTML component
-and video that is part of Group 0 is displayed:
+and video that is part of Group 0 is displayed.
 
 .. image:: ../Images/a-b-test-lms-group-0.png
  :alt: Image of a unit page with Group 0 selected
 
 You can change the experiment group selection to view the content that a
-different experiment group of students sees:
+different experiment group of students sees.
 
 .. image:: ../Images/a-b-test-lms-group-2.png
  :alt: Image of a unit page with Group 1 selected
 
-.. note:: 
-  The example course content in this chapter uses content experiment
-  terminology to make the functionality clear. Typically, you would not use
-  terminology in course content that would make students aware of the
-  experiment.
+.. note::    The example course content in this chapter uses content experiment
+terminology to make the functionality clear. Typically, you would not use
+terminology in course content that would make students aware of the
+experiment.


### PR DESCRIPTION
Preparation for cohorted courseware doc: separate out the conceptual and configuration content that applies to cohorted content groups vs content experiments; update terminology for the redesigned group configurations page ("experiment groups").
