### PR TITLE
Update exercises and tools with support information

### DIFF
--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -9,28 +9,35 @@ Introduction to Exercises and Tools
 ************************************
 
 Studio allows you to create a wide variety of exercises and tools for your
-course. Many of these exercises and tools have templates in Studio so that you
-can create them easily. In addition, individual course teams frequently create
-exercises that don't have templates in Studio. We're striving to make these
-tools available to all our course teams as well, and we have instructions for
-creating some of them in this section.
+course. Many of these exercises and tools have templates in Studio to help you
+create exercises. In addition, individual course teams frequently create
+exercises that don't have templates in Studio. 
 
-Depending on the exercise or tool, you'll use an HTML, Problem, or Advanced
-component. The page for each individual exercise or tool contains an example of
-each exercise or tool, together with all the files, code, and step-by-step
+.. note:: The level of support that edX provides for each tool varies.
+   Exercises and tools that are not fully supported by edX are flagged with an
+   indicator of either provisional or no support.
+
+   Exercises and tools with provisional support might lack the robustness of
+   functionality that courses you build using edX require. Exercises and tools
+   with no support are not maintained by edX, and might be deprecated in the
+   future.
+
+Depending on the exercise or tool, you use an HTML, problem, or advanced
+component. The page for each individual exercise or tool contains an example
+of each exercise or tool, together with all the files, code, and step-by-step
 instructions that you need to create the exercise or tool.
 
-.. note:: 
-  Problems must include labels for accessibility. The label generally includes
-  the text of the main question in your problem. Instructions for adding labels
-  appear in the page for each individual problem.
+.. note:: When you create problems, you must include labels for accessibility.
+   Accessible labels generally include the text of the main question in your
+   problem. Instructions for adding labels appear in the page for each
+   individual problem.
 
 ****************************
 General Exercises and Tools
 ****************************
 
 .. list-table::
-   :widths: 25 25 50
+   :widths: 30 25 60 20
 
    * - .. image:: ../../../shared/building_and_running_chapters/Images/AnnotationExample.png
           :width: 100
@@ -40,6 +47,7 @@ General Exercises and Tools
        specific block of text. The question appears above the text when the
        student hovers the mouse over the highlighted text so that students can
        think about the question as they read.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/PollExample.png
           :width: 100
           :alt: Example poll
@@ -48,6 +56,7 @@ General Exercises and Tools
         groups of students see. For example, students who answer "Yes" to a
         poll question then see a different block of text from the students who
         answer "No" to that question.
+     - Provisional support   
    * - .. image:: ../../../shared/building_and_running_chapters/Images/JavaScriptInputExample.png
           :width: 100
           :alt: Example JavaScript problem
@@ -56,6 +65,7 @@ General Exercises and Tools
        JavaScript problems* or *JS Input problems*) allow you to create a
        custom problem or tool that uses JavaScript and then add the problem or
        tool directly into Studio.
+     - Full support   
    * - .. image:: ../../../shared/building_and_running_chapters/Images/external-grader-correct.png
           :width: 100
           :alt: Example external grader
@@ -66,6 +76,7 @@ General Exercises and Tools
        separately from the edX platform. An external grader is particularly
        useful for software programming courses where students are asked to
        submit complex code.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/google-calendar.png   
           :width: 100
           :alt: Google Calendar
@@ -73,12 +84,14 @@ General Exercises and Tools
      - You can embed a Google calendar in your course so that students see the
        calendar in the courseware. You can use a Google calendar to share quiz
        dates, office hours, or other schedules of interest to students.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/google-spreadsheet.png   
           :width: 100
           :alt: Google Drive Files Tool
      - :ref:`Google Drive Files Tool`
      - You can embed a Google Drive file, such as a document, spreadsheet, or
        image, in your course so that students see the file in the courseware.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/GoogleHangout_WithPeople.png   
           :width: 100
           :alt: Google Hangout
@@ -87,17 +100,20 @@ General Exercises and Tools
        directly from your course. With instant hangouts, students can interact
        through live video and voice, share screens and watch videos together,
        and collaborate on documents.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/IFrame_1.png
           :width: 100
           :alt: Example IFrame tool
      - :ref:`IFrame`
      - IFrames allow you to integrate ungraded exercises and tools from any
        Internet site into an HTML component in your course.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/LTIExample.png
           :width: 100
           :alt: Example LTI component
      - :ref:`LTI Component`
      - LTI components allow you to add an external learning application or non-PDF textbook to Studio.
+     - Full support
    * - .. image:: ../../../shared/building_and_running_chapters/Images/PA_QandRField.png
           :width: 100
           :alt: Example open response assessment
@@ -106,12 +122,14 @@ General Exercises and Tools
        responses of varying lengths as well as image files that the students
        upload. Open response assessments include self assessment and peer
        assessment.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/PollExample.png
           :width: 100
           :alt: Example poll
      - :ref:`Poll`
      - You can run polls in your course so that your students can share
        opinions on different questions.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/ProblemWithAdaptiveHintExample.png
           :width: 100
           :alt: Example problem with adaptive hint
@@ -120,12 +138,14 @@ General Exercises and Tools
        gives the student feedback or a hint based on that response so that the
        student is more likely to answer correctly on the next attempt. These
        problems can be text input or multiple choice problems.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/ProblemWrittenInLaTeX.png
           :width: 100
           :alt: Example problem written in LaTeX
      - :ref:`Problem Written in LaTeX`
      - If you have an problem that is already written in LaTeX, you can use
        this problem type to easily convert your code into XML.
+     - No support
    * - .. image:: ../../../shared/building_and_running_chapters/Images/TextInputExample.png
           :width: 100
           :alt: Example text input problem
@@ -133,12 +153,14 @@ General Exercises and Tools
      - In text input problems, students enter text into a response field. The
        response can include numbers, letters, and special characters such as
        punctuation marks.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/WordCloudExample.png
           :width: 100
           :alt: Example word cloud
      - :ref:`Word Cloud`
      - Word clouds arrange text that students enter - for example, in response
        to a question - into a colorful graphic that students can see.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/CustomPythonExample.png  
           :width: 100
           :alt: Example write-your-own-grader problem
@@ -147,22 +169,24 @@ General Exercises and Tools
        problems, the grader uses a Python script that you create and embed in
        the problem to evaluates a student's response or provide hints. These
        problems can be any type.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/RecommenderXBlockExample.png
           :width: 100
           :alt: Example RecommenderXBlock
      - :ref:`RecommenderXBlock`
      - RecommenderXBlock can hold a list of resources for misconception
-       remediation, additional reading, etc. This tool allows instructors
-       and students to work together and maintain the qualit of list. For
-       example, instructors and students can suggest new resource, vote 
-       useful ones, or flag abuse and spam.
+       remediation, additional reading, and so on. This tool allows
+       instructors and students to work together and maintain the list of
+       resources. For example, instructors and students can suggest new
+       resources, vote for useful ones, or flag abuse and spam.
+     - Provisional support  
 
 ********************************
 Image-Based Exercises and Tools
 ********************************
 
 .. list-table::
-   :widths: 30 25 80
+   :widths: 30 25 60 20
 
    * - .. image:: ../../../shared/building_and_running_chapters/Images/DragAndDropProblem.png
           :width: 100
@@ -170,6 +194,7 @@ Image-Based Exercises and Tools
      - :ref:`Drag and Drop`
      - In drag and drop problems, students respond to a question by dragging
        text or objects to a specific location on an image.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/image-modal.png
           :width: 100
           :alt: Example full screen image tool
@@ -178,6 +203,7 @@ Image-Based Exercises and Tools
        whole browser window. This is useful when the image contains a large
        amount of detail and text that is easier to view in context when
        enlarged.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/ImageMappedInputExample.png
           :width: 100
           :alt: Example image mapped input problem
@@ -185,19 +211,21 @@ Image-Based Exercises and Tools
      - In an image mapped input problem, students click inside a defined area
        in an image. You define this area by including coordinates in the body
        of the problem.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/Zooming_Image.png
           :width: 100
           :alt: Example zooming image tool
      - :ref:`Zooming Image`
      - Zooming images allow you to enlarge sections of an image so that
        students can see the section in detail.
+     - Full support  
 
 ************************************
 Multiple Choice Exercises and Tools
 ************************************
 
 .. list-table::
-   :widths: 30 25 80
+   :widths: 30 25 60 20
 
    * - .. image:: ../../../shared/building_and_running_chapters/Images/CheckboxExample.png
           :width: 100
@@ -206,6 +234,7 @@ Multiple Choice Exercises and Tools
      - In checkbox problems, the student selects one or more options from a
        list of possible answers. The student must select all the options that
        apply to answer the problem correctly.
+     - Full support
    * - .. image:: ../../../shared/building_and_running_chapters/Images/DropdownExample.png
           :width: 100
           :alt: Example dropdown problem
@@ -215,6 +244,7 @@ Multiple Choice Exercises and Tools
        problems, whose answers are always visible directly below the question,
        dropdown problems don't show answer choices until the student clicks the
        dropdown arrow.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/MultipleChoiceExample.png
           :width: 100
           :alt: Example multiple choice problem
@@ -224,6 +254,7 @@ Multiple Choice Exercises and Tools
        don't appear until the student clicks the drop-down arrow, answer
        choices for multiple choice problems are always visible directly below
        the question.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/MultipleChoice_NumericalInput.png
           :width: 100
           :alt: Example multiple choice and numerical input problem
@@ -231,13 +262,14 @@ Multiple Choice Exercises and Tools
      - You can create a problem that combines a multiple choice and numerical
        input problems. Students not only select a response from options that
        you provide, but also provide more specific information, if necessary.
+     - Provisional support  
 
 ********************************
 STEM Exercises and Tools
 ********************************
 
 .. list-table::
-   :widths: 30 25 80
+   :widths: 30 25 60 20
 
    * - .. image:: ../../../shared/building_and_running_chapters/Images/ChemicalEquationExample.png
           :width: 100
@@ -247,6 +279,7 @@ STEM Exercises and Tools
        represents a chemical equation into a text box. The grader evaluates the
        student's response by using a Python script that you create and embed in
        the problem.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/CircuitSchematicExample_short.png
           :width: 100
           :alt: Example circuit schematic builder problem
@@ -255,6 +288,7 @@ STEM Exercises and Tools
        elements such as voltage sources, capacitors, resistors, and MOSFETs on
        an interactive grid. They then submit a DC, AC, or transient analysis of
        their circuit to the system for grading.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/GeneExplorer.png
           :width: 100
           :alt: Example gene explorer problem
@@ -264,6 +298,7 @@ STEM Exercises and Tools
        GeneX allows students to make specific mutations in a gene sequence, and
        it then calculates and displays the effects of the mutations on the mRNA
        and protein.
+     - Provisional support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/MathExpressionInputExample.png
           :width: 100
           :alt: Example math expression input problem
@@ -273,6 +308,7 @@ STEM Exercises and Tools
        answer a question. These problems can include unknown variables and more
        complex symbolic expressions. You can specify a correct answer either
        explicitly or by using a Python script.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/Molecule_Editor.png
           :width: 100
           :alt: Example molecule editor problem
@@ -281,11 +317,13 @@ STEM Exercises and Tools
        rules for covalent bond formation and formal charge, even if the
        molecules are chemically impossible, are unstable, or do not exist in
        living systems.
+     - No support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/MoleculeViewer.png
           :width: 100
           :alt: Example molecule viewer tool
      - :ref:`Molecule Viewer`
      - The molecule viewer allows you to create three-dimensional representations of molecules for students to view.
+     - No support
    * - .. image:: ../../../shared/building_and_running_chapters/Images/image292.png
           :width: 100
           :alt: Example numerical input problem
@@ -296,15 +334,18 @@ STEM Exercises and Tools
        integers and a few select constants. You can specify a margin of error,
        and you can specify a correct answer either explicitly or by using a
        Python script.
+     - Full support  
    * - .. image:: ../../../shared/building_and_running_chapters/Images/Periodic_Table.png
           :width: 100
           :alt: Example periodic table problem
      - :ref:`Periodic Table`
      - An interactive periodic table of the elements shows detailed information
        about each element as the student moves the mouse over the element.
+     - No support
    * - .. image:: ../../../shared/building_and_running_chapters/Images/ProteinBuilder.png
           :width: 100
           :alt: Example protein builder problem
      - :ref:`Protein Builder`
      - The Protex protein builder asks students to create specified protein
        shapes by stringing together amino acids.
+     - No support


### PR DESCRIPTION
This PR updates the "Exercises and Tools" intro section in the B&R Guide with information about levels of support. Modified the intro paragraph and added a note explaining the levels of support. Updated the index table with a new column indicating the level of support for each tool. (https://openedx.atlassian.net/browse/DOC-949) 
@mhoeber FYI: Changes also include minor edits to Recommender XBlock description to correct typos.

The restructuring of the Exercises and Tools chapter to group exercises/tools by level of support will be done in a separate PR.

@explorerleslie @mhoeber can you please review? (Draft HTML for easier reading: http://draft-exercises-and-tools.readthedocs.org/en/latest/exercises_tools/create_exercises_and_tools.html#introduction-to-exercises-and-tools)
@WatsonEmily @mrrudnick FYI
