### PR TITLE
correct variable name to ENTRANCE_EXAMS feature

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Alison Hodges <ahodges@edx.org>
 Mark Hoeber <hoeber@edx.org>
 Sylvia Pearce <spearce@edx.org>
 Carol Tong <ctong@edx.org>
+TJ Keemon <keems21@gmail.com>

--- a/en_us/install_operations/source/configuration/enable_entrance_exams.rst
+++ b/en_us/install_operations/source/configuration/enable_entrance_exams.rst
@@ -25,13 +25,13 @@ Open edX Course* and *Open edX Learner's* guides.
 Enable Entrance Exams in Studio and the Learning Management System
 *************************************************************************
 
-#. Set the value of ``ENABLE_ENTRANCE_EXAMS`` in the
+#. Set the value of ``ENTRANCE_EXAMS`` in the
    ``/cms/envs/common.py`` and ``/lms/envs/common.py`` files to ``True``.
    
    .. code-block:: bash
 
      # Entrance exams feature flag
-     'ENABLE_ENTRANCE_EXAMS': True,
+     'ENTRANCE_EXAMS': True,
 
 #. Save the ``/cms/envs/common.py`` and ``/lms/envs/common.py`` files.
    


### PR DESCRIPTION
The docs seem to incorrectly reference ENABLE_ENTRANCE_EXAMS when the variable to enable the feature should be ENTRANCE_EXAMS.

References in the code:
https://github.com/edx/edx-platform/blob/820b0118f485f3bda36e06db0af1f0fad5ea28f6/cms/envs/devstack.py#L79
https://github.com/edx/edx-platform/blob/60836459d529623fc36d383f6f02331e4ed0f570/cms/envs/bok_choy.env.json#L71

The naming isn't consistent with other EDXAPP_FEATURES, but ENTRANCE_EXAMS works on both edx-platform:named-release/birch and edx-platform:master
