### PR TITLE
Fixes DOC-1406

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -1854,8 +1854,12 @@ This section includes descriptions of the following events.
 * ``problem_graded``
 
 Problem interaction events are emitted by the server or the browser to capture
-information about interactions with problems, specifically, problems defined in
-the edX Capa module.
+information about interactions with problems. 
+
+These events were designed for the problem types implemented in the edX
+platform by the ``capa_module.py`` XBlock. Problem types that are implemented
+by other XBlocks, such as :ref:`open response assessments<ora2>`, are
+instrumented with different events.
 
 ``problem_check`` (Browser)
 *********************************

--- a/en_us/olx/source/links.rst
+++ b/en_us/olx/source/links.rst
@@ -9,7 +9,7 @@
 
 .. _2014.xml: https://github.com/edx/edx-platform/blob/master/common/test/data/manual-testing-complete/course/2014.xml
 
-.. _LONCAPA XML format: https://s1.lite.msu.edu/adm/help/Authoring_XML_Intro.hlp#Authoring_XML_Intro
+.. _LON-CAPA XML format: https://s1.lite.msu.edu/adm/help/Authoring_XML_Intro.hlp#Authoring_XML_Intro
 
 .. _edX-Insider: https://github.com/pmitros/edX-Insider
 

--- a/en_us/olx/source/problem-xml/index.rst
+++ b/en_us/olx/source/problem-xml/index.rst
@@ -4,7 +4,7 @@
 Problems
 #################################
 
-The format for edX problems is based on the `LONCAPA XML format`_,
+The format for edX problems is based on the `LON-CAPA XML format`_,
 although the two are not quite compatible. In the edX variant, problems are
 composed of four types of tags:
 
@@ -22,7 +22,8 @@ this doesn't always work. For example, in the former case, a multiple choice
 question would not give an output in a format a numerical grader could handle.
 
 In addition, in many cases, there is a 1:1 mapping between graders and inputs.
-For some types of inputs (especially discipline-specific specialized ones), only one grader is needed.
+For some types of inputs (especially discipline-specific specialized ones),
+only one grader is needed.
 
 The most general grader is ``customresponse``. This uses Python code
 to evaluate the input. By design, this ought to work with any inputtype,

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -5,8 +5,8 @@ Glossary
 ############
 
 :ref:`A` - :ref:`C` - :ref:`D` - :ref:`E` - :ref:`F` - :ref:`G` - :ref:`H` 
-- :ref:`I` - :ref:`K` - :ref:`L` - :ref:`M` - :ref:`N` - :ref:`P` - :ref:`R` 
-- - :ref:`S` - :ref:`T` - :ref:`V` - :ref:`W` - :ref:`XYZ<X>`
+- :ref:`I` - :ref:`K` - :ref:`L` - :ref:`M` - :ref:`N` - :ref:`O` - :ref:`P` 
+- :ref:`R` - :ref:`S` - :ref:`T` - :ref:`V` - :ref:`W` - :ref:`XYZ<X>`
 
 .. _A:
 
@@ -58,6 +58,15 @@ A
 C
 ****
 
+**Capa Problem**
+
+  Any of the problem types implemented in the edX platform by the
+  ``capa_module`` XBlock. Examples range from text input, drag and drop, and
+  math expression input problem types to circuit schematic builder, custom
+  JavaScript, and chemical equation problem types.
+
+  Other assessment methods are also available, and implemented using other
+  XBlocks. An open response assessment is an example of a non-capa problem type.
 
 .. _Certificate:
  
@@ -464,6 +473,14 @@ L
 
   For more information, see `View Your Live Course`_.
 
+**LON-CAPA**
+
+  The LearningOnline Network with Computer-Assisted Personalized Approach
+  e-learning platform. The structure of capa problem types in the edX platform
+  is based on the `LON-CAPA`_ assessment system, although they are not
+  compatible.
+
+  See :ref:`Capa Problems<C>`.
 
 .. _M:
 
@@ -530,6 +547,21 @@ N
   For more information, see `Numerical Input Problem`_.
 
 
+.. _O:
+
+****
+O
+****
+
+**Open Response Assessment**
+
+  A type of assignment that allows learners to answer using text and,
+  optionally, an image, as in a short essay. Learners then evaluate each
+  others' work by comparing each response to a rubric created by the course
+  team. These assignments can also include a self assessment, in which
+  learners compare their own responses to the rubric.
+
+  For more information, see `Open Response Assessments`_.
 
 .. _P:
 
@@ -828,4 +860,5 @@ XYZ
 .. _Text Input Problem: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/text_input.html
 .. _Working with Video Components: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/create_video.html#working-with-video-components
 .. _Hide or Show the Course Wiki Page: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/pages.html#hide-or-show-the-course-wiki-page
-
+.. _LON-CAPA: http://www.lon-capa.org/
+.. _Open Response Assessments: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html


### PR DESCRIPTION
DOC-1406 asks for "LONCAPA" to be added to the glossary, which is shared across most of the edX guides.
@mhoeber , @pmitros , @ormsbee , please let me know if the definition I've added to en_us/shared/glossary/glossary.rst is accurate and provides meaningful information to our broad edX audience. 
