### PR TITLE
DOC: clarify diff bn cohorted vs cohort specific discussions

### DIFF
--- a/en_us/shared/building_and_running_chapters/cohorts/cohorts_setup_discussions.rst
+++ b/en_us/shared/building_and_running_chapters/cohorts/cohorts_setup_discussions.rst
@@ -46,6 +46,14 @@ For information about using cohorts in a course and managing discussions that
 are divided by cohort, see :ref:`Cohorts Overview` and :ref:`Moderating
 Discussions for Cohorts`.
 
+.. note:: Making discussion topics divided by cohort, described in this and
+   the following topics, only divides posts within the discussion topics by
+   cohort; the discussion topics are still visible to all learners in the
+   course. If you want to make specific content-specific discussion topics
+   visible only to certain cohorts, you can implement content groups and
+   change the visibility settings on the discussion components. For more
+   details, see :ref:`Cohorted Courseware Overview`.
+
 
 .. _Coursewide Discussion Topics and Cohorts:
 


### PR DESCRIPTION
Added a note to cohorted discussions topic, making it clear that cohorted discussions only have divided posts within them; they are still visible to all learners. Provides pointer to topic about creating cohort-specific courseware. (DOC-1786)
@explorerleslie @andy-armstrong
