### PR TITLE
Fix links from install config guide

### DIFF
--- a/en_us/install_operations/source/links.rst
+++ b/en_us/install_operations/source/links.rst
@@ -61,7 +61,8 @@
 
 .. _edX Managing the Full Stack: https://github.com/edx/configuration/wiki/edX-Managing-the-Full-Stack
 
-.. _Set Up Course HTML Certificates: http://edx.readthedocs.org/projects/open_edx_course_authors/build/html/building_course/creating_course_certificates.html#setting-up-course-certificates
+.. _Set Up Course HTML Certificates: http://edx.readthedocs.org/projects/open_edx_building-and-running-a-course/en/latest/building_course/creating_course_certificates.html#setting-up-course-certificates
 
-.. _Enable Badges In Each Course: http://edx.readthedocs.org/projects/open_edx_course_authors/build/html/building_course/creating_course_certificates.html#enable-or-disable-badges-for-your-course
+.. _Enable Badges In Each Course: http://edx.readthedocs.org/projects/open_edx_building-and-running-a-course/en/latest/building_course/creating_course_certificates.html#enable-or-disable-badges-for-your-course
+
 


### PR DESCRIPTION
Fix link from open edx install-config guide to open edx building and running a course guide.
@mhoeber @lamagnifica @srpearce can one of you please do a quick sanity check? Thanks!
