### PR TITLE
ORA doc enhancements

### DIFF
--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -22,6 +22,8 @@ July 2015
 
    * - Date
      - Change
+   * - 15 July 2015
+     - Added the :ref:`Best Practices for ORA` and :ref:`PA Scoring` sections.  
    * - 8 July 2015
      - Added the :ref:`Poll Tool` and :ref:`Survey Tool` sections.
    * - 1 July
@@ -202,13 +204,11 @@ February 2015
      - Updated the :ref:`Cohorted Courseware Overview` section to reflect the
        ability to delete content groups and view their usage in a course.      
    * - 2/19/15
-     - Updated ORA documentation to reflect ability to :ref:`remove a student
-       response from peer grading<Remove a student response from peer
-       grading>`.
+     - Updated ORA documentation to reflect ability to :ref:`Remove a learner response from peer grading`
    * - 
-     - Updated ORA documentation to indicate that course staff can use student
-       usernames to :ref:`access student information<Access Student
-       Information>`. They no longer need to obtain an anonymized student ID.
+     - Updated ORA documentation to indicate that course staff can use learner
+       usernames to :ref:`access learner information<Access Learner
+       Information>`. They no longer need to obtain an anonymized learner ID.
    * - 2/13/15
      - Updated the example in the :ref:`Drag and Drop Problem XML` topic.
    * - 2/12/15

--- a/en_us/shared/building_and_running_chapters/developing_course/course_subsections.rst
+++ b/en_us/shared/building_and_running_chapters/developing_course/course_subsections.rst
@@ -259,11 +259,16 @@ Set the Assignment Type and Due Date for a Subsection
 You set the assignment type for problems at the subsection level. 
 
 When you set the assignment type for a subsection, all problems within the
-subsection are graded and weighted as a single type.  For example, if you
+subsection are graded and weighted as a single type. For example, if you
 designate the assignment type for a subsection as **Homework**, then all
 problem types in that subsection are graded as homework.
 
-To set the assignment type and due date for a subsection:
+.. note:: Unlike other problem types, ORA assignments are not governed by the
+   subsection due date. Due dates for each ORA assignment are set in the assignment's
+   settings. For details, see :ref:`PA Specify Name and Dates`.
+
+
+To set the assignment type and due date for a subsection, follow these steps.
 
 #. Click the Settings icon in the subsection box.
    

--- a/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
+++ b/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
@@ -1,22 +1,22 @@
 .. _Accessing ORA Assignment Information:
 
 ##########################################
-Accessing Assignment and Student Metrics
+Accessing Assignment and Learner Metrics
 ##########################################
 
 After your open response assessment assignment has been released, you can access
-information about the number of students in each step of the assignment or the
-performance of individual students. This information is available in the
+information about the number of learners in each step of the assignment or the
+performance of individual learners. This information is available in the
 **Course Staff Information** section at the end of each assignment. To access
-student information, open the assignment in the courseware, scroll to the bottom of the
-assignment, and then click the black **Course Staff Information** banner.
+learner information, open the assignment in the courseware, scroll to the bottom of the
+assignment, and then select the black **Course Staff Information** banner.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CourseStaffInfo_Collapsed.png
    :alt: The Course Staff Information banner at the bottom of the peer assessment
 
-When you access a specific student's information for an open response
+When you access a specific learner's information for an open response
 assessment, you can view his responses and, if necessary, :ref:`cancel the
-student's submission<Remove a student response from peer grading>` so that it is
+learner's submission<Remove a learner response from peer grading>` so that it is
 not included in peer assessments.
 
 .. _PA View Metrics for Individual Steps:
@@ -25,7 +25,7 @@ not included in peer assessments.
 View Metrics for Individual Steps
 ************************************************
 
-You can check the number of students who have completed, or are currently
+You can check the number of learners who have completed, or are currently
 working through, the following steps:
 
 * Submitted responses.
@@ -35,142 +35,142 @@ working through, the following steps:
 * Completed the entire assignment. 
 
 To find this information, open the assignment in the courseware, scroll to the
-bottom of the assignment, and then click **Course Staff Information**.
+bottom of the assignment, and then select **Course Staff Information**.
 
 The **Course Staff Information** section expands, and you can see the number
-of students who are currently working through (but have not completed) each
+of learners who are currently working through (but have not completed) each
 step of the problem.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CourseStaffInfo_Expanded.png
    :alt: The Course Staff Information box expanded, showing problem status
 
-.. _Access Information for a Specific Student:
+.. _Access Information for a Specific Learner:
 
 ***********************************************
-Access Information for a Specific Student
+Access Information for a Specific Learner
 ***********************************************
 
-You can access information about an individual student's performance on a peer
+You can access information about an individual learner's performance on a peer
 assessment assignment, including:
 
-* The student's response. 
-* The peer assessments that other students performed on the student's
+* The learner's response. 
+* The peer assessments that other learners performed on the learner's
   response, including feedback on individual criteria and on the overall
   response.
-* The peer assessments that the student performed on other students'
+* The peer assessments that the learner performed on other learners'
   responses, including feedback on individual criteria and on the overall
   responses.
-* The student's self assessment.
+* The learner's self assessment.
 
 In the following example, you can see the performance information for a specific
-student. This student's response received one peer assessment, and the student
-completed a peer assessment on one other student's response. The student also
+learner. This learner's response received one peer assessment, and the learner
+completed a peer assessment on one other learner's response. The learner also
 completed a self assessment.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_SpecificStudent.png
    :width: 500
-   :alt: Report showing information about a student's response
+   :alt: Report showing information about a learner's response
 
-To determine whether this student has received the required number of
-assessments from other students and has completed the required number of
-assessments for other students, refer to the **Graded By** and **Must Grade**
+To determine whether this learner has received the required number of
+assessments from other learners and has completed the required number of
+assessments for other learners, refer to the **Graded By** and **Must Grade**
 values that were set for the open response assessment assignment in Studio. For
 more information about these settings, see :ref:`Specify Step Settings<PA
 Specify Step Settings>`.
 
-For details about accessing information for a specific student, and for an
-example that shows a student's response with more assessments, see :ref:`Access
-Student Information`.
+For details about accessing information for a specific learner, and for an
+example that shows a learner's response with more assessments, see :ref:`Access
+Learner Information`.
 
 
-.. _Access Student Information:
+.. _Access Learner Information:
 
 =======================================
-Access a Specific Student's Information
+Access a Specific Learner's Information
 =======================================
 
 #. In the LMS, go to the peer assessment assignment that you want to see.
    
-#. Scroll to the bottom of the problem, and click the black **Course Staff
+#. Scroll to the bottom of the problem, and select the black **Course Staff
    Information** banner.
    
-#. In the **Get Student Info** box, enter the student's username, and click
+#. In the **Get Student Info** box, enter the learner's username, and select
    **Submit**.
 
-The student's information appears below the **Get Student Info** box.
+The learner's information appears below the **Get Student Info** box.
 
 The following example shows:
 
-* The student's response. 
+* The learner's response. 
 * The two peer assessments for the response.
-* The two peer assessments the student completed.
-* The student's self assessment.
+* The two peer assessments the learner completed.
+* The learner's self assessment.
 
-For a larger view, click the image so that it opens by itself in the browser
+For a larger view, select the image so that it opens by itself in the browser
 window, and then click anywhere on the image that opens.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_SpecificStudent_long.png
    :width: 250
-   :alt: Report showing information about a student's response
+   :alt: Report showing information about a learner's response
 
 
-.. _Remove a student response from peer grading:
+.. _Remove a learner response from peer grading:
 
 ************************************************
-Remove a Student Response from Peer Grading
+Remove a Learner's Response from Peer Grading
 ************************************************
 
-If you use open response assessments, students might alert you to vulgar,
+If you use open response assessments, learners might alert you to vulgar,
 abusive, or otherwise inappropriate responses that they have seen while
 performing peer assessments. In such a situation you can :ref:`locate<Locate a
 specific ORA submission>` and cancel the submission. Doing so removes the
 inappropriate response from peer assessments so that it is no longer shown to
-other students.
+other learners.
 
-.. note:: Removing a student's submission is an irreversible action. 
+.. note:: Removing a learner's submission is an irreversible action. 
 
 When you cancel an inappropriate submission, the response is immediately removed
 from the pool of submissions available for peer assessment. If the inappropriate
-response has already been sent to other students for peer assessment, it is also
-removed from their queue. However, if any student has already graded the
+response has already been sent to other learners for peer assessment, it is also
+removed from their queue. However, if any learner has already graded the
 inappropriate response, it is counted as one of the submissions they have
 graded.
 
 .. note:: After you remove an inappropriate response from peer assessment, you
-   decide whether the student who submitted that response is allowed to submit a
-   replacement response. If you do not want to allow the student to submit a
+   decide whether the learner who submitted that response is allowed to submit a
+   replacement response. If you do not want to allow the learner to submit a
    replacement response, you do not need to take any additional action. The
-   student receives a grade of zero for the entire submission. To allow the
-   student to resubmit a response for a cancelled submission, :ref:`reset the
-   student's attempts for the problem<reset_attempts>`.
+   learner receives a grade of zero for the entire submission. To allow the
+   learner to resubmit a response for a cancelled submission, :ref:`reset the
+   learner's attempts for the problem<reset_attempts>`.
 
 Remove a submission from peer assessment by completing these steps.
 
 #. In the LMS, go to the peer assessment assignment that contains the submission
    you want to remove.
    
-#. Scroll to the bottom of the problem, then click the black **Course Staff
+#. Scroll to the bottom of the problem, then select the black **Course Staff
    Information** banner.
    
-#. Scroll down to the **Get Student Info** box, enter the student's username in
-   the box, and click **Submit**. 
+#. Scroll down to the **Get Student Info** box, enter the learner's username in
+   the box, and select **Submit**. 
 
-   The student's information appears below the **Get Student Info** box.
+   The learner's information appears below the **Get Student Info** box.
    
 #. Scroll down to the **Student Response** section and locate the submission you
    want to remove.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/ORA_RemoveSubmission.png
-   :alt: Dialog allowing comments to be entered when removing a student submission
+   :alt: Dialog allowing comments to be entered when removing a learner submission
    
 5. Enter a comment to document or explain the removal. This comment appears to
-   the student when she views her response in the open response assessment
+   the learner when she views her response in the open response assessment
    problem.
    
 #. Click **Remove submission**. 
 
    The inappropriate submission is removed from peer assessment. When you access
-   this student's information again, instead of the response, you see a note
+   this learner's information again, instead of the response, you see a note
    showing the date and time that the submission was removed, and the comments
    that you entered.
 
@@ -178,7 +178,7 @@ Remove a submission from peer assessment by completing these steps.
    were previously listed.
    
 .. image:: ../../../../shared/building_and_running_chapters/Images//ORA_CancelledStudentResponse.png
-   :alt: The date, time and comment for removal of a student response is shown instead of the original response.  
+   :alt: The date, time and comment for removal of a learner response is shown instead of the original response.  
 
 
 .. _Locate a specific ORA submission:
@@ -188,7 +188,7 @@ Locate a Specific Submission in an ORA Assignment
 *************************************************
 
 If you are alerted to an inappropriate ORA submission that you want to cancel
-and :ref:`remove from peer assessment<Remove a student response from peer
+and :ref:`remove from peer assessment<Remove a learner response from peer
 grading>`, locate the specific submission by following these steps.
 
 #. Ask the person who reported the incident to send you a sample of text from
@@ -205,8 +205,8 @@ grading>`, locate the specific submission by following these steps.
 #. From any matching entries in the spreadsheet, locate the username of the
    learner who posted the submission.
 
-#. Make a note of the username, and follow the steps to :ref:`remove a student
-   response from peer grading<Remove a student response from peer grading>`.
+#. Make a note of the username, and follow the steps to :ref:`remove a learner
+   response from peer grading<Remove a learner response from peer grading>`.
 
 
 

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -5,8 +5,7 @@ Create an Open Response Assessment Assignment
 #############################################
 
 
-Creating an open response assessment is a multi-step process:
-
+Creating an open response assessment is a multi-step process. Each step is covered in detail below.
 
 * :ref:`PA Create Component`
 * :ref:`PA Add Prompt`
@@ -17,11 +16,9 @@ Creating an open response assessment is a multi-step process:
 * :ref:`PA Show Top Responses`
 * :ref:`PA Test Assignment`
 
-Each of these steps is covered in detail below.
-
 For more information about the components of an open response assessment, see
 :ref:`Open Response Assessments 2`. For information about viewing metrics and
-student responses for released open response assessments, see :ref:`Accessing
+learner responses for released open response assessments, see :ref:`Accessing
 ORA Assignment Information`.
 
 
@@ -35,9 +32,16 @@ To create the component for your open response assessment, complete these steps.
 
 #. In Studio, open the unit where you want to create the open response
    assessment.   
-#. Under **Add New Component**, click **Problem**, click the **Advanced** tab,
-   and then click **Peer Assessment**.
-#. In the Problem component that appears, click **Edit**.
+#. Under **Add New Component**, select **Problem**, select the **Advanced** tab,
+   and then select **Peer Assessment**.
+#. In the Problem component that appears, select **Edit**.
+
+.. note:: After you publish an ORA assignment, you can no longer change the
+   structure of the rubric or the point values associated with each criterion
+   in the rubric. If you correct typographical errors in the text of the
+   rubric, only learners who have not yet started the assignment will see the
+   corrections. However, you can modify due dates and the weight of the ORA
+   assignment after you publish an ORA assignment.
 
 
 .. _PA Add Prompt:
@@ -72,13 +76,12 @@ field.
 .. _PA Allow Images:
 
 ============================================
-Allow Students to Submit Images (optional)
+Allow Learners to Submit Images (optional)
 ============================================
 
+To allow learners to submit an image with a response, complete these steps.
 
-To allow students to submit an image with a response, complete these steps.
-
-#. In the open response assessment component editor, click the **Settings** tab.
+#. In the open response assessment component editor, select the **Settings** tab.
 #. For **Allow Image Responses**, select **True**.
 
 .. note:: 
@@ -86,11 +89,11 @@ To allow students to submit an image with a response, complete these steps.
    * The image file must be a .jpg or .png file, and it must be smaller than 5
      MB in size. 
    * Currently, course teams cannot see any of the images that
-     students submit. Images are not visible in the body of the assignment in
+     learners submit. Images are not visible in the body of the assignment in
      the courseware, and they are not included in the course data package.
-   * You can allow students to upload an image, but you cannot require it.
-   * Students can only submit one image with each response.     
-   * All responses must contain text. Students cannot submit a response that
+   * You can allow learners to upload an image, but you cannot require it.
+   * Learners can only submit one image with each response.     
+   * All responses must contain text. Learners cannot submit a response that
      contains only an image.
 
 .. _PA Add Rubric:
@@ -99,33 +102,41 @@ To allow students to submit an image with a response, complete these steps.
 Step 3. Add the Rubric
 ******************************
 
-In this step, you add your rubric and provide your students with feedback
+In this step, you add your rubric and provide your learners with feedback
 options. You add one rubric for each problem, regardless of the number of
 prompts in the problem.
 
 For each step below, replace any default text with your own text.
 
 .. note:: All open response assessments include a feedback field below the
-   rubric so that students can provide written feedback on a peer's overall
-   response. You can also allow or require students to provide feedback for
+   rubric so that learners can provide written feedback on a peer's overall
+   response. You can also allow or require learners to provide feedback for
    individual criteria. See step 2.4 below for instructions. For more
    information, see :ref:`Feedback Options`.
 
 To add the rubric, complete these steps.
 
-#. In the open response assessment component editor, click the **Rubric** tab.
+#. In the open response assessment component editor, select the **Rubric** tab.
 #. In the first **Criterion** section, enter the name and prompt text of your first criterion.
 #. In the first **Option** section, enter the name, explanation, and point value for the first option.
 #. In the next **Option** section, enter the name, explanation, and point value for the next option.
-#. Repeat step 4 for each option. If you need to add more options, click **Add Option**.
-#. Next to **Feedback for This Criterion**, select a value in the drop-down list.
+#. Repeat step 4 for each option. If you need to add more options, select **Add Option**.
+#. Next to **Feedback for This Criterion**, select a value in the dropdown list.
 
-   * If you do not want students to provide feedback for this individual criterion, select **None**.
-   * If you want to require students to provide feedback, select **Required**.
-   * If you want to allow students to provide feedback, but not require it, select **Optional**.
+   * If you do not want learners to provide feedback for this individual criterion, select **None**.
+   * If you want to require learners to provide feedback, select **Required**.
+   * If you want to allow learners to provide feedback, but not require it, select **Optional**.
 
-7. Follow the instructions in steps 2-6 to add your remaining criteria. If you need to add more criteria, click **Add Criterion** at the end of the list of criteria.
-#. Include instructions for students to provide overall written feedback on their peers' responses. You can leave the default text in the **Feedback Instructions** field or replace it with your own text.
+7. Follow the instructions in steps 2-6 to add your remaining criteria. If you need to add more criteria, select **Add Criterion** at the end of the list of criteria.
+#. Include instructions for learners to provide overall written feedback on their peers' responses. You can leave the default text in the **Feedback Instructions** field or replace it with your own text.
+
+.. note:: After you publish an ORA assignment, you can no longer change the
+   structure of the rubric or the point values associated with each criterion
+   in the rubric. If you correct typographical errors in the text of the
+   rubric, only learners who have not yet started the assignment will see the
+   corrections. However, you can modify due dates and the weight of the ORA
+   assignment after you publish an ORA assignment.
+
 
 .. _PA Criteria Comment Field Only:
 
@@ -142,8 +153,9 @@ In the following image, the first criterion has a comment field but no options. 
 
 To provide a comment field without options, complete these steps.
 
-#. In the criterion, click **Remove** to remove, or delete, all the options.
-#. Next to **Feedback for This Criterion**, select **Required** in the drop-down list.
+#. In the criterion, select **Remove** to remove, or delete, all the options.
+#. Next to **Feedback for This Criterion**, select **Required** in the dropdown list.
+
 
 .. _PA Specify Name and Dates:
 
@@ -154,12 +166,23 @@ Step 4. Specify the Assignment Name and Response Dates
 To specify a name for the assignment as well as start and due dates for all
 student responses, complete these steps.
 
-#. In the component editor, click the **Settings** tab.
+#. In the component editor, select the **Settings** tab.
 #. Next to **Display Name**, type the name you want to give the assignment.
-#. Next to **Response Start Date** and **Response Start Time**, enter the date and time when you want students to be able to begin submitting responses. Note that all times are in Universal Coordinated Time (UTC).
-#. Next to **Response Due Date** and **Response Due Time**, enter the date and time by which all student responses must be submitted. Note that all times are in Universal Coordinated Time (UTC).
+#. Next to **Response Start Date** and **Response Start Time**, enter the date and time when you want learners to be able to begin submitting responses. Note that all times are in Universal Coordinated Time (UTC).
+#. Next to **Response Due Date** and **Response Due Time**, enter the date and time by which all learner responses must be submitted. Note that all times are in Universal Coordinated Time (UTC).
 
-.. note:: We recommend that you set the response due date and time at least two days before the peer assessment due date and time. If the response due time and peer assessment due time are close together, and a student submits a response just before responses are due, other students may not have time to perform peer assessments before peer assessments are due.
+.. note:: Unlike other problem types, ORA assignments are not governed by the
+   subsection due date. Due dates for each ORA assignment are set in the
+   assignment's settings.
+
+.. note:: EdX recommends that you set the response due date at least one week
+   before the peer assessment due date and time, to allow enough time for peer
+   assessments to be performed after learners have submitted their own
+   responses. If the response due time and peer assessment due time are close
+   together, and a learner submits a response just before responses are due,
+   other learners may not have time to perform peer assessments before peer
+   assessments are due. For details, see :ref:`Best Practices for ORA`.
+
 
 .. _PA Select Assignment Steps:
 
@@ -167,15 +190,22 @@ student responses, complete these steps.
 Step 5. Select Assignment Steps
 ****************************************
 
-Open response assessment assignments can include student training, peer assessment, and self assessment steps. You can include a peer assessment step before a self assessment step and vice versa. 
+Open response assessment assignments can include learner training, peer assessment, and self assessment steps. 
 
-If you include a student training step, you **must** include a peer assessment step. You can also include a self assessment step. The student training step must come before both the peer assessment and the self assessment step.
+.. note:: If you include a learner training step, you must also include a peer
+   assessment step. The learner training step must come before peer or self
+   assessment steps. If you include both peer and self assessment steps, edX
+   recommends that you place the peer assessment before the self assessment.
 
-To add steps to the assignment:
 
-#. In the component editor, click the **Settings** tab.
-#. Scroll down past the **Allow Image Responses** field.
-#. Locate the following headings:
+To add steps to the open response assignment, complete these actions.
+
+#. In the component editor, select the **Settings** tab.
+
+#. Scroll down past the **Allow Image Responses** and **Allow Latex
+   Responses** fields.
+
+#. Locate the following headings.
 
    * **Step: Student Training**
    * **Step: Peer Assessment**
@@ -183,7 +213,11 @@ To add steps to the assignment:
 
    Select the check boxes for the steps that you want the assignment to include. 
 
-#. (optional) If you want to change the order of the steps, drag the steps into the order that you want. If you include a student training step, make sure it is the first step in the assignment.
+#. (optional) To change the order of the steps, drag the steps into the order
+   that you want.
+
+.. note:: If you include a student training step, make sure it is the first
+   step in the assignment.
 
 .. _PA Specify Step Settings:
 
@@ -194,7 +228,9 @@ Step 6. Specify Step Settings
 After you select the steps that you want, you can specify settings for those
 steps.
 
-.. note:: If you make changes to a step, but then you clear the check box for that step, the step will no longer be part of the assignment and your changes will not be saved. 
+.. note:: If you make changes to a step, but then you clear the check box for
+   that step, the step will no longer be part of the assignment and your
+   changes will not be saved.
 
 .. _PA Student Training Step:
 
@@ -210,29 +246,31 @@ created, then select an option for each criterion in your rubric.
    of your criteria or any of its options, you must also update the student
    training step.
 
-To add and score student training responses:
+To add and score student training responses, follow these steps.
 
 #. Under **Step: Student Training**, locate the first **Scored Response** section.
 #. In the **Response** field, enter the text of your example response.
-#. Under **Response Score**, select the option that you want for each criterion.
+#. Under **Response Score**, for each criterion, select the option that you want.
 
-For more information, see :ref:`PA Student Training Assessments`.
+For more information, see :ref:`PA Learner Training Assessments`.
+
 
 ============================
 Peer Assessment
 ============================
 
 For the peer assessment step, you specify the number of responses that each
-student must grade, the number of students who must grade each response, and
+learner must grade, the number of learners who must grade each response, and
 start and due dates. All fields are required.
 
-To specify peer assessment settings:
+To specify peer assessment settings, follow these steps.
 
 #. Locate the **Step: Peer Assessment** heading.
-#. Next to **Must Grade**, enter the number of responses that each student must grade.
-#. Next to **Graded By**, enter the number of students that must grade each response.
-#. Next to **Start Date** and **Start Time**, enter the date and time when students can begin assessing their peers' responses. All times are in Universal Coordinated Time (UTC).
+#. Next to **Must Grade**, enter the number of responses that each learner must grade.
+#. Next to **Graded By**, enter the number of learners that must grade each response.
+#. Next to **Start Date** and **Start Time**, enter the date and time when learners can begin assessing their peers' responses. All times are in Universal Coordinated Time (UTC).
 #. Next to **Due Date** and **Due Time**, enter the date and time by which all peer assessments must be complete. All times are in UTC.
+
 
 ============================
 Self Assessment
@@ -243,10 +281,11 @@ For the self assessment step, you specify when the step starts and ends.
 #. Locate the **Step: Self Assessment** heading.
    
 #. Next to **Start Date** and **Start Time**, enter the date and time when
-   students can begin assessing their peers' responses. All times are in
+   learners can begin assessing their peers' responses. All times are in
    Universal Coordinated Time (UTC).
    
 #. Next to **Due Date** and **Due Time**, enter the date and time by which all peer assessments must be complete. All times are in UTC.
+
 
 .. _PA Show Top Responses:
 
@@ -254,13 +293,13 @@ For the self assessment step, you specify when the step starts and ends.
 Step 7. Show Top Responses
 ******************************
 
-To allow students to see the top-scoring responses for the assignment, you
+To allow learners to see the top-scoring responses for the assignment, you
 specify a number on the **Settings** tab.
 
-#. In the component editor, click the **Settings** tab.
+#. In the component editor, select the **Settings** tab.
    
 #. In the **Top Responses** field, specify the number of responses that you want
-   to appear in the **Top Responses** section below the student's final score.
+   to appear in the **Top Responses** section below the learner's final score.
    If you do not want this section to appear, set the number to 0. The maximum
    number is 100.
 

--- a/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
+++ b/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
@@ -4,128 +4,211 @@
 Open Response Assessments
 #########################
 
+The topics in this section provide an overview and details about open response
+assessments.
+
+.. contents::
+   :depth: 1
+   :local:
+
+
 *****************************************
 Introduction to Open Response Assessments
 *****************************************
 
 Open response assessments allow instructors to assign questions that might not
-have definite answers, such as text responses or short essays. Students submit
-responses to questions, then each student and the student's peers compare the
-responses to a rubric that you create. You can also allow students to upload an
+have definite answers, such as text responses or short essays. Learners submit
+responses to questions, then each learner and the learner's peers compare the
+responses to a rubric that you create. You can also allow learners to upload an
 image to accompany a text response.
 
-Open response assessments include peer assessments and self assessments. In peer
-assessments, students compare their peers' responses to a rubric that you
-create. In self assessments, students compare their own responses to the rubric.
+Open response assessments can include both peer assessments and self
+assessments. In peer assessments, learners compare their peers' responses to a
+rubric that you create. In self assessments, learners compare their own
+responses to the rubric.
 
-In open response assessments, students usually only see their own responses and
-any peer responses they assess. You can also allow students to see the top-
+In open response assessments, learners usually only see their own responses
+and any peer responses they assess. You can also allow learners to see the top
 scoring responses that their peers have submitted. For more information, see
 :ref:`PA Top Responses`.
 
-.. note:: Open response assessments that are visible to all students do not
-   respect cohorts. In other words, it is possible for students in one cohort to
-   be asked to grade responses for students in another cohort. If you want to
+.. note:: Open response assessments that are visible to all learners do not
+   respect cohorts. In other words, it is possible for learners in one cohort to
+   be asked to grade responses for learners in another cohort. If you want to
    make an open response assessment divided by cohort, you must create that
    assessment in a course component that is defined as cohort-specific. For more
    information about cohorts and creating cohort-specific courseware, see
    :ref:`Cohorts Overview` and :ref:`Cohorted Courseware Overview`.
 
-For more information about creating open response assessments, including step-
-by-step instructions, see the following sections.
+For more information about creating open response assessments, including step
+by step instructions, see the following sections.
 
+* :ref:`Best Practices for ORA`
 * :ref:`PA Elements`
 * :ref:`PA Scoring`
 * :ref:`PA Create an ORA Assignment`
 * :ref:`Accessing ORA Assignment Information`
+
   
-For information about viewing metrics and student responses for released open
+For information about viewing metrics and learner responses for released open
 response assessments, see :ref:`Accessing ORA Assignment Information`.  
 
-For information about the student experience with open response assessments, see
-`Open Response Assessments <http://edx-guide-for-
+For information about the learner experience with open response assessments,
+see `Open Response Assessments <http://edx-guide-for-
 students.readthedocs.org/en/latest/SFD_ORA.html>`_ in the `edX Guide for
-Students <http://edx-guide-for-students.readthedocs.org/en/latest/index.html>`_.
+Learners <http://edx-guide-for-
+students.readthedocs.org/en/latest/index.html>`_.
+
+
+.. _Best Practices for ORA:
+
+*********************************************
+Best Practices for Open Response Assessments
+*********************************************
+
+Open response assessments can be a powerful teaching tool, but they are more
+effective in some situations than in others. In general, open response
+assessments are best suited to open-ended or project-based assignments with
+subjective essay answers and discussion. For example, open response
+assessments work well in humanities assignments where learners are encouraged
+to make subjective assessments of text or images, but they might not be the
+ideal tool in chemistry assignments where there are definitively correct or
+incorrect answers to questions.
+
+EdX suggests that you follow these guidelines and best practices when you use
+open response assessments in your courses.
+
+* Make sure you have a well designed and clear :ref:`rubric <PA Rubric>`. A
+  good rubric is very important in helping to eliminate ambiguity in the peer
+  grading process.
+
+* Make ORA assignments count toward only a small percentage of the final
+  course grade, or make them ungraded.
+
+* In graded ORA assignments, consider setting the lowest possible score to a
+  number higher than zero, so that learners can earn some credit for the work
+  they have done, even if their peer assessors give them low grades.
+
+* Provide an ungraded practice ORA assignment prior to the first graded ORA
+  assignment in the course, so that learners can understand the peer grading
+  process and get the most out of the eventual graded ORA assignment. 
+
+* Consider using ungraded ORA assignments to generate learner interaction and
+  feedback without affecting grades.
+
+* Be wary of including too many ORA assessments in your course. :ref:`Peer
+  assessments <Peer Assessment Step>` are hard work for learners, and having
+  to perform too many peer assessments can have a negative impact on learners'
+  course completion rates.
+
+* Set the **Must Grade** number higher than the **Graded By** number to minimize
+  the chance that some responses will not be peer assessed. EdX recommends a
+  setting such as **Must Grade** = 4 and **Graded By** = 3.
+
+* In ORA assignments, to allow enough time for peer assessments to be
+  performed after learners have submitted their own responses, set the
+  response due date and time at least one week before the peer assessment due
+  date and time. If the response due time and peer assessment due time are
+  close together, and a learner submits a response just before responses are
+  due, other learners may not have time to perform peer assessments before
+  peer assessments are due.
+
+* In discussion forum posts, provide guidance for peer grading of ORA
+  assignments.
+
+* Consider extending due dates to allow course staff to monitor discussion
+  forums for questions about or reactions to peer grading, and to address
+  issues when necessary.
+
+  If learners raise concerns about ORA assignments in discussion forums,
+  course staff have the ability to perform actions such as :ref:`deleting a
+  learner's history, or "state" <Adjust_grades>` for a problem so that he can
+  submit his assignment again, or :ref:`removing a learner response <Remove a
+  learner response from peer grading>` from peer grading. If there are more
+  widespread issues with peer grading, course staff can reduce the weight of
+  the peer assessment within the final course grade or allow learners to drop
+  the lowest graded assignment from their grades.
+
 
 .. _PA Elements:
 
-==========================================
+******************************************
 Elements of an Open Response Assessment
-==========================================
+******************************************
 
 When you create an open response assessment assignment, you include several
 elements:
 
-* One or more prompts, or questions.
+* One or more :ref:`prompts <PA Prompts>`, or questions.
 
-* The rubric. One rubric is used to grade all the prompts in the
+* The :ref:`rubric <PA Rubric>`. One rubric is used to grade all the prompts in the
   assessment.
   
-* One or more assessment steps. Assignments can include a student training step,
-  a peer assessment step, and a self assessment step.
+* One or more :ref:`assessment steps <PA Assessment Steps>`. Assignments can
+  include a learner training step, a peer assessment step, and a self
+  assessment step.
 
-.. note:: If you include a student training step, you must also include a peer
-   assessment step. The student training step must come first, before the peer
+.. note:: If you include a learner training step, you must also include a peer
+   assessment step. The learner training step must come first, before the peer
    and self assessment steps.
 
 For step-by-step instructions for creating an open response assessment, see
 :ref:`PA Create an ORA Assignment`.
 
-*******
+.. _PA Prompts:
+
+=======
 Prompts
-*******
+=======
 
-Each **prompt**, or question, that you want your students to answer, appears
-near the top of the page, followed by a field where the student enters a
-response. You can require your students to enter text as a response, or you can
-allow your students to both enter text and upload an image.
+Each **prompt**, or question, that you want your learners to answer, appears
+near the top of the page, followed by a field where the learner enters a
+response. You can require your learners to enter text as a response, or you can
+allow your learners to both enter text and upload an image.
 
-.. note:: If students upload an image, the image file must be a .jpg or .png file, and it must be smaller than 5 MB in size.
+.. note:: If learners upload an image, the image file must be a .jpg or .png file, and it must be smaller than 5 MB in size.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_QandRField.png
    :width: 500
    :alt: Single ORA question and its corresponding blank response field
 
 When you write each question, you can include helpful information for your
-students, such as what they can expect after they submit responses, or the
+learners, such as what they can expect after they submit responses, or the
 approximate number of words or sentences that their response should have. 
 
-.. note:: Each student is limited to a total word count of 10,000 for all
+.. note:: Each learner is limited to a total word count of 10,000 for all
    responses in an ORA assignment.
 
 For more information, see :ref:`PA Add Prompt`.
 
 
-==========================================
-Asking Students to Upload Images
-==========================================
+Asking Learners to Upload Images in Responses
+***********************************************
 
-
-In open response assessments, you can ask your students to upload an image as
+In open response assessments, you can ask your learners to upload an image as
 part of their response. If you do this, however, keep the following points in
 mind.
 
-* Currently, you cannot require your students to upload an image. You can only
-  allow it.
+* You cannot require your learners to upload an image. You can only allow it.
 
-* All responses must include some text. Students cannot submit a response that
+* All responses must include some text. Learners cannot submit a response that
   contains only an image.
 
-* Students can submit only one image with each response.
+* Learners can submit only one image with each response.
 
-.. note:: Currently, course teams cannot see any of the images that students
+.. note:: Currently, course teams cannot see any of the images that learners
    submit. Images are not visible in the body of the assignment in the
    courseware, and they are not included in the course data package.
 
 .. _PA Rubric:
 
-******
+=======
 Rubric
-******
+=======
 
 Your assignment must include a **rubric** that you design. The same rubric is
-used for peer and self assessments, and the rubric appears when students begin
-grading. Students compare their peers' responses to the rubric.
+used for peer and self assessments, and the rubric appears when learners begin
+grading. Learners compare their peers' responses to the rubric.
 
 Rubrics consist of *criteria* and *options*.
 
@@ -134,9 +217,9 @@ Rubrics consist of *criteria* and *options*.
    * The name is a very short summary of the criterion, such as "Ideas" or
      "Content". Criterion names generally have just one word. Because the system
      uses criterion names for identification, **the name for each criterion must
-     be unique.** Criterion names do not appear in the rubric that students see
+     be unique.** Criterion names do not appear in the rubric that learners see
      when they are completing peer assessments, but they do appear on the page
-     that shows the student's final grade.
+     that shows the learner's final grade.
 
      .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CriterionName.png
         :alt: A final score page with call-outs for the criterion names
@@ -154,15 +237,15 @@ Different criteria in the same assignment can have different numbers of options.
 For example, in the image above, the first criterion has three options and the
 second criterion has four options.
 
-.. note:: You can also include criteria that do not have options, but that do include a field where students can enter feedback. For more information, see :ref:`PA Criteria Comment Field Only`.
+.. note:: You can also include criteria that do not have options, but that do include a field where learners can enter feedback. For more information, see :ref:`PA Criteria Comment Field Only`.
 
 You can see both criterion and option names when you access assignment
-information for an individual student. For more information, see :ref:`Accessing
+information for an individual learner. For more information, see :ref:`Accessing
 ORA Assignment Information`.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_Crit_Option_Names.png
    :width: 600
-   :alt: Student-specific assignment information with call-outs for criterion and option names
+   :alt: learner-specific assignment information with call-outs for criterion and option names
 
 When you create your rubric, decide how many points each option will receive,
 and make sure that the explanation for each option is as specific as possible.
@@ -207,60 +290,67 @@ points possible)
 
 For more information, see :ref:`PA Add Rubric`.
 
-************************
-Assessment Steps
-************************
 
-In your assignment, you'll also specify the **assessment steps**. You can set
-the assignment to include a student training step, a peer assessment step, and a
+.. _PA Assessment Steps:
+
+=================
+Assessment Steps
+=================
+
+In your assignment, you also specify the **assessment steps**. You can set the
+assignment to include a learner training step, a peer assessment step, and a
 self assessment step.
 
 You can see the type and order of the assessments when you look at the
-assignment. In the following example, after students submit a response, they
-complete a student training step ("Learn to Assess Responses"), complete peer
-assessments on other students' responses ("Assess Peers"), and then complete
+assignment. In the following example, after learners submit a response, they
+complete a learner training step ("Learn to Assess Responses"), complete peer
+assessments on other learners' responses ("Assess Peers"), and then complete
 self assessments ("Assess Your Response").
+
+.. note:: If you include a learner training step, you must also include a peer
+   assessment step. The learner training step must come before peer or self
+   assessment steps. If you include both peer and self assessment steps, edX
+   recommends that you place the peer assessment before the self assessment.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_AsmtWithResponse.png
   :alt: Image of peer assessment with assessment steps and status labeled
   :width: 600
 
-.. note:: If you include a student training step, you must also include a peer assessment step. The student training step must come before peer and self assessment steps.
 
-.. _PA Student Training Assessments:
+.. _PA Learner Training Assessments:
 
-========================
-Student Training Step
-========================
+
+Learner Training Step
+*****************************
 
 When you create a peer assessment assignment, you can include one or more
-student training assessments to help students learn to perform their own
-assessments. A student training assessment contains one or more sample responses
+learner training assessments to help learners learn to perform their own
+assessments. A learner training assessment contains one or more sample responses
 that you write, together with the scores that you would give the sample
-responses. Students review these responses and try to score them the way that
+responses. Learners review these responses and try to score them the way that
 you scored them.
 
-.. note:: If you include a student training step, you must also include a peer
-   assessment step. The student training step must come before peer and self
+.. note:: If you include a learner training step, you must also include a peer
+   assessment step. The learner training step must come before peer and self
    assessment steps.
 
-In a student training assessment, the **Learn to Assess Responses** step opens
-immediately after a student submits a response. The student sees one of the
+In a learner training assessment, the **Learn to Assess Responses** step opens
+immediately after a learner submits a response. The learner sees one of the
 sample responses that you created, along with the rubric. The scores that you
-gave the response do not appear. The student also sees the number of sample
+gave the response do not appear. The learner also sees the number of sample
 responses that he or she will assess.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_TrainingAssessment.png
    :alt: Sample training response, unscored
    :width: 500
 
-The student selects an option for each of the assignment's criteria, and then
-clicks **Compare your selections with the instructor's selections**. If all of
-the student's selections match the instructor's selections, the next sample
+The learner selects an option for each of the assignment's criteria, and then
+selects **Compare your selections with the instructor's selections**. If all of
+the learner's selections match the instructor's selections, the next sample
 response opens automatically.
 
-If any of the student's selections differs from the instructor's selections, the
-student sees the response again, and the following message appears above the
+If any of the learner's selections differs from the instructor's selections, the
+learner sees the response again, and the following message appears above the
 response:
 
 .. code-block:: xml
@@ -270,8 +360,8 @@ response:
   response and consider why the instructor may have assessed it differently. Then, try 
   the assessment again.
 
-For each of the criteria, the student sees one of the following two messages,
-depending on whether the student's selections matched those of the instructor:
+For each of the criteria, the learner sees one of the following two messages,
+depending on whether the learner's selections matched those of the instructor:
 
 .. code-block:: xml
 
@@ -283,48 +373,51 @@ depending on whether the student's selections matched those of the instructor:
   Selected Options Agree
   The option you selected is the option that the instructor selected.
 
-For example, the following student chose one correct option and one incorrect
+For example, the following learner chose one correct option and one incorrect
 option.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_TrainingAssessment_Scored.png
    :alt: Sample training response, scored
    :width: 500
 
-The student continues to try scoring the sample response until the student's
+The learner continues to try scoring the sample response until the learner's
 scoring for all criteria matches the instructor's scoring.
 
 For more information, see :ref:`PA Student Training Step`.
 
+.. _Peer Assessment Step:
 
-=====================
 Peer Assessment Step
-=====================
+*****************************
 
-In the peer assessment step, students review other students' responses. For each
+In the peer assessment step, learners review other learners' responses. For each
 response, they select an option for each criterion in your rubric based on the
-response. Students can also provide text feedback, or comments, on each
+response. Learners can also provide text feedback, or comments, on each
 response.
 
+If you include both peer and self assessment steps, edX recommends that you
+place the peer assessment before the self assessment.
 
-************************************
+
 Number of Responses and Assessments
 ************************************
 
-When you specify a peer assessment step, you specify the **number of responses**
-that each student has to assess and the **number of peer assessments** that each
-response has to receive.
+When you specify a peer assessment step, you specify the number of responses
+that each learner has to assess (**Must Grade**) and the number of peer
+assessments that each response has to receive (**Graded By**) before the
+assignment is complete.
 
-.. note:: Because some students might submit a response without completing any
+.. note:: Because some learners might submit a response without performing any
    peer assessments, some responses might not receive the required number of
    assessments. To increase the chance that all responses receive a sufficient
-   number of assessments, you must set the number of responses that students
+   number of assessments, you must set the number of responses that learners
    must assess to be higher than the number of assessments that each response
    must undergo. For example, if you require each response to receive three
-   assessments, you could require each student to assess five responses.
+   assessments, you could require each learner to assess five responses.
 
-If all responses have received assessments, but some students have not completed
-the required number of peer assessments, those students can assess responses
-that other students have already assessed. The student who submitted the
+If all responses have received assessments, but some learners have not completed
+the required number of peer assessments, those learners can assess responses
+that other learners have already assessed. The learner who submitted the
 response sees the additional peer assessments when he sees his score. However,
 the additional peer assessments do not count toward the score that the response
 receives.
@@ -332,11 +425,10 @@ receives.
 
 .. _Feedback Options:
 
-****************
 Feedback Options
 ****************
 
-By default, students see a single comment field below the entire rubric. You can
+By default, learners see a single comment field below the entire rubric. You can
 also add a comment field to an individual criterion or to several individual
 criteria. This comment field can contain up to 300 characters.
 
@@ -352,21 +444,79 @@ For more information, see :ref:`PA Add Rubric` and :ref:`PA Criteria Comment
 Field Only`.
 
 
+Assessing Additional Responses
+********************************
+
+Learners can assess more than the required number of responses. After a learner
+completes the peer assessment step, the step "collapses" so that only the
+**Assess Peers** heading is visible.
+
+.. image:: ../../../../shared/building_and_running_chapters/Images/PA_PAHeadingCollapsed.png
+   :width: 500
+   :alt: The peer assessment step with just the heading visible.
+
+If the learner selects the **Assess Peers** heading, the step expands. The
+learner can then select **Continue Assessing Peers**.
+
+.. image:: ../../../../shared/building_and_running_chapters/Images/PA_ContinueGrading.png
+   :width: 500
+   :alt: The peer assessment step expanded so that "Continue Assessing Peers" is visible.
+
+
+=====================
+Self Assessment Step
+=====================
+
+In self assessments, the learner sees his response followed by your rubric. As
+with peer assessments, the learner compares the rubric to his response and
+selects an option for each of the criteria.
+
+If you include both peer and self assessments, we recommend that you include the
+peer assessment before the self assessment.
+
+
 .. _PA Scoring:
 
-***********************
+******************************************
+How Open Response Assessments Are Scored
+******************************************
+
+In open response assessments that contain both peer assessment and self
+assessments, only the peer assessment score counts toward the assignment's
+final grade. The self assessment score is not taken into account. There is no
+option for weighting the peer and self assessment portions independently.
+
+In open response assessments that include only self assessments, the
+assignment's final grade is equivalent to the self assessment score.
+
+.. note:: Given the high level of subjectivity in peer assessments, edX
+   recommends that you make ORA assignments count towards only a small
+   percentage of a course's final grade.
+
+The following sections detail how the scores for peer assessments and self
+assessments are calculated.
+
+
+=======================
 Peer Assessment Scoring
-***********************
+=======================
 
-Peer assessments are scored by criteria. An individual criterion's score is the
-median of the scores that each peer assessor gave that criterion. For example,
-if the Ideas criterion in a peer assessment receives a 10 from one student, a 7
-from a second student, and an 8 from a third student, the Ideas criterion's
-score is 8.
+.. note:: If an open response assessment includes both peer and self
+   assessments, only the peer assessment score counts towards the assignment's
+   final grade. The self assessment score is not taken into account.
 
-A student's final score for a peer assessment is the sum of the median scores for each individual criterion. 
+Peer assessments are scored by criteria. A number of peer assessors rate a
+learner's response by each of the required criteria. The learner's score for a
+particular criterion is the median of all scores that each peer assessor gave
+that criterion. For example, if the Ideas criterion in a peer assessment
+receives a 10 from one learner, a 7 from a second learner, and an 8 from a
+third learner, the Ideas criterion's score is 8.
 
-For example, a response may receive the following scores from peer assessors:
+The learner's final score on a response is the sum of the median scores from all
+peer assessors for all of the required criteria.
+
+For example, a response might have received the following scores from three peer
+assessors.
 
 .. list-table::
    :widths: 25 10 10 10 10
@@ -394,7 +544,8 @@ For example, a response may receive the following scores from peer assessors:
      - 5
      - **4**
 
-To calculate the final score, add the median scores for each criterion:
+To calculate the final score for the response, add the median scores that were
+given for each criterion, as follows.
 
   **Ideas median (8/10) + Content median (8/10) + Grammar median (4/5) = final
   score (20/25)**
@@ -403,41 +554,27 @@ To calculate the final score, add the median scores for each criterion:
    individual assessor. Therefore, the score for the response is not the median
    of the scores that each individual peer assessor gave the response.
 
-
-For information on grades for student submissions that you have cancelled and
-removed from peer assessment, refer to :ref:`Remove a student response from peer
+For information on grades for learner submissions that you have cancelled and
+removed from peer assessment, refer to :ref:`Remove a learner response from peer
 grading`.
 
 
-********************************
-Assessing Additional Responses
-********************************
+=======================
+Self Assessment Scoring
+=======================
 
-Students can assess more than the required number of responses. After a student
-completes the peer assessment step, the step "collapses" so that just the
-**Assess Peers** heading is visible.
+.. note:: If an open response assessment includes both peer and self
+   assessments, the self assessment score does not count toward the final
+   grade.
 
-.. image:: ../../../../shared/building_and_running_chapters/Images/PA_PAHeadingCollapsed.png
-   :width: 500
-   :alt: The peer assessment step with just the heading visible
+If an open response assessment includes only self assessments, the
+assignment's final grade is equivalent to the self assessment score.
 
-If the student clicks the **Assess Peers** heading, the step expands. The student can then click **Continue Assessing Peers**.
-
-.. image:: ../../../../shared/building_and_running_chapters/Images/PA_ContinueGrading.png
-   :width: 500
-   :alt: The peer assessment step expanded so that "Continue Assessing Peers" is visible
+Self assessments are scored by criteria. Each learner rates herself on each
+criterion, using the rubric. The learner's final score on a response is the
+total number of earned points, out of the total possible points.
 
 
-=====================
-Self Assessment Step
-=====================
-
-In self assessments, the student sees his response followed by your rubric. As
-with peer assessments, the student compares the rubric to his response and
-selects an option for each of the criteria.
-
-If you include both peer and self assessments, we recommend that you include the
-peer assessment before the self assessment.
 
 .. _PA Top Responses:
 
@@ -446,9 +583,9 @@ Top Responses
 *****************************
 
 You can include a **Top Responses** section that shows the top-scoring responses
-that students have submitted for the assignment, along with the scores for those
-responses. The **Top Responses** section appears below the student's score
-information after the student finishes every step in the assignment.
+that learners have submitted for the assignment, along with the scores for those
+responses. The **Top Responses** section appears below the learner's score
+information after the learner finishes every step in the assignment.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_TopResponses.png
    :alt: Section that shows the text and scores of the top three responses for the assignment
@@ -456,7 +593,7 @@ information after the student finishes every step in the assignment.
 
 You can allow the **Top Responses** section to show between 1 and 100 responses.
 Keep in mind, however, that each response might be up to 300 pixels in height in
-the list. (For longer responses, students can scroll to see the entire
+the list. (For longer responses, learners can scroll to see the entire
 response.) We recommend that you specify 20 or fewer responses to prevent the
 page from becoming too long.
 
@@ -464,7 +601,7 @@ page from becoming too long.
    **Top Responses** list.
 
    If a high-scoring response is :ref:`removed from peer assessment<Remove a
-   student response from peer grading>` it is also removed from the **Top
+   learner response from peer grading>` it is also removed from the **Top
    Responses** list.
 
 For more information, see :ref:`PA Show Top Responses`.


### PR DESCRIPTION
Making some enhancements to the ORA documentation, including clarifying whether self and peer assessments count towards the grade, that self and peer assessments can't be weighted independently, and that subsection due dates don't apply to ORA assignments. Added 2 new sections: "How Are Open Response Assessments Scored?" and "Best Practices for ORA". (DOC-2092, DOC-1744, DOC-1711)

@explorerleslie @mmacfarlane @srpearce can you please review?
DRAFT HTML is here:
http://draft-ora-partner-br-guide.readthedocs.org/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html
