### PR TITLE
Add accessibility chapter to Open EdX BR Guide

### DIFF
--- a/en_us/open_edx_course_authors/source/accessibility/best_practices_course_content_dev.rst
+++ b/en_us/open_edx_course_authors/source/accessibility/best_practices_course_content_dev.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/accessibility/best_practices_course_content_dev.rst

--- a/en_us/open_edx_course_authors/source/accessibility/edX_accessib_guidelines.rst
+++ b/en_us/open_edx_course_authors/source/accessibility/edX_accessib_guidelines.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/accessibility/edX_accessib_guidelines.rst

--- a/en_us/open_edx_course_authors/source/accessibility/index.rst
+++ b/en_us/open_edx_course_authors/source/accessibility/index.rst
@@ -1,0 +1,30 @@
+.. _Accessibility Index:
+
+######################################################################
+Accessibility Best Practices Guidance for Content Providers
+######################################################################
+
+The core mission of edX is to expand access to education for everyone. We
+expect courses and course content developed on the edX platform to be
+accessible to everyone, regardless of any physical limitation that they might
+have.
+
+EdX is committed to incorporating accessibility into its platform, website
+(http://www.edx.org), and mobile applications so that course providers can use
+edX tools to develop accessible courses and course content that meets the
+needs of all learners, including those with disabilities.
+
+The topics in this section are intended to help course teams understand how to
+develop courses that can serve the widest possible audience.
+
+.. note:: Course teams should familiarize themselves with these best practice
+   guidelines and distribute them to any members of their teams who are
+   responsible for creating course content.
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 2
+   
+   edX_accessib_guidelines
+   supporting_learners_diverse_needs
+   best_practices_course_content_dev   

--- a/en_us/open_edx_course_authors/source/accessibility/supporting_learners_diverse_needs.rst
+++ b/en_us/open_edx_course_authors/source/accessibility/supporting_learners_diverse_needs.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/accessibility/supporting_learners_diverse_needs.rst

--- a/en_us/open_edx_course_authors/source/front_matter/change_log.rst
+++ b/en_us/open_edx_course_authors/source/front_matter/change_log.rst
@@ -12,6 +12,9 @@ Apr-Jun 2015
 
    * - Date
      - Change
+   * - 22 Jun 2015
+     - Updated the :ref:`Accessibility Best Practices for Course Content
+       Development` section.
    * - 16 Jun 2015
      - Added the :ref:`Creating a Custom Course` section.
    * - 10 Jun 2015

--- a/en_us/open_edx_course_authors/source/getting_started/accessibility.rst
+++ b/en_us/open_edx_course_authors/source/getting_started/accessibility.rst
@@ -1,1 +1,0 @@
-.. include:: ../../../shared/accessibility/accessibility.rst

--- a/en_us/open_edx_course_authors/source/getting_started/index.rst
+++ b/en_us/open_edx_course_authors/source/getting_started/index.rst
@@ -9,4 +9,3 @@ Getting Started
 
    dashboard_acctsettings_profile
    get_started
-   accessibility

--- a/en_us/open_edx_course_authors/source/index.rst
+++ b/en_us/open_edx_course_authors/source/index.rst
@@ -8,6 +8,7 @@ Building and Running an Open edX Course
 
    front_matter/index
    getting_started/index
+   accessibility/index
    building_course/index
    developing_course/index
    creating_content/index


### PR DESCRIPTION
This PR adds the Accessibility chapter from the Partner B&R Guide (https://github.com/edx/edx-documentation/pull/342) to the Open edX B&R Guide.
@mhoeber 
