### PR TITLE
DOC Libraries: Add Show/Hide Preview step

### DIFF
--- a/en_us/shared/building_and_running_chapters/creating_content/libraries.rst
+++ b/en_us/shared/building_and_running_chapters/creating_content/libraries.rst
@@ -5,7 +5,7 @@ Working with Content Libraries
 ##############################
 
 
-.. _ Content Libraries Overview:
+.. _Content Libraries Overview:
 
 **************************
 Content Libraries Overview
@@ -183,6 +183,10 @@ To view the entire contents of a library in Studio, follow these steps.
 #. Log in to Studio.
 #. Click **Libraries**, then click the library whose components you want to
    view.
+#. Optionally, click **Hide Previews** at the top right of the library page to
+   collapse the component previews and see only the list of component display
+   names. To return to the full preview of components in the library, click
+   **Show Previews**.
 
 The components in the library display in the order in which they were added,
 with the most recently added at the bottom. If your library has more than 10


### PR DESCRIPTION
This PR adds doc for the Show/Hide preview option in content libraries. DOC-1540
(Had been previously reviewed and approved but the feature PR was not merged until now)
