### PR TITLE
Documentation: Remove section on how to obtain anonymized ID (no longer required for getting student info in ORA)

### DIFF
--- a/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
+++ b/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
@@ -49,52 +49,24 @@ In the following example, you can see the student's response. The response recei
    :width: 500
    :alt: Report showing information about a student's response
 
-For an example that shows a student's response with more assessments, see :ref:`Access Student Information`.
+For details about accessing information for a specific student, and for an
+example that shows a student's response with more assessments, see :ref:`Access
+Student Information`.
 
-Accessing information about a specific student has two steps:
-
-#. Determine the student's course-specific anonymized ID.
-#. Access information for that student.
-
-=====================================================
-Determine the Student's Course-Specific Anonymized ID
-=====================================================
-
-To determine a student's course-specific anonymized ID, you'll need two .csv spreadsheets from the Instructor Dashboard: the grade report (**<course name>_grade_report_<datetime>.csv**) and the list of course-specific anonymized student IDs (**<course name>-anon-ids.csv**).
-
-#. In the LMS, click the **Instructor** tab.
-#. On the Instructor Dashboard, click **Data Download**.
-#. On the **Data Download** page, locate the **Data Download** section, and then click **Get Student Anonymized IDs CSV**. A spreadsheet named **<course name>-anon-ids.csv** automatically downloads. Click to open the spreadsheet.
-#. Scroll down to the **Reports** section, and then click **Generate Grade Report**. 
-
-   The system automatically begins to generate the grade report. When it's finished, a link to the grade report appears in the list below **Reports Available for Download**.
-
-   .. note:: Generating a grade report for a large class may take several hours.
-
-5. When the link to the grade report appears in the **Reports Available for Download** list, click the link to open the spreadsheet.
-#. When you have both spreadsheets open, view the **<course name>_grade_report_<datetime>.csv** spreadsheet. Locate the student that you want by username or e-mail address. Make a note of the number in the ID column (column A) for that student. In the following example, the student ID for e-mail address ``amydorrit@example.com`` (username ``lildorrit``) is ``18557``.
-
-   .. image:: ../../../../shared/building_and_running_chapters/Images/PA_grade_report.png
-      :width: 500
-      :alt: Spreadsheet listing enrolled students and grades
-
-7. Go to the **<course name>-anon-ids.csv** spreadsheet, locate the user ID that you noted in step 6, and then copy the value in the "Course Specific Anonymized user ID" column (**column C**) for the user. The value in column C is the student's anonymized user ID for the course. In the following example, the anonymized user ID for student ID ``18557`` is ``ofouw6265242gedud8w82g16qshsid87``.
-
-   .. image:: ../../../../shared/building_and_running_chapters/Images/PA_anon_ids.png
-      :width: 500
-      :alt: Spreadsheet listing students' anonymous user IDs
-
-   .. note:: Make sure that you don't copy the value in column B. You need the *course-specific* anonymized user ID from **column C**.
 
 .. _Access Student Information:
 
 =======================================
-Access the Student's Information
+Access a Specific Student's Information
 =======================================
 
 #. In the LMS, go to the peer assessment assignment that you want to see.
-#. Scroll to the bottom of the problem, and then click the black **Course Staff Information** banner.
-#. Scroll down to the **Get Student Info** box, paste the student's course-specific anonymized user ID in the box, and then click **Submit**.
+   
+#. Scroll to the bottom of the problem, and click the black **Course Staff
+   Information** banner.
+   
+#. In the **Get Student Info** box, enter the student's username, and click
+   **Submit**.
 
 The student's information appears below the **Get Student Info** box.
 


### PR DESCRIPTION
DOC-1641 -- documentation for TNL-836
This PR removes the mentions of and steps for obtaining the anonymized student ID and replaces it with "enter the student's username".
@explorerleslie @muzaffaryousaf @symbolist can you please review for technical accuracy and workflow?
@mhoeber @srpearce @lamagnifica can any one of you please do an editorial pass?
Thanks!
