### PR TITLE
Breaklines for table headers

### DIFF
--- a/en_us/developers/source/extending_platform/extending.rst
+++ b/en_us/developers/source/extending_platform/extending.rst
@@ -10,16 +10,24 @@ and innovative educational content in your courses.
 
 This section of the developers' documentation lists and explains the different ways to extend the platform, starting with the following table. Click the name of the extension type in the column header for more information.
 
+.. |br| raw:: html
+
+  <br />
+
 .. list-table::
    :widths: 10 10 10 10 10 10
    :header-rows: 1
 
    * - 
-     - :ref:`Custom JavaScript Applications`
+     - Custom |br|
+       JavaScript |br|
+       Applications*
      - LTI
-     - External Graders
+     - External |br|
+       Graders
      - XBlocks
-     - Platform Customization
+     - Platform |br|
+       Customization
    * - Development Cost
      - Low
      - Low
@@ -87,3 +95,4 @@ This section of the developers' documentation lists and explains the different w
      - No
      - No
 
+(*) :ref:`Custom JavaScript Applications`


### PR DESCRIPTION
The table's width displayed in extending.rst is bigger than it's container therefor users would need to scroll left-right for all the information. Adding breaklines in the table header cells fixes this.

Table as it is now:
![screenshot from 2015-07-10 14 32 11](https://cloud.githubusercontent.com/assets/2808092/8618669/9971032e-2710-11e5-8579-1b97ee39cf7b.png)

Table with breaklines:
![screenshot from 2015-07-10 14 13 31](https://cloud.githubusercontent.com/assets/2808092/8618646/62e61a7e-2710-11e5-9bb7-86c0a9d97607.png)

Also I'm not sure if the link "Custom Javascript Applications" will work with the breaklines. Can somebody confirm?
