### PR TITLE
Remove requirements doc to make RTD work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ To run a test compilation of a contribution, first install the prerequisites:
 
 .. code::
   
-  pip install -r requirements.txt
+  pip install -r shared/travis-requirements.txt
 
 Then run the tests:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-shared/travis_requirements.txt


### PR DESCRIPTION
@mulby   I don't fully understand why; having the top level requirements file is breaking RTD.  I'm removing for now, updated readme to point to travis requirements.

FY @lamagnifica @srpearce @catong 
