### PR TITLE
Document ability to view usage of a content group, and delete content groups

### DIFF
--- a/en_us/shared/building_and_running_chapters/cohorts/cohorted_courseware.rst
+++ b/en_us/shared/building_and_running_chapters/cohorts/cohorted_courseware.rst
@@ -117,6 +117,8 @@ For an example of using content groups to create cohort-specific courseware, see
 Create Content Groups
 *********************
 
+To create a content group, follow these steps.
+
 #. In Studio, select **Settings**, then select **Group Configurations**.
  
 #. On the **Group Configurations** page, click **New content group**.
@@ -137,10 +139,56 @@ Groups`.
 On the Instructor Dashboard, you associate each content group with one or more
 cohorts. For details, see :ref:`Associate Cohorts with Content Groups`.
 
-.. note:: Once a content group is created, you cannot delete it. You can remove
-   the association between a content group and its cohorts by changing the
-   association to **Not Selected**.
 
+.. _View Usage of a Content Group:
+
+*************************************
+View Usage of a Content Group
+*************************************
+
+To view the units that are visible to a content group, follow these steps.
+
+#. In Studio, select **Settings**, then select **Group Configurations**.
+ 
+#. On the **Group Configurations** page, locate the content group for which you
+   want to view the usage.
+   
+   The content group's box displays whether the content group is used in this
+   course. If it is used, you see the number of units that it is used in, and
+   links to each unit.
+
+#. Click each link to go to that unit in the **Course Outline**, where you can
+   :ref:`specify whether that unit is visible to the content group<Specify
+   Components in Courseware as Visible Only to Certain Content Groups>`.
+
+For details about previewing your course to ensure that students in a cohort
+correctly see the content intended for them, see :ref:`Preview Cohort Specific
+Courseware`. For details about deleting content groups, see :ref:`Delete Content
+Groups`.
+
+
+.. _Delete Content Groups:
+
+*********************
+Delete Content Groups
+*********************
+
+.. note:: You can delete a content group only if it is not in use in any course
+   unit. To delete a content group that is currently in use, you must first
+   remove it from any course unit visibility settings that use the content
+   group. For information about seeing which units use a content group, see
+   :ref:`View Usage of a Content Group`.
+
+#. In Studio, select **Settings**, then select **Group Configurations**.
+ 
+#. On the **Group Configurations** page, locate the content group that you want
+   to delete.  
+   
+#. Move your cursor over the content group's box, then click the **Delete**
+   icon.
+
+#. In the confirmation message, click **Delete** again to confirm the deletion.
+      
 
 .. _Specify Components in Courseware as Visible Only to Certain Content Groups:
 
@@ -305,3 +353,5 @@ selected content group would see it.
 After your course is live, you can also see the live version as a student would
 see it, by clicking **View Live** from Studio. For more information, see
 :ref:`View Your Live Course`.
+
+


### PR DESCRIPTION
TNL-1271 = DOC-1544
Added step for deleting a content group as well as view the usage for a content group. Still need to verify whether usage information includes actual links to units. 
@muzaffaryousaf @explorerleslie please review for technical accuracy/workflow
@srpearce @mhoeber @lamagnifica can any one of you do an editorial pass?
