### PR TITLE
update contributor agreement link

### DIFF
--- a/en_us/developers/source/process/contributor.rst
+++ b/en_us/developers/source/process/contributor.rst
@@ -148,5 +148,5 @@ links:
 * `Javascript Guidelines <https://github.com/edx/edx-platform/wiki/Javascript-Guidelines>`_
 
 .. _edx-platform Github wiki: https://github.com/edx/edx-platform/wiki#development
-.. _contributor's agreement with edX: http://code.edx.org/individual-contributor-agreement.pdf
+.. _contributor's agreement with edX: http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf
 .. _compatible licenses: https://github.com/edx/edx-platform/wiki/Licensing


### PR DESCRIPTION
updated the link to the contributor agreement:
https://groups.google.com/d/msg/edx-code/g0248_8qUjc/-ZqyFKwkTxkJ
