### PR TITLE
Fix build warnings

### DIFF
--- a/en_us/shared/building_and_running_chapters/building_course/setting_up_student_view.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/setting_up_student_view.rst
@@ -35,9 +35,9 @@ based on the content of the page.
 You configure the contents of this page in Studio, as described in this topic.
 
 .. note:: Given the diversity of MOOC learners, be careful to clearly 
-   communicate the  target audience, level, and prerequisites for your course. 
+   communicate the target audience, level, and prerequisites for your course. 
    Aim for concrete, unambiguous words (for example, ``understand eigenvalue 
-   decomposition'' rather than ``intermediate linear algebra'').
+   decomposition`` rather than ``intermediate linear algebra``).
 
 
 .. _The Learner Dashboard:

--- a/en_us/shared/building_and_running_chapters/running_course/Section_course_student.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/Section_course_student.rst
@@ -1,5 +1,9 @@
 .. _Using the Learner Engagement Report:
 
+*************************************
+Using the Learner Engagement Report
+*************************************
+
 With the learner engagement report, you can monitor what individual learners
 are doing in your course. The report contains a row for each enrolled learner,
 and has columns that quantify overall course activity and engagement with

--- a/en_us/shared/building_and_running_chapters/running_course/Section_track_student_activity.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/Section_track_student_activity.rst
@@ -1,4 +1,8 @@
 .. _Track Student Activity:
+    
+***********************
+Track Student Activity
+***********************
 
 To monitor student activity during your course, you can review the number of
 students who, each week, interacted with your course. To be considered active,

--- a/en_us/shared/building_and_running_chapters/running_course/course_student.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/course_student.rst
@@ -185,17 +185,9 @@ the ``{course_id}_student_profile_info_{date}.csv`` file of student data or the
 
 .. only:: Open_edX
 
-    *************************************
-    Using the Learner Engagement Report
-    *************************************
-
     .. include:: ../../../shared/building_and_running_chapters/running_course/Section_course_student.rst
 
 .. only:: Partners
-
-    ***********************
-    Track Student Activity
-    ***********************
 
     .. include:: ../../../shared/building_and_running_chapters/running_course/Section_track_student_activity.rst
 


### PR DESCRIPTION
@catong   @srpearce @lamagnifica 

Don't need all to review, but so everyone's aware.  made a few fixes for build errors.  Minor stuff. But we should be ensuring we don't introduce new warnings.  Guides build cleanly except for two warnings in the partners course staff project, warnings for links that are in conditions for open edx and not written to html file anyhow.  I'd like to figure out how to get rid of those warnings, for now we need to expect them.
