### PR TITLE
DOC: various discussions-related clarifications

### DIFF
--- a/en_us/shared/building_and_running_chapters/creating_content/create_discussion.rst
+++ b/en_us/shared/building_and_running_chapters/creating_content/create_discussion.rst
@@ -49,9 +49,9 @@ Create a Discussion Component
 
    The value in the **Display Name** field identifies the discussion in the
    course content. The values in the **Category** and **Subcategory** fields
-   appear in the list of discussion topics on the **Discussion** page. To
-   uniquely identify the discussion in your course, each **Category** /
-   **Subcategory** pair that you supply must be unique.
+   appear in the list of discussion topics on the **Discussion** page. 
+
+   .. note:: Each **Category**/**Subcategory** pair for the discussion topics in your course must be unique.
 
    .. image:: ../../../shared/building_and_running_chapters/Images/Discussion_category_subcategory.png
     :alt: The list of discussions with the "Answering More Than Once" topic indented under "Getting Graded"

--- a/en_us/shared/building_and_running_chapters/running_course/discussions.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/discussions.rst
@@ -43,8 +43,9 @@ consider different viewpoints, and ask questions. In a discussion, there are
 three hierarchical levels of interaction.
 
 * A *post* is the first level of interaction. A post opens a new subject. Posts
-  are often posed as questions, either to start a conversation or to surface an
-  issue that requires some action. When you add a post, you categorize it as a **Question** or as a **Discussion**.  
+  can be made as questions, to solicit a concrete answer, or as discussions,
+  to start a conversation. When you add a post, you decide whether to add it
+  as a **Question** or as a **Discussion**.
 
 * A *response* is the second level of interaction. A response is a reply made
   directly to a post to provide a solution or continue the conversation.
@@ -82,8 +83,9 @@ content-specific topics that you add to course units as discussion components.
 You create both types of discussion topics in Studio.
 
 For details about creating discussion topics, see :ref:`Create CourseWide
-Discussion Topics` and :ref:`Create ContentSpecific Discussion Topics`.
-For details about configuring discussion topics in courses with cohorts enabled, see :ref:`Set up Discussions in Cohorted Courses`.
+Discussion Topics` and :ref:`Create ContentSpecific Discussion Topics`. For
+details about configuring discussion topics in courses with cohorts enabled,
+see :ref:`Set up Discussions in Cohorted Courses`.
 
 .. _Create CourseWide Discussion Topics:
 
@@ -177,14 +179,16 @@ Assign Discussion Administration Roles
 
 You can designate a team of people to help you run course discussions.
 
-.. note:: 
-  The course team that you set up in Studio (or the course staff and
-  instructors you add on the Instructor Dashboard) are not automatically
-  granted discussion administration roles. Discussion administration roles must
-  be explicitly granted to members of the course team for them to moderate or
-  administer course discussions. The course author, team members with Admin
-  access (Studio), and Instructors (Instructor Dashboard) can grant discussion
-  administration roles.
+.. note:: The course team that you set up in Studio (or the course staff and
+   instructors you add on the Instructor Dashboard) are not automatically
+   granted discussion administration roles.
+
+
+   Discussion administration roles must be explicitly granted to members of
+   the course team for them to moderate or administer course discussions. The
+   course author, team members with Admin access (Studio), and Instructors
+   (Instructor Dashboard) can grant discussion administration roles.
+
 
 Different options for working with discussions are available through
 these roles:
@@ -228,9 +232,9 @@ addresses or usernames.
 Assign Roles
 ====================================
 
-To assign a discussion administration role, you must be the course author or an
-Instructor (that is, you are identified in Studio as a team member with Admin
-access).
+To assign a discussion administration role, you must be the course author or
+an Instructor (that is, you are identified in Studio as a team member with
+Admin access or in the LMS as an Instructor).
 
 #. View the live version of the course.
 
@@ -243,8 +247,26 @@ access).
 #. Under the list of users who currently have that role, enter an email address
    or username and click **Add** for the role type.
 
-#. To remove an assigned role, view the list of users and then click **Revoke
-   access**.
+
+==============
+Remove Roles
+==============
+
+To remove role privileges from a user, you must be the course author or
+an Instructor (that is, you are identified in Studio as a team member with
+Admin access or in the LMS as an Instructor).
+
+#. View the live version of the course.
+
+#. Click **Instructor**, then click **Membership**.
+
+#. In the Administration List Management section, use the drop-down list to
+   select Discussion Admins, Discussion Moderators, or Discussion Community
+   TAs.
+
+#. From the list of users who currently have that role, select the user you
+   want to remove, then click **Revoke access**.
+
 
 .. _Running_discussions:
 

--- a/en_us/shared/building_and_running_chapters/running_course/discussions_students.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/discussions_students.rst
@@ -94,17 +94,19 @@ respond to it more easily.
 Types of Discussion Posts
 ====================================
 
-When you make a contribution to a course discussion topic, it can typically be
-categorized as either a question or a discussion.
+When you make a contribution in a course discussion topic, you add your post
+as either a question or a discussion.
 
 * A *question* post raises an issue so that the course staff and community can
-  provide answers.
+  provide answers. 
 
-* A *discussion* post starts a conversation by sharing thoughts and
-  reflections, and inviting community participation.
+* A *discussion* post starts a conversation by sharing thoughts and reflections,
+  and inviting community participation.
 
-When you add a post to a discussion topic, you specify whether it is a question
-or a discussion. When you visit the **Discussion** page for your course, a
+When you add a post to a discussion topic, you must specify whether it is a question
+or a discussion. 
+
+After you make your post, on the **Discussion** page for your course, a
 question mark image identifies posts that ask questions and a conversation
 bubble image identifies posts that start discussions.
 
@@ -113,7 +115,10 @@ bubble image identifies posts that start discussions.
 
 If you have any difficulty deciding which type of post you want to add, think
 about whether you want to get concrete information (a question) or start an
-open-ended conversation (a discussion).
+open-ended conversation (a discussion). If you require an answer from the
+course team, be sure to create your post as a question, so that the course
+team sees that a response is required and responds appropriately.
+
 
 .. _Find Posts:
 
@@ -167,8 +172,9 @@ topic you select appear in the list of posts.
 Review Only Unread or Unanswered Posts
 =======================================
 
-To limit the posts shown on the **Discussion** page, you can select one of the filter options. Above the list of posts, the **Show all** filter
-is selected by default. 
+To limit the posts shown on the **Discussion** page, you can select one of the
+filter options. Above the list of posts, the **Show all** filter is selected
+by default.
 
 * To list only the discussions and questions that you have not yet viewed,
   select **Unread**.
@@ -187,8 +193,7 @@ Add a Post
 ================================
 
 To make sure that other students and the course team can find and respond to
-your post, try to select the correct type for your post: either question or
-discussion.
+your post, determine the type for your post: either question or discussion.
 
 Add a Post to a Content-Specific Discussion Topic
 **************************************************

--- a/en_us/students/source/sfd_discussions/add_post.rst
+++ b/en_us/students/source/sfd_discussions/add_post.rst
@@ -22,32 +22,45 @@ Add a Post, Response, or Comment
 Add a Post
 ==============
 
-When you add a post to the course discussions, you'll determine the post type
-and the post topic, and then you'll add the post either directly inside the
-course unit or on the **Discussion** page.
+When you add a post to a discussion in your course, you decide what type of
+post to make and the topic of the post. You then add the post either directly
+inside the course unit or on the **Discussion** page.
 
 .. _Determine Post Type:
 
+**************************************************
 Determine the Post Type: Discussion or Question
 **************************************************
 
 To make sure that other students and the course team can find and respond to
-your post, determine the type for your post: either question or discussion.
+your post, decide what type of post you want to make: either question or
+discussion.
 
-* A *question* post raises an issue so that the discussion staff and community can
-  provide answers.
+* A *question* post raises an issue so that the discussion staff or community
+  can provide answers. 
 
 * A *discussion* post starts a conversation by sharing thoughts and
   reflections, and inviting community participation.
 
 If you have any difficulty deciding which type of post you want to add, think
 about whether you want to get concrete information (a question) or start an
-open-ended conversation (a discussion).
+open-ended conversation (a discussion). If you are asking a question about the
+course and need an answer from the course team, be sure to create your post as
+a question, so that the course team sees that a response is required and
+responds appropriately.
 
-.. note:: You can change the post type from discussion to question or vice versa at any time after you add your post. For more information, see :ref:`Edit or Delete`.
+After you make your post, on the **Discussion** page for your course, a
+question mark image identifies posts that ask questions and a conversation
+bubble image identifies posts that start discussions.
+
+.. note:: You can change the post type from discussion to question or vice
+   versa at any time after you add your post. For more information, see
+   :ref:`Edit or Delete`.
+   
 
 .. _Determine Post Topic:
 
+*************************
 Determine the Post Topic
 *************************
 
@@ -61,6 +74,7 @@ which topic is the most appropriate for your post. For more information, see
 After you've decided on a post type and topic, you can add your post on the
 **Discussion** page or in the body of the course.
 
+************************************
 Add a Post on the Discussion Page
 ************************************
 
@@ -93,6 +107,7 @@ this is the case, you'll see a **Post Anonymously** check box under the field
 where you enter your text. When you post anonymously, discussion staff can see your
 username, but other students cannot.
 
+************************************
 Add a Post in a Course Unit
 ************************************
 
@@ -130,6 +145,7 @@ to content-specific discussions.
 #. Enter the complete text of your post. Click the buttons above the text field
    to see options for formatting the text and for adding links or images.
 
+
 In a few courses, you can add posts, responses, and comments anonymously. If
 this is the case, you'll see a **Post Anonymously** check box under the field
 where you enter your text. When you post anonymously, discussion staff can see your
@@ -148,6 +164,7 @@ adding a response, or expand on a particular response by adding a comment.
 The same options for formatting the text and for adding links or images are
 available for responses and comments as for posts.
 
+**************************************************
 Add a Response or Comment on the Discussion Page
 **************************************************
 
@@ -174,6 +191,7 @@ topics on the **Discussion** page.
  - To add a comment to a response, click inside the **Add a comment** field below
    the response. When your comment is complete, click **Submit**.  
 
+*******************************************
 Add a Response or Comment in a Course Unit
 *******************************************
 
@@ -204,7 +222,7 @@ topic inside the course.
 
 *******************************************
 Edit or Delete a Post, Response, or Comment
-******************************************* 
+*******************************************
 
 You can edit or delete your own posts, responses, or comments at any time. You
 cannot edit or delete contributions from other students.


### PR DESCRIPTION
This PR covers a few small updates to discussions-related doc:
- category/subcategory must be unique (DOC-120)
- make clear that Admin role in Studio = Instructor role in LMS
- change note formatting to make clearer the info course team permissions not equal to discussion admin roles
- when learners create posts they must choose question or discussion type (DOC-1082)
