### PR TITLE
DOC-1542 Edits to highlight separate discussion privileges

### DIFF
--- a/en_us/shared/building_and_running_chapters/cohorts/cohorts_manage_discussions.rst
+++ b/en_us/shared/building_and_running_chapters/cohorts/cohorts_manage_discussions.rst
@@ -5,24 +5,30 @@
 Managing Discussions in Courses with Student Cohorts
 ##########################################################
 
-In courses that have the cohort feature enabled, every post has an indicator of
-who can read it: either everyone, or only the members of a single cohort. For
-students, this is the only noticeable difference between discussions in courses
-that include cohorts when compared to courses that do not. You can share the
-examples in the :ref:`Read the Cohort Indicator in Posts` section with your
-students, along with the :ref:`Discussions for Students and Staff` section of
-this guide.
+In courses that have cohorts enabled, every post has an indicator of who can
+read it: either all students, or only the members of a single cohort. For
+students, this is the only noticeable difference between discussions in
+courses that include cohorts when compared to courses that do not. You can
+share the examples in the :ref:`Read the Cohort Indicator in Posts` section
+with your students, along with the :ref:`Discussions for Students and Staff`
+section of this guide.
 
-Staff members who have the discussion admin, discussion moderator, or community
-TA role see the same indicator of who can read each post. Unlike the students,
-however, the discussion staff members can read and contribute to every post,
-regardless of the cohort assignment of the student who posted it.
+Staff members who have the discussion admin, discussion moderator, or
+community TA role see the same indicator of who can read each post. Unlike the
+students, however, staff members with discussion privileges can read and
+contribute to every post, regardless of the cohort assignment of the student
+who posted it.
 
-.. note:: Students who have the Community TA role can read and 
- contribute to all posts.
+.. note:: Course team members must have discussion moderator or admin
+   privileges in addition to their course staff privileges to be able to view
+   posts that are divided by cohort. For information about adding discussion
+   privileges, see :ref:`Assigning_discussion_roles`.
 
-In courses with the cohort feature enabled, members of the discussion staff can
-also:
+   Students who have the Community TA role can read and contribute to all
+   posts.
+
+In courses with the cohort feature enabled, course team members who have
+discussion moderator or admin privileges can also:
 
 * Choose who will be able to see the posts that they add to divided topics. See
   :ref:`Choosing the Visibility of a Post`.
@@ -174,6 +180,10 @@ Viewing the Posts of a Cohort
 When a course includes student cohorts, you can view posts and monitor
 discussion activity for one cohort at a time. You can also view all
 posts.
+
+.. note:: Course team members must have discussion moderator or admin
+   privileges in addition to their course staff privileges to be able to view
+   posts that are divided by cohort.
 
 Above the list of posts on the **Discussion** page, the **in all cohorts**
 filter is selected by default. You see every post when you make this selection,

--- a/en_us/shared/building_and_running_chapters/running_course/discussions.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/discussions.rst
@@ -13,8 +13,8 @@ community.
 
 Discussions are also excellent sources of feedback and ideas for the future.
 
-For options you can use to run and moderate discussions, see the following
-sections:
+For information about running and moderating discussions, see the following
+sections.
 
 * :ref:`Overview_discussions`
 
@@ -31,6 +31,14 @@ sections:
 For information about how using cohorts in your course affects how your course
 team might moderate course discussions, see :ref:`Moderating Discussions for
 Cohorts`.
+
+.. note:: The :ref:`Discussions for Students and Staff` section describes
+   features that are available to all discussion participants, and might be
+   useful to students who are new to online discussion forums. You can share
+   the section with your students by, for example, adding a "Never Used a
+   Discussion Forum Before?" post that includes the information you think will
+   be most useful to them.
+
 
 .. _Overview_discussions:
 
@@ -55,21 +63,29 @@ three hierarchical levels of interaction.
   post as a whole.
  
 The dialogue created by a post, its responses, and the comments on those
-responses is sometimes called a thread.
+responses is sometimes called a thread. Discussion threads are saved as part
+of the course history.
 
 All course staff members and enrolled students can add posts, responses, and
 comments, and view all of the posts, responses, and comments made by other
-course participants. Members of the course community, both staff and students,
-can be given permission to moderate or administer course discussions through a
-set of discussion administration roles. Discussion threads are saved as part of
-the course history.
+course participants. 
 
-.. note:: 
-  The :ref:`Discussions for Students and Staff` chapter describes features that
-  are available to all discussion participants, and may be useful to students
-  who are new to online discussion forums. You can share the chapter with your
-  students by, for example, adding a "Never Used a Discussion Forum Before?"
-  post that includes the information you think will be most useful to them.
+Members of the course community, both staff and students, can be given
+permission to moderate or administer course discussions through a set of
+discussion administration roles. 
+
+.. note:: The course team that you set up in Studio (or the course staff and
+   instructors you add on the Instructor Dashboard) are not automatically
+   granted discussion administration privileges, which are required to view
+   all posts, for example in courses using cohorts.
+
+   Discussion administration roles must be explicitly granted to members of
+   the course team for them to moderate or administer course discussions. The
+   course author, team members with Admin access (Studio), and Instructors
+   (Instructor Dashboard) can grant discussion administration roles. For
+   information about adding discussion privileges, see
+   :ref:`Assigning_discussion_roles`.
+
 
 .. _Organizing_discussions:
 


### PR DESCRIPTION
This PR addresses DOC-1542. The goal is to clarify that discussion moderator and admin roles are required for discussion moderation, in addition to having course team roles. 
(The PR also includes some cleanup and minor edits).
@mhoeber @explorerleslie can you please review?
@mmacfarlane FYI
