### PR TITLE
Remove extra slash in URL for randomized content blocks

### DIFF
--- a/en_us/release_notes/source/links.rst
+++ b/en_us/release_notes/source/links.rst
@@ -416,4 +416,4 @@
 
 .. _Working with Libraries: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/libraries.html
 
-.. _Randomized Content Blocks: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools//randomized_content_blocks.html
+.. _Randomized Content Blocks: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/randomized_content_blocks.html


### PR DESCRIPTION
@mhoeber @lamagnifica @catong FYI, this fixes the bug Melanie reported (extra slash in the Randomized Content Blocks URL) - no review needed
