### PR TITLE
Fixes DOC-1400, moderation prigs not part of course team privs

### DIFF
--- a/en_us/shared/building_and_running_chapters/building_course/creating_new_course.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/creating_new_course.rst
@@ -158,11 +158,12 @@ To add a course team member:
 #. Click **Add a New Team Member**.
 #. Enter the new team member's email address, then click **ADD USER**. 
 
-The new team member can now work on the course in Studio. To preview the
-course in the LMS or work on the Instructor Dashboard, the team member must
-enroll in the course. For the team member to also moderate the course
-discussions, you must separately assign one of the discussion roles to her.
-For more information, see :ref:`Assigning_discussion_roles`.
+The new team member can now work on the course in Studio. 
+
+* To preview the course in the LMS, the team member must enroll in the course.
+* To moderate course discussions, the team member must also have one of the
+  discussion roles. For more information, see
+  :ref:`Assigning_discussion_roles`.
 
 You can also assign privileged roles to users when you work in the LMS.
 

--- a/en_us/shared/building_and_running_chapters/building_course/creating_new_course.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/creating_new_course.rst
@@ -158,9 +158,11 @@ To add a course team member:
 #. Click **Add a New Team Member**.
 #. Enter the new team member's email address, then click **ADD USER**. 
 
-The new team member can now work on the course in Studio. To preview
-the course in the LMS or work on the Instructor Dashboard, the team member
-must enroll in the course.
+The new team member can now work on the course in Studio. To preview the
+course in the LMS or work on the Instructor Dashboard, the team member must
+enroll in the course. For the team member to also moderate the course
+discussions, you must separately assign one of the discussion roles to her.
+For more information, see :ref:`Assigning_discussion_roles`.
 
 You can also assign privileged roles to users when you work in the LMS.
 

--- a/en_us/shared/building_and_running_chapters/running_course/course_staffing.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/course_staffing.rst
@@ -60,9 +60,9 @@ as the course staff. They can also:
 * Add and remove Discussion Admins, Discussion Moderators, and Discussion
   Community TAs.
 
-.. note:: For a team member to be able to moderate the course discussions, 
- you must separately assign one of the discussion roles to her. For more
- information, see :ref:`Assigning_discussion_roles`.
+.. note:: To moderate course discussions, the team member must also have one 
+ of the discussion roles. For more information, see
+ :ref:`Assigning_discussion_roles`.
 
 .. 12 Feb 14 Sarina: This all sounds right but there are other tasks (rescoring, etc) not mentioned. Probably worth nailing down what tasks can and cannot be done by a course staff.
 

--- a/en_us/shared/building_and_running_chapters/running_course/course_staffing.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/course_staffing.rst
@@ -60,6 +60,10 @@ as the course staff. They can also:
 * Add and remove Discussion Admins, Discussion Moderators, and Discussion
   Community TAs.
 
+.. note:: For a team member to be able to moderate the course discussions, 
+ you must separately assign one of the discussion roles to her. For more
+ information, see :ref:`Assigning_discussion_roles`.
+
 .. 12 Feb 14 Sarina: This all sounds right but there are other tasks (rescoring, etc) not mentioned. Probably worth nailing down what tasks can and cannot be done by a course staff.
 
 **********************


### PR DESCRIPTION
@mlkwaqas, I added these changes in addition to previously added notes
in these sections of the Building & Running an edX Course guide:
http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/r
unning_course/discussions.html#assigning-discussion-roles
http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/r
unning_course/course_staffing.html#staffing
http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/b
uilding_course/creating_new_course.html#add-course-team-members
@srpearce please review
