### PR TITLE
Changes based on renamed EdX Video ID field, fixes DOC-1874

### DIFF
--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -12,6 +12,9 @@ April 2015
 
    * - Date
      - Change
+   * - 22 Apr 2015
+     - Updated the :ref:`Working with Video Components` section to reflect a field
+       label change. 
    * - 16 Apr 2015
      - In the :ref:`Create Exercises` section, added a column to the tables to
        indicate level of support for each exercise or tool.
@@ -34,7 +37,6 @@ March 2015
 
    * - Date
      - Change
-
    * - 25 Mar 2015
      - Added the **Video Available on Web Only** :ref:`advanced setting<Video
        Advanced Options>` to the :ref:`Working with Video Components` chapter.

--- a/en_us/shared/building_and_running_chapters/creating_content/create_video.rst
+++ b/en_us/shared/building_and_running_chapters/creating_content/create_video.rst
@@ -326,9 +326,6 @@ The following options appear on the **Advanced** tab in the video component.
         students by using the **Upload Handout** field. For more information,
         see :ref:`Additional Transcripts`.
 
-    * - **EdX Video ID**
-      - An optional field used only by course teams that are working with
-        edX to process and host video files.
     * - **Show Transcript**
       - Specifies whether the transcript plays along with the video by default.
     * - **Transcript Languages**
@@ -359,6 +356,9 @@ The following options appear on the **Advanced** tab in the video component.
         To help make sure all standard browsers can play your video, we
         **strongly** recommend that you use the .mp4 or .webm format.
 
+    * - **Video ID**
+      - An optional field used only by course teams that are working with
+        edX to process and host video files.
     * - **Video Start Time**
       - The time you want the video to start if you do not want the entire
         video to play. Formatted as HH:MM:SS. The maximum value is 23:59:59.

--- a/en_us/video/source/front_matter/change_log.rst
+++ b/en_us/video/source/front_matter/change_log.rst
@@ -8,6 +8,9 @@ Change Log
 
    * - Date
      - Change
+   * - 22 Apr 2015
+     - Updated the :ref:`Adding Videos to a Course` section to reflect a field
+       label change in Studio.
    * - 4 Apr 2015
      - Added the :ref:`Add a Video Transcript` section to provide procedures
        for obtaining transcripts and associating them with your video files.

--- a/en_us/video/source/video_course.rst
+++ b/en_us/video/source/video_course.rst
@@ -16,7 +16,7 @@ with the video file in a video component.
 .. _Copy the edX Video ID:
 
 ************************
-Copy the edX Video ID
+Copy the Video ID
 ************************
  
 #. Open the course in Studio. 
@@ -32,7 +32,7 @@ Copy the edX Video ID
 #. Right-click and select **Copy**. Be sure to select and copy the entire
    video ID value.
    
-   Next, you paste this value into the **EdX Video ID** field for a video
+   Next, you paste this value into the **Video ID** field for a video
    component. See :ref:`Add the edX Video ID to a Video Component`.
 
    .. note:: The video ID is available for every uploaded file. However, 
@@ -48,7 +48,7 @@ video ID for every uploaded file.
 .. _Add the edX Video ID to a Video Component:
 
 ************************************************
-Add the edX Video ID to a Video Component
+Add the Video ID to a Video Component
 ************************************************
 
 This section describes the procedure that course teams follow in place of the
@@ -76,15 +76,15 @@ page appear in one window while you add video components in the other.
    appear below the **Component Display Name** and **Default Timed Transcript**
    fields.
 
-#. Scroll down to the **EdX Video ID** field and paste in the ID of the video
+#. Scroll down to the **Video ID** field and paste in the ID of the video
    file that you want to play. See :ref:`Copy the edX Video ID`.
 
-   When you supply a valid edX video ID in this field, you associate your
+   When you supply a valid video ID in this field, you associate your
    video component with files on YouTube and AWS that are optimized for
    viewing with different devices and bandwidths. You do not need to add
    values to the **Default Video URL**, **Video File URLs**, or the **YouTube
    ID** fields. If those fields already have values, the URLs that are
-   associated with this edX video ID override them.
+   associated with this video ID override them.
 
 6. Set the **Video Download Allowed** field to **True** or **False** to define
    whether learners can download this video.
@@ -149,7 +149,7 @@ To associate a transcript with a video, follow these steps.
 
 .. note:: 
  This procedure assumes that you have already created the video component and
- followed the procedures to :ref:`add the edX video ID<Add the edX Video ID to
+ followed the procedures to :ref:`add the video ID<Add the edX Video ID to
  a Video Component>` to it. In addition, you must have the .srt file, or the
  subtitles or captions must be available on YouTube, before you complete
  these steps.

--- a/en_us/video/source/video_uploads.rst
+++ b/en_us/video/source/video_uploads.rst
@@ -105,7 +105,7 @@ parties identify and track video files over time.
 
 .. This procedure needs to be completed only once per course in Studio.
 
-.. #. Work with your institution's video administrator to obtain the edX video
+.. #. Work with your institution's video administrator to obtain the video
    identifier for your course. The edX media team defines a unique video
    identifier for each course.
 


### PR DESCRIPTION
@BenjiLee , @lou-wang @mhoeber 
See MA-318, the UI had a "Video ID" l;abel and an "EdX Video ID" label for the same value in different places. This request makes the necessary changes in the Video Processing guide for our member partners who use VAL/VEDA processing and for the Video Component documentation used by all Studio users
