### PR TITLE
Correct data type of user_id

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -224,7 +224,7 @@ The following member fields are present in the ``context`` field for all events.
      - string
      - The URL that generated the event. 
    * - ``user_id``
-     - string
+     - integer
      - Identifies the individual who is performing the action.
 
 


### PR DESCRIPTION
Is the user_id supposed to be an integer or a string? [Here](http://edx.readthedocs.org/en/latest/internal_data_formats/tracking_logs.html#context-member-fields-common-to-all-events) it's listed as a string but [everywhere else](http://edx.readthedocs.org/en/latest/internal_data_formats/tracking_logs.html) seems to have it as an integer. I'm not sure about this --I just wanted to make sure!

Thank you!
