### PR TITLE
DOC-2160 Remove notes re limitation of preview as specific student

### DIFF
--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -26,6 +26,12 @@ July 2015
      - Updated the :ref:`Review_Answers` section to remove references to
        features on the Analytics page of the Instructor Dashboard. Course data
        is available in edX Insights.
+   * -  
+     - Added the :ref:`View Specific Student Assigned Problems from Randomized
+       Content Block` and :ref:`Adjust Grades for a Problem from a Randomized
+       Problem Block` sections. Also updated information in the :ref:`Preview
+       Cohort Specific Courseware` and :ref:`View Your Live Course` sections
+       to reflect the ability to preview the courseware as a specific student.
    * - 17 July 2015
      - Added the :ref:`Best Practices for ORA` and :ref:`PA Scoring` sections.
    * - 

--- a/en_us/shared/building_and_running_chapters/cohorts/cohorted_courseware.rst
+++ b/en_us/shared/building_and_running_chapters/cohorts/cohorted_courseware.rst
@@ -346,9 +346,8 @@ You can view the course as a member of these groups.
       - You see any content that is intended for all
         students.
     * - Specific Student
-      - Viewing content as a specific student is not available for any content
-        that is visible only to a particular group (content groups and
-        experiment groups).
+      - You see content that is intended for the student whose email or
+        username you specify. 
     * - Student in <Content Group Name>            
       - You see content that is intended for all learners, as well
         as any content specifically set to be visible to this content group.

--- a/en_us/shared/building_and_running_chapters/creating_content/libraries.rst
+++ b/en_us/shared/building_and_running_chapters/creating_content/libraries.rst
@@ -201,12 +201,6 @@ Matching Components in a Randomized Content Block`.
 To view the randomized content that was assigned to a specific learner, see
 :ref:`Specific Student View`. 
 
-.. note:: You cannot use the **Specific student** view for any course content
-   that is visible only to certain groups. For example, if your course uses
-   cohorts or experiment groups, and some courseware is visible only to
-   learners in a particular content group or experiment group, you cannot see
-   that content when you view the live course as a specific student.
-
 
 .. _Edit Components in a Library:
 

--- a/en_us/shared/building_and_running_chapters/developing_course/testing_courseware.rst
+++ b/en_us/shared/building_and_running_chapters/developing_course/testing_courseware.rst
@@ -1,4 +1,4 @@
-.. _Testing Your Course Content:
+f.. _Testing Your Course Content:
 
 ###########################
 Testing Your Course Content
@@ -120,9 +120,7 @@ You can view the course as a member of these groups.
         students.
     * - Specific Student
       - You see content that is intended for the student whose email or
-        username you specify. NOTE: Viewing content as a specific student is
-        not available for any content that is visible only to a particular
-        group (content groups and experiment groups).
+        username you specify. 
     * - Student in <Content Group Name>            
       - You see content that is intended for all students, as well
         as any content specifically set to be visible to this content group.
@@ -206,12 +204,13 @@ To switch to the **Student** view, click **View this course as** and select
 * You do not see sections or subsections that have not yet been released.
 
 * If the section and subsection are released, you see units that are
-  :ref:`Published and Live`. For units that are
-  :ref:`Draft (Unpublished Changes)`, you see the last published version of the
-  unit. 
+  :ref:`Published and Live`. For units that are :ref:`Draft (Unpublished
+  Changes)`, you see the last published version of the unit.
 
 * You do not see units that are :ref:`Draft (Never Published)` or
-  :ref:`Visible to Staff Only`. To see these units, you must switch back to Instructor view or use Preview mode as described in :ref:`Preview Course Content`.
+  :ref:`Visible to Staff Only`. To see these units, you must switch back to
+  Instructor view or use Preview mode as described in :ref:`Preview Course
+  Content`.
 
 * You can access the Instructor Dashboard, which has features and reports that
   help you run your course.
@@ -233,11 +232,6 @@ view the courseware as a specific student to see the actual problems that they
 were assigned. For details about adjusting grades or resetting attempts, see
 :ref:`Adjust_grades`.
 
-.. note:: You cannot use the **Specific student** view for any course content
-   that is visible only to certain groups. For example, if your course uses
-   cohorts or experiment groups, and some courseware is visible only to
-   learners in a particular content group or experiment group, you cannot see
-   that content when you view the live course as a specific student.
 
 To switch to the **Specific student** view, click **View this course as**.
 Select **Specific student** from the drop down list, and enter the username or
@@ -257,7 +251,8 @@ as.
   unit. 
 
 * You do not see units that are :ref:`Draft (Never Published)` or
-  :ref:`Visible to Staff Only`. To see these units, you must switch back to Staff view or use Preview mode as described in :ref:`Preview Course Content`.
+  :ref:`Visible to Staff Only`. To see these units, you must switch back to
+  Staff view or use Preview mode as described in :ref:`Preview Course Content`.
 
 * You can access the Instructor Dashboard, which has features and reports that
   help you run your course.

--- a/en_us/shared/exercises_tools/randomized_content_blocks.rst
+++ b/en_us/shared/exercises_tools/randomized_content_blocks.rst
@@ -296,12 +296,6 @@ In a live course, to view the components that are assigned to a specific
 student from a randomized content block, follow the steps described in the
 :ref:`Specific Student View` topic.
 
-.. note:: You cannot use the **Specific student** view for any course content
-   that is visible only to certain groups. For example, if your course uses
-   cohorts or experiment groups, and some courseware is visible only to
-   learners in a particular content group or experiment group, you cannot see
-   that content when you view the live course as a specific student.
-
 
 .. _Adjust Grades for a Problem from a Randomized Content Block:
 
@@ -311,7 +305,7 @@ Adjust Grades for a Problem from a Randomized Content Block
 
 To adjust a grade or reset the attempts for a problem that was assigned from a
 randomized content block, you can view the courseware as a specific student to
-see the actual problems that they were assigned. 
+see the actual problems that they were assigned.
 
 Obtain the username or email address for the learner whose grades you want to
 adjust, and follow the steps described in the :ref:`Specific Student View`


### PR DESCRIPTION
This PR removes notes to explain that you could not view any content limited by groups (cohorts or experiment groups) using the Preview as Specific Student feature. With the release of SOL-1064, preview as a specific student works for all content, including content that is limited to a content group (which can consist of multiple cohorts) or to an experiment group.
@antoviaque @mhoeber @pbaruah please review. Thanks!
FYI @griffresch 
