### PR TITLE
DOC-2491: Add bookmark events to research guide

### DIFF
--- a/en_us/data/source/internal_data_formats/course_structure.rst
+++ b/en_us/data/source/internal_data_formats/course_structure.rst
@@ -30,6 +30,8 @@ The following fields are present for all of the objects in the
 
 Descriptions of these fields follow.
 
+.. _Course Structure Category Field:
+
 ====================================
 Course Structure ``category`` Field
 ====================================

--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -60,6 +60,14 @@ D, E, F
      - :ref:`Instructor_Event_Types`
    * - ``dump-grades-raw``
      - :ref:`Instructor_Event_Types`
+   * - ``edx.bookmark.accessed``
+     - :ref:`bookmark_events`
+   * - ``edx.bookmark.added``
+     - :ref:`bookmark_events`
+   * - ``edx.bookmark.listed``
+     - :ref:`bookmark_events`
+   * - ``edx.bookmark.removed``
+     - :ref:`bookmark_events`
    * - ``edx.certificate.created``
      - :ref:`certificate_events`
    * - ``edx.certificate.shared``

--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -1507,6 +1507,8 @@ module_type
        - A specialized problem that produces a graphic from the words that
          students enter.
 
+.. _module_id:
+
 -----------
 module_id
 -----------

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -402,7 +402,6 @@ other than the Instructor Dashboard.
   :local:
   :depth: 1
 
-
 The descriptions that follow include what each event represents, the system
 component it originates from, the history of any changes made to the event
 over time, and any additional member fields that the common ``context`` or
@@ -2728,6 +2727,173 @@ The server emits ``showanswer`` events when the answer to a problem is shown.
    * - ``problem_id``
      - string
      - EdX ID of the problem being shown.
+   * - ``[answers, contents]``
+     - array
+     - The array includes each problem in a problem component that has multiple
+       problems.
+
+       * ``answers`` provides the value checked by the user.
+
+       * ``contents`` delivers HTML using data entered for the problem in
+         Studio, including the display name, problem text, and choices or response field
+         labels.
+
+
+.. _bookmark_events:
+
+==========================
+Bookmark Events
+==========================
+
+This section includes descriptions of the following events.
+
+.. contents::
+ :local:
+ :depth: 1
+
+Users can add bookmarks to course units for easy access in the future. The
+browser emits these events when users view, add, use, or delete bookmarks.
+
+.. _edx_bookmark_accessed:
+
+``edx.bookmark.accessed``
+*********************************
+
+The browser emits this event when a user accesses a bookmark by selecting a
+link on the **My Bookmarks** page in the LMS.
+
+``event`` **Member Fields**:
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``bookmark_id``
+     - string
+     - The unique internal identifier for the bookmark.
+   * - ``component_type``
+     - string
+     - The component type of the bookmarked XBlock. For more information, see
+       :ref:`Course Structure Category Field`.
+   * - ``component_usage_id``
+     - string
+     - The unique usage identifier of the bookmarked XBlock. This ID
+       corresponds to the ``courseware_studentmodule.module_id``. For more
+       information, see :ref:`module_id`.
+
+**Event Source**: Browser
+
+**History**: Added 4 Jan 2016.
+
+.. _edx_bookmark_added:
+
+``edx.bookmark.added``
+*********************************
+
+The browser emits this event when a user bookmarks a page.
+
+``event`` **Member Fields**:
+
+The ``edx.course.bookmark.added`` events include the same event member fields
+that are described for :ref:`edx_bookmark_accessed`. The following
+member fields serve the same purpose for accessed bookmarks, added bookmarks,
+and removed bookmarks.
+
+* ``bookmark_id``
+* ``component_type``
+* ``component_usage_id``
+
+The following ``event`` member field applies specifically to
+``edx.course.bookmark.added`` and ``edx.course.bookmark.removed`` events.
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``course_id``
+     - string
+     - The identifier of the course that includes the bookmark.
+
+**Event Source**: Browser
+
+**History**: Added 4 Jan 2016.
+
+``edx.bookmark.listed``
+*********************************
+
+The browser emits this event when a user selects **My Bookmarks** in the LMS
+to list previously bookmarked pages. If the number of bookmarked events
+exceeds the defined page length, the browser emits an additional
+``edx.course.bookmark.listed`` event each time the user navigates to a
+different page of results.
+
+``event`` **Member Fields**:
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``bookmarks_count``
+     - integer
+     - The number of pages a learner has bookmarked. If the ``course_id`` is
+       specified, this value is the number of pages a learner has bookmarked
+       in that course.
+   * - ``course_id``
+     - string
+     - The identifier of the course that includes the bookmark. This is an optional
+       field that is present only if the value for ``list_type`` is ``per_course``.
+
+       * ``per_course`` indicates that all listed bookmarks are in a single course.
+       * ``all_courses`` indicates that the listed bookmarks can be in any
+         course that the learner is enrolled in.
+
+   * - ``list_type``
+     - string
+     - Possible values are 'per_course' or 'all_courses'.
+   * - ``page_number``
+     - integer
+     - The current page number in the list of bookmarks.
+   * - ``page_size``
+     - integer
+     - The number of bookmarks on the current page.
+
+**Event Source**: Browser
+
+**History**: Added 4 Jan 2016.
+
+``edx.bookmark.removed``
+*********************************
+
+The browser emits this event when a user removes a bookmark from a page.
+
+``event`` **Member Fields**:
+
+The ``edx.course.bookmark.removed`` event includes the same event member
+fields that are described for :ref:`edx_bookmark_accessed`, and it also
+includes the ``course_id`` field that is described for
+:ref:`edx_bookmark_added`.
+
+The ``edx.course.bookmark.removed`` event includes the following event member
+fields.
+
+* ``bookmark_id``
+* ``component_type``
+* ``component_usage_id``
+* ``course_id``
+
+**Event Source**: Browser
+
+**History**: Added 4 Jan 2016.
+
 
 .. _library_events:
 
@@ -2901,6 +3067,7 @@ This section includes descriptions of the following events.
 .. contents::
   :local:
   :depth: 1
+
 
 The server emits discussion forum events when a user interacts with a course
 discussion. This section presents the discussion forum events alphabetically.
@@ -5501,7 +5668,6 @@ uploading a .csv file of student cohort assignments.
    * - ``user_id``
      - number
      - The numeric ID (from ``auth_user.id``) of the added user.
-
 
 
 .. include:: ../../../links/links.rst


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DOC-2491
Dec 2, 2015 - reviving this PR in preparation for release of the bookmarks feature to edx.org.

NB: Files were restored from the original limited release of the documentation in June 2015. 
Reviewers please keep an eye out for any implementation/workflow details that changed between then and the coming release that are not reflected in this documentation. Thanks!
### Reviewers
- [x] Subject matter expert: @symbolist, @muhammad-ammar 
- [x] Product owner: @explorerleslie 
- [x] Doc team review: @lamagnifica 
### Testing
- [x] Run ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
