### PR TITLE
changes - to _ to match filename travis_requirements.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ To run a test compilation of a contribution, first install the prerequisites:
 
 .. code::
   
-  pip install -r shared/travis-requirements.txt
+  pip install -r shared/travis_requirements.txt
 
 Then run the tests:
 


### PR DESCRIPTION
I noticed this little typo when I as reading through the README for the docs repo.
