### PR TITLE
Add report events to Researcher Guide

### DIFF
--- a/en_us/data/source/front_matter/change_log.rst
+++ b/en_us/data/source/front_matter/change_log.rst
@@ -4,8 +4,9 @@
 Change Log
 ###########
 
+
 **********************
-January-March 2015
+April-June 2015
 **********************
 
 .. list-table::
@@ -14,6 +15,9 @@ January-March 2015
 
    * - Date
      - Change
+   * - 19 May 15
+     - Added information about new instructor report events to the
+       :ref:`Tracking Logs` chapter.
    * - 11 May 2015 
      - Updated the descriptions of the ``pause_video``, ``play_video``, and
        ``stop_video`` :ref:`video interaction events<video>` to include the
@@ -25,6 +29,18 @@ January-March 2015
    * - 6 Apr 15
      - Added a section to describe the
        :ref:`course structure<course_structure>` file.
+
+
+**********************
+January-March 2015
+**********************
+
+.. list-table::
+   :widths: 20 70
+   :header-rows: 1
+
+   * - Date
+     - Change
    * - 18 Mar 2015
      - Added information about library events for students to the
        :ref:`Tracking Logs` chapter.

--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -78,6 +78,10 @@ Alphabetical Event List
      - :ref:`content`
    * - ``edx.googlecomponent.document.displayed``
      - :ref:`content`
+   * - ``edx.instructor.report.downloaded``
+     - :ref:`Instructor_Event_Types`
+   * - ``edx.instructor.report.requested``
+     - :ref:`Instructor_Event_Types`
    * - ``edx.video.loaded``
      - :ref:`video`, see ``load_video``
    * - ``edx.video.paused``

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -3626,11 +3626,12 @@ that are common to all events. See :ref:`common`.
 * ``list-staff``
 * ``list-students``
 
-.. _rescore_all:
 
 ======================================================
-``rescore-all-submissions`` and ``reset-all-attempts``
+``add_instructor`` and ``remove_instructor`` 
 ======================================================
+
+.. previously a comma-separated list; "Rows identical after the second column" (which means the name and description columns) were combined
 
 **Component**: Instructor Dashboard
 
@@ -3644,10 +3645,9 @@ that are common to all events. See :ref:`common`.
 
    * - Field
      - Type
-   * - ``course``
+   * - ``instructor``
      - string
-   * - ``problem`` 
-     - string
+
 
 .. _rescore_student:
 
@@ -3676,6 +3676,111 @@ that are common to all events. See :ref:`common`.
    * - ``student``
      - string
 
+
+======================================================
+``edx.instructor.report.downloaded`` 
+======================================================
+
+The browser emits an  ``edx.instructor.report.downloaded`` event when the user
+clicks a report link on the instructor dashboard to download a report.
+
+**History**: Added 8 May 2015.
+
+**Component**: Instructor Dashboard
+
+**Event Source**: Browser
+
+``event`` **Member Fields**: 
+
+.. list-table::
+   :widths: 20 20 40
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``report_url``
+     - string
+     - The URL to the report file.  
+
+
+======================================================
+``edx.instructor.report.requested`` 
+======================================================
+
+The server emits an  ``edx.instructor.report.requested`` event when the user
+clicks to request the generation of a report on the instructor dashboard. 
+
+**History**: Added 8 May 2015.
+
+**Component**: Instructor Dashboard
+
+**Event Source**: Server
+
+``event`` **Member Fields**: 
+
+.. list-table::
+   :widths: 20 20 40
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``report_type``
+     - string
+     - The type of report that was requested.
+
+
+.. _progress:
+
+======================================================
+``get-student-progress-page`` 
+======================================================
+
+**Component**: Instructor Dashboard
+
+**Event Source**: Server
+
+``event`` **Member Fields**: 
+
+.. list-table::
+   :widths: 40 40
+   :header-rows: 1
+
+   * - Field
+     - Type
+   * - ``course``
+     - string
+   * - ``instructor``
+     - string
+   * - ``student``
+     - string
+
+
+.. _rescore_all:
+
+======================================================
+``rescore-all-submissions`` and ``reset-all-attempts``
+======================================================
+
+**Component**: Instructor Dashboard
+
+**Event Source**: Server
+
+``event`` **Member Fields**: 
+
+.. list-table::
+   :widths: 40 40
+   :header-rows: 1
+
+   * - Field
+     - Type
+   * - ``course``
+     - string
+   * - ``problem`` 
+     - string
+
+
 .. _reset_attempts:
 
 ======================================================
@@ -3703,51 +3808,8 @@ that are common to all events. See :ref:`common`.
    * - ``student``
      - string
 
-.. _progress:
 
-======================================================
-``get-student-progress-page`` 
-======================================================
 
-**Component**: Instructor Dashboard
-
-**Event Source**: Server
-
-``event`` **Member Fields**: 
-
-.. list-table::
-   :widths: 40 40
-   :header-rows: 1
-
-   * - Field
-     - Type
-   * - ``course``
-     - string
-   * - ``instructor``
-     - string
-   * - ``student``
-     - string
-
-======================================================
-``add_instructor`` and ``remove_instructor`` 
-======================================================
-
-.. previously a comma-separated list; "Rows identical after the second column" (which means the name and description columns) were combined
-
-**Component**: Instructor Dashboard
-
-**Event Source**: Server
-
-``event`` **Member Fields**: 
-
-.. list-table::
-   :widths: 40 40
-   :header-rows: 1
-
-   * - Field
-     - Type
-   * - ``instructor``
-     - string
 
 .. _list_forum:
 


### PR DESCRIPTION
This PR adds 2 new events to the Researcher Guide for instructor dashboard reports. (TNL-1988, DOC-1963)
Events added to the Instructor Events list in the tracking logs file, as well as to the alphabetical list of events. Also, per discussion with Alison, I put existing events in that section into alphabetical order -- unfortunately this makes the diffs look confusing in this PR. The 2 new events are on lines 3629-3676.

@andy-armstrong @lamagnifica @explorerleslie In tracking_logs.rst, please review only lines 3629-3676. Thanks!
