### PR TITLE
Update code-quality.rst

### DIFF
--- a/en_us/developers/source/testing/code-quality.rst
+++ b/en_us/developers/source/testing/code-quality.rst
@@ -41,4 +41,4 @@ in the line.
 .. _pep8: https://pypi.python.org/pypi/pep8
 .. _coverage.py: https://pypi.python.org/pypi/coverage
 .. _pylint: http://pylint.org/
-.. _diff-quality: https://github.com/Bachman1234/diff-cover
+.. _diff-quality: https://github.com/Bachmann1234/diff-cover


### PR DESCRIPTION
The link to diff-quality tool documentation doesn't work. The new one added links to (what I think is) the current official documentation. Which has broken images and could use some work as well.
