### PR TITLE
Revisions to descriptions of cohort events

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -2733,15 +2733,22 @@ the child module that was shown to the student.
 Student Cohort Events
 ==========================
 
+For information about including student cohorts in a course, see `Including
+Student Cohorts`_ in the *Building and Running an edX Course* guide.
+
 ``edx.cohort.created``
 ----------------------------------
 
 When a cohort group is created, the server emits an ``edx.cohort.created``
-event. A member of the course staff can create a cohort group manually via the
-Instructor Dashboard (see :ref:`instructor_cohort_events`). The system
-automatically creates the default cohort group and cohort groups included in
-the course's ``auto_cohort_groups`` setting as they are needed (e.g. when a
-student is assigned to one).
+event. Cohort groups can be created manually by members of the course team.
+The system automatically creates the default cohort group and any cohort
+groups that are defined by the ``auto_cohort_groups`` advanced setting when
+they are needed (for example, when a student is assigned to one of those
+groups). 
+
+Additional events are emitted when members of the course team interact with
+the Instructor Dashboard to create a cohort group. See
+:ref:`instructor_cohort_events`.
 
 **Event Source**: Server
 
@@ -2767,12 +2774,16 @@ student is assigned to one).
 ----------------------------------
 
 When a user is added to a cohort group, the server emits an
-``edx.cohort.user_added`` event. A member of the course staff can add a user to
-a cohort group manually via the Instructor Dashboard (see
-:ref:`instructor_cohort_events`). The system automatically adds a user to the 
-default cohort group or a cohort group included in the course's 
-``auto_cohort_groups`` setting if the user accesses a discussion but has not 
-yet been assigned to a cohort group.
+``edx.cohort.user_added`` event. Members of the course team can add users to
+cohort groups individually or by uploading a CSV file of student cohort group
+assignments. The system automatically adds a user to the default cohort group
+or a cohort group included in the course's ``auto_cohort_groups`` setting if
+the user accesses course content that is divided by cohort but has not yet
+been assigned to a cohort group.
+
+Additional events are emitted when members of the course team interact with
+the Instructor Dashboard to add a user to a group. See
+:ref:`instructor_cohort_events`.
 
 **Event Source**: Server
 
@@ -2795,14 +2806,14 @@ yet been assigned to a cohort group.
      - The display name of the cohort group.
    * - ``user_id``
      - integer
-     - The numeric ID (from auth_user.id) of the added user.
+     - The numeric ID (from ``auth_user.id``) of the added user.
 
 ``edx.cohort.user_removed``
 ----------------------------------
 
-When a user is removed from a cohort group (by being assigned to a different
-cohort group via the Instructor Dashboard), the server emits an
-``edx.cohort.user_removed`` event.
+When a course team member changes the cohort group assignment of a user on
+the Instructor Dashboard, the server emits an ``edx.cohort.user_removed``
+event.
 
 **Event Source**: Server
 
@@ -2825,7 +2836,7 @@ cohort group via the Instructor Dashboard), the server emits an
      - The display name of the cohort group.
    * - ``user_id``
      - integer
-     - The numeric ID (from auth_user.id) of the removed user.
+     - The numeric ID (from ``auth_user.id``) of the removed user.
 
 .. _ora:
 
@@ -3267,15 +3278,17 @@ For details about the enrollment events, see :ref:`enrollment`.
 Instructor Cohort Events
 =============================
 
-In addition to the cohort events that are generated when students are assigned
-to cohort groups (which can happen automatically or manually via the Instructor
-Dashboard; see :ref:`student_cohort_events`), actions by instructors and course
-staff members generate additional events.
+In addition to the cohort events that are generated when cohorts are created
+and users are assigned to them (see :ref:`student_cohort_events`), actions by
+instructors and course staff members also generate cohort-related events.
+
+For more information about student cohorts, see `Including Student Cohorts`_
+in the *Building and Running an edX Course* guide.
 
 ``edx.cohort.creation_requested``
 ----------------------------------
 
-When an instructor or course staff member manually creates a cohort group via
+When an instructor or course staff member manually creates a cohort group on
 the Instructor Dashboard, the server emits an ``edx.cohort.creation_requested``
 event.
 
@@ -3302,9 +3315,11 @@ event.
 ``edx.cohort.user_add_requested``
 ----------------------------------
 
-When an instructor or course staff member adds a student to a cohort group via
-the Instructor Dashboard, the server emits an ``edx.cohort.user_add_requested``
-event.
+When an instructor or course staff member adds a student to a cohort group on
+the Instructor Dashboard, the server emits an
+``edx.cohort.user_add_requested`` event. Course team members can add students
+to a cohort group individually, or by uploading a CSV file of student cohort
+group assignments.
 
 **Event Source**: Server
 
@@ -3328,17 +3343,25 @@ event.
    * - ``previous_cohort_id``
      - integer
      - The numeric ID of the cohort group that the user was previously assigned
-       to (or null if the user was not previously assigned to a cohort group).
+       to.
+
+       Null if the user was not previously assigned to a cohort group.
+
    * - ``previous_cohort_name``
      - string
      - The display name of the cohort group that the user was previously
-       assigned to (or null if the user was not previously assigned to a cohort
-       group).
+       assigned to.
+
+       Null if the user was not previously assigned to a cohort
+       group.
+
    * - ``user_id``
      - integer
-     - The numeric ID (from auth_user.id) of the added user.
+     - The numeric ID (from ``auth_user.id``) of the added user.
 
 
 .. _Creating a Peer Assessment: http://edx.readthedocs.org/projects/edx-open-response-assessments/en/latest/
 
 .. _Creating Content Experiments: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/content_experiments/index.html#creating-content-experiments
+
+.. _Including Student Cohorts: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/cohorts/index.html#including-student-cohorts


### PR DESCRIPTION
@catong these are the events that are emitted when things relating to cohorts happen. Basically, I wanted to get rid of "manually" in relation to course teams adding students to cohorts. But I took the opportunity to remove the Latin, inlcude xrefs to the B&R guide, and otherwise polish up these descriptions. No rush.
@stroilova, FYI
