### PR TITLE
Ahodges/clibrary events

### DIFF
--- a/en_us/data/source/internal_data_formats/change_log.rst
+++ b/en_us/data/source/internal_data_formats/change_log.rst
@@ -14,6 +14,9 @@ January-March 2015
 
    * - Date
      - Change
+   * - 18 Mar 2015
+     - Added information about library events for students to the
+       :ref:`Tracking Logs` chapter.
    * - 11 Mar 2015
      - Added information about additional video interaction events that are
        now emitted by the edX mobile app, and reorganized the :ref:`video` in

--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -52,6 +52,10 @@ Alphabetical Event List
      - :ref:`student_cohort_events`
    * - ``edx.cohort.user_removed``
      - :ref:`student_cohort_events`
+   * - ``edx.librarycontentblock.content.assigned``
+     - :ref:`library`
+   * - ``edx.librarycontentblock.content.removed``
+     - :ref:`library`
    * - ``edx.course.enrollment.activated``
      - :ref:`enrollment` and :ref:`instructor_enrollment`
    * - ``edx.course.enrollment.deactivated`` 

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -697,7 +697,8 @@ XYZ
  
 **XBlock**
 
-  EdX’s component architecture for writing courseware components.  
+  EdX’s component architecture for writing courseware components: XBlocks are
+  the components that deliver course content to learners.
 
   Third parties can create components as web applications that can run within
   the edX learning management system.


### PR DESCRIPTION
@bradenmacdonald , @antoviaque , @marcotuts , @brianhw , @stroilova the description of the two new events is in the internal_data_formats/tracking_logs.rst file, under the ".. _library:" marker. Please review for accuracy and completeness. Reviewing table-formatted text in rat files can be tedious, so the "View" button near the file name can be helpful.
@catong, please review.
