### PR TITLE
Ahodges/forum events

### DIFF
--- a/en_us/data/source/internal_data_formats/change_log.rst
+++ b/en_us/data/source/internal_data_formats/change_log.rst
@@ -14,6 +14,9 @@ January-March 2015
 
    * - Date
      - Change
+   * - 4 Mar 2015
+     - Added new events for contributions to discussion forums to the
+       :ref:`Tracking Logs` chapter.
    * - 23 Feb 2015
      - Added new common fields for HTTP header values and new events for video
        caption use to the :ref:`Tracking Logs` chapter.

--- a/en_us/data/source/internal_data_formats/discussion_data.rst
+++ b/en_us/data/source/internal_data_formats/discussion_data.rst
@@ -31,7 +31,7 @@ of the attributes that these two types of objects share and that are specific
 to each type, follow.
 
 In addition to these collections, events are also emitted to track specific
-user activities. See :ref:`forum_events`.
+user activities. For more information, see :ref:`forum_events`.
 
 *********
 Samples

--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -62,7 +62,13 @@ Alphabetical Event List
      - :ref:`enrollment`
    * - ``edx.course.enrollment.upgrade.succeeded``
      - :ref:`enrollment`
+   * - ``edx.forum.comment.created``
+     - :ref:`forum_events`
+   * - ``edx.forum.response.created``
+     - :ref:`forum_events`
    * - ``edx.forum.searched``
+     - :ref:`forum_events`
+   * - ``edx.forum.thread.created``
      - :ref:`forum_events`
    * - ``edx.video.loaded``
      - :ref:`video`, see ``load_video``

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -279,7 +279,7 @@ that originate on mobile devices.
 **Details:** Identifies the type of event triggered.
 
 **History:** Server and mobile events added beginning on 07 May 2014 include a
-``name`` field. When this field is present for an event, it replaces the
+``name`` field. When this field is present for an event, it supersedes the
 ``event_type`` field.
 
 ===================
@@ -1607,7 +1607,7 @@ within 500ms of each other.
      - Type
      - Details
    * - ``caseSensitive``
-     - boolean
+     - Boolean
      - 'true' if the case sensitive option is selected. 
        
        'false' if this option is not selected.
@@ -1616,7 +1616,7 @@ within 500ms of each other.
      - string
      - The name of the PDF file. 
    * - ``highlightAll``
-     - boolean
+     - Boolean
      - 'true' if the option to highlight all matches is selected. 
        
        'false' if this option is not selected.
@@ -1659,7 +1659,7 @@ clicks on the Find Next or Find Previous icons for an entered search string.
      - Type
      - Details
    * - ``caseSensitive``
-     - boolean
+     - Boolean
      - 'true' if the case sensitive option is selected. 
        
        'false' if this option is not selected.
@@ -1668,13 +1668,13 @@ clicks on the Find Next or Find Previous icons for an entered search string.
      - string
      - The name of the PDF file. 
    * - ``findprevious``
-     - boolean
+     - Boolean
      - 'true' if the user clicks the Find Previous icon. 
        
        'false' if the user clicks the Find Next icon.
 
    * - ``highlightAll``
-     - boolean
+     - Boolean
      - 'true' if the option to highlight all matches is selected. 
        
        'false' if this option is not selected.
@@ -1717,7 +1717,7 @@ selects or clears the **Highlight All** option for a search.
      - Type
      - Details
    * - ``caseSensitive``
-     - boolean
+     - Boolean
      - 'true' if the case sensitive option is selected. 
        
        'false' if this option is not selected.
@@ -1726,7 +1726,7 @@ selects or clears the **Highlight All** option for a search.
      - string
      - The name of the PDF file. 
    * - ``highlightAll``
-     - boolean
+     - Boolean
      - 'true' if the option to highlight all matches is selected. 
        
        'false' if this option is not selected.
@@ -1769,7 +1769,7 @@ user selects or clears the **Match Case** option for a search.
      - Type
      - Details
    * - ``caseSensitive``
-     - boolean
+     - Boolean
      - 'true' if the case sensitive option is selected. 
        
        'false' if this option is not selected.
@@ -1778,7 +1778,7 @@ user selects or clears the **Match Case** option for a search.
      - string
      - The name of the PDF file. 
    * - ``highlightAll``
-     - boolean
+     - Boolean
      - 'true' if the option to highlight all matches is selected.
        
        'false' if this option is not selected.
@@ -2294,8 +2294,120 @@ for a problem and it is graded successfully.
 .. _forum_events:
 
 ==========================
-Forum Events
+Discussion Forums Events
 ==========================
+
+The server emits discussion forums events when a user interacts with a course
+discussion. This section presents the discussion forum events alphabetically.
+However, several of these events have hierarchical or sequential
+relationships.
+
+* When a user creates a new thread, such as a student asking a question, the
+  server emits an :ref:`forum_thread` event.
+
+* When a user responds to a thread, such as another student answering the
+  question, the server emits an :ref:`forum_response` event.
+
+* When a user adds a comment to a response, such as a staff member adding a
+  clarification to the student answer, the server emits an
+  :ref:`forum_comment` event.
+
+These events are included in the daily event logs in addition to the MongoDB
+discussion forums database data that is included in the weekly database data
+files. For information about the discussion forums database, see
+:ref:`Discussion Forums Data`.
+
+.. _forum_comment:
+
+``edx.forum.comment.created``
+*********************************
+
+Users create a comment about a response by entering text and then submitting
+the contributions. When these actions are complete, the server emits an
+``edx.forum.comment.created`` event.
+
+**Component**: Discussion
+
+**Event Source**: Server
+
+**History**: Added 4 Mar 2015.
+
+``event`` **Member Fields**:
+
+The ``edx.forum.comment.created`` events include many of the same ``event``
+member fields that are described for :ref:`forum_thread` and
+:ref:`forum_response` events. The following member fields serve the same
+purpose for comments as they do for threads or responses.
+
+* ``body``
+* ``commentable_id``
+* ``discussion``
+* ``id``
+* ``options``
+* ``truncated``
+* ``url``
+* ``user_course_roles``
+* ``user_forums_roles``
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``response``
+     - dictionary
+     - Contains a member ``id`` field with the unique identifier of the
+       response that the user added this comment to.
+
+.. _forum_response:
+
+``edx.forum.response.created``
+*********************************
+
+Users create a reply to a post by clicking **Add a Response** and then
+submitting their contributions. When these actions are complete, the server
+emits an ``edx.forum.response.created`` event.
+
+**Component**: Discussion
+
+**Event Source**: Server
+
+**History**: Added 4 Mar 2015. 
+
+``event`` **Member Fields**:
+
+The ``edx.forum.response.created`` events include many of the same ``event``
+member fields that are described for :ref:`forum_thread` events. The following
+member fields serve the same purpose for responses as they do for threads.
+
+* ``body``
+* ``commentable_id``
+* ``id``
+* ``options``
+* ``truncated``
+* ``url``
+* ``user_course_roles``
+* ``user_forums_roles``
+
+The following additional ``event`` member field applies specifically to
+``edx.forum.response.created`` events.
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``discussion``
+     - dictionary
+     - Contains a member ``id`` field with the unique identifier of the thread
+       that the user responded to.
+
+       Also present for ``edx.forum.comment.created`` events.
+
 
 ``edx.forum.searched``
 *********************************
@@ -2353,6 +2465,137 @@ Jun 2014. The ``group_id`` field was added 7 October 2014.
    * - ``total_results``
      - integer
      - The total number of results matching the query.
+
+.. _forum_thread:
+
+``edx.forum.thread.created``
+*********************************
+
+Users create a new top-level thread, also known as a post, by clicking **New
+Post** and then submitting their contributions. When these actions are
+complete, the server emits an ``edx.forum.thread.created`` event.
+
+**Component**: Discussion
+
+**Event Source**: Server
+
+**History**: Added 4 Mar 2015.
+
+``event`` **Member Fields**:
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``anonymous``
+     - Boolean
+     - Applies only to courses that allow discussion posts that are anonymous
+       to all other users.
+       
+       'true' only if the user selected the **post anonymously** check box.
+
+   * - ``anonymous_to_peers``
+     - Boolean
+     - Applies only to courses that allow discussion posts that are anonymous
+       to other students. The username of the thread creator is visible only
+       to users who have discussion management privileges.
+       
+       'true' only if the user selected the **post anonymously to classmates**
+       check box.
+
+   * - ``body``
+     - string
+     - The text supplied for the new post.
+       
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+
+   * - ``category_id``
+     - string
+     - Identifier for the specific discussion component or top-level,
+       course-wide discussion.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
+   * - ``category_name``
+     - string
+     - The display name for the specific discussion component or top-level,
+       course-wide discussion.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+
+   * - ``commentable_id``
+     - string
+     - Identifier for the specific discussion component or top-level,
+       course-wide discussion. Duplicates the ``category_id``.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
+   * - ``group_id``
+     - string
+     - The numeric ID of the cohort to which the contribution is restricted,
+       or ``null`` if the contribution is not restricted to a specific cohort.
+   * - ``id``
+     - string
+     - A unique identifier for this forum contribution.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
+   * - ``options``
+     - dictionary
+     - Contains the ``followed`` Boolean, which identifies whether the user
+       elected to track the responses that others make to this post.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
+   * - ``thread_type``
+     - string
+     - The person who creates the thread specifies either 'discussion' or
+       'question' to characterize the purpose of the post.
+   * - ``title``
+     - string
+     - The brief descriptive text supplied to identify the post.
+   * - ``truncated``
+     - Boolean
+     - 'true' only if the post was longer than 2000 characters, which is the
+       maximum included in the event.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
+   * - ``url``
+     - string
+     - The escaped URL of the page the user was visiting when this event was
+       emitted.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
+   * - ``user_course_roles``
+     - array
+     - Identifies the course-level 'Instructor' or 'Staff' privilege assigned
+       to the user. No value is reported for students.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
+   * - ``user_forums_roles``
+     - array
+     - Identifies a user who does not have discussion management privileges as
+       a 'Student'. Identifies users who have discussion management privileges
+       as a course 'Community TA', 'Moderator', or 'Administrator'.
+
+       Also present for ``edx.forum.response.created`` and
+       ``edx.forum.comment.created`` events.
+       
 
 .. _ora2:
 


### PR DESCRIPTION
@kelketek, @mulby, @stroilova Please review for accuracy and completeness. If you can provide details, I am not sure about:
- where the maximum length is set that determines truncation, or what that maximum is
- whether the options dictionary can contain any members besides the followed Boolean
- if I have interpreted user_course_role correctly, that it is null unless the user has Instructor or Staff privileges
- whether we are using the group_id field for cohort identification or if that is a “reserved for future use” field

@mhoeber , @catong , @srpearce , @WatsonEmily 
