### PR TITLE
Add documentation for running the analytics devstack

### DIFF
--- a/en_us/install_operations/source/devstack/analytics_devstack.rst
+++ b/en_us/install_operations/source/devstack/analytics_devstack.rst
@@ -6,10 +6,10 @@
 Installing the Open edX Analytics Developer Stack
 #################################################
 
-This chapter is intended for those who are installing and running the Open edX
+This section is intended for those who are installing and running the Open edX
 Analytics Developer Stack.
 
-.. contents:: Chapter Contents:
+.. contents::
 
 
 **********
@@ -33,7 +33,7 @@ The Analytics Devstack includes the following additional components:
 
 Analytics Devstack also includes all components needed to run the edX
 Analytics Pipeline, the primary Extract Transform and Load (ETL) tool used to
-exctract and analyze data from the other Open edX services.
+extract and analyze data from the other Open edX services.
 
 **************************
 Software Prerequisites
@@ -43,24 +43,27 @@ To install and run the Analytics Devstack, you must first install the base
 :ref:`Open edX Developer Stack <Installing the Open edX Developer Stack>`.
 
 Open edX Analytics Pipeline includes a tool that is used to deploy itself.
-In order to make use of these tools, follow the instructions below.
+To make use of these tools, follow these steps.
 
 
-1. Clone the repository.
-
-  .. code-block:: bash
-
-     git clone https://github.com/edx/edx-analytics-pipeline
-
-
-2. Install the project dependencies.
+1. Clone the repository on your host, not on the Virtual Machine.
 
   .. code-block:: bash
 
-     make bootstrap
+     $ git clone https://github.com/edx/edx-analytics-pipeline
+
+
+2. Install the project dependencies into a virtualenv on your host.
+
+  .. code-block:: bash
+
+     $ cd edx-analytics-pipeline
+     $ virtualenv venv
+     $ source venv/bin/activate
+     $ make bootstrap
 
 The system is now ready to start running tasks on the Analytics Devstack
-using the `remote-task` tool.
+using the ``remote-task`` tool.
 
   
 .. _Install the Analytics Devstack:  
@@ -70,26 +73,26 @@ Install the Analytics Devstack
 ******************************
 
 To install the Analytics Devstack extensions directly from the command line,
-follow the instructions below.
+follow these steps.
 
-1. Navigate to the directory where you installed the base Open edX Devstack.
-
-  .. code-block:: bash
-
-     cd devstack
-
-#. Login to the base Open edX Devstack.
+1. Create the ``analyticstack`` directory and navigate to it in the command prompt.
    
    .. code-block:: bash
 
-     vagrant ssh
+     $ mkdir analyticstack
+     $ cd analyticstack
 
-#. Install the Analytics Devstack extensions.
+2. Download the Analytics Devstack Vagrant file.
    
    .. code-block:: bash
 
-     cd /edx/app/edx_ansible/edx_ansible/playbooks/edx-east
-     /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook -i localhost, -c local analytics_single.yml
+     $ curl -L https://raw.github.com/edx/configuration/master/vagrant/release/analyticstack/Vagrantfile > Vagrantfile
+
+3. Create the Analytics Devstack virtual machine.
+
+   .. code-block:: bash
+
+     $ vagrant up
 
 
 ****************************
@@ -100,114 +103,110 @@ Using the Analytics Devstack
 Run the Open edX LMS
 ====================
 
-#. Login to the base Open edX Devstack.
+1. Log in to the Analytics Devstack.
    
    .. code-block:: bash
 
-     vagrant ssh
+     $ vagrant ssh
 
-#. Switch to the edxapp user.
+2. Switch to the ``edxapp`` user.
    
    .. code-block:: bash
 
-     sudo su edxapp
+     $ sudo su edxapp
 
-#. Start the LMS.
+3. Start the LMS.
    
    .. code-block:: bash
      
-     paver devstack lms
+     $ paver devstack lms
 
 ===================================
 Run the Open edX Analytics Data API
 ===================================
 
-#. Login to the base Open edX Devstack.
+1. Log in to the base Open edX Devstack.
    
    .. code-block:: bash
 
-     vagrant ssh
+     $ vagrant ssh
 
-#. Switch to the analytics_api user.
+2. Switch to the ``analytics_api`` user.
    
    .. code-block:: bash
 
-     sudo usermod analytics_api -s /bin/bash
-     sudo su analytics_api
+     $ sudo su analytics_api
 
-#. Start the Data API.
+3. Start the Data API.
    
    .. code-block:: bash
 
-     cd /edx/app/analytics_api
-     . analytics_api_env
-     venvs/analytics_api/bin/python analytics_api/manage.py runserver 0.0.0.0:8100 --insecure
+     $ ~/venvs/analytics_api/bin/python ~/analytics_api/manage.py runserver 0.0.0.0:8100 --insecure
 
 =====================
 Run Open edX Insights
 =====================
 
-#. Login to the base Open edX Devstack.
+1. Log in to the base Open edX Devstack.
    
    .. code-block:: bash
 
-     vagrant ssh
+     $ vagrant ssh
 
-#. Switch to the insights user.
+2. Switch to the ``insights`` user.
    
    .. code-block:: bash
 
-     sudo usermod insights -s /bin/bash
-     sudo su insights
+     $ sudo su insights
 
-#. Enable features that are disabled by default.
+3. Enable features that are disabled by default.
 
    .. code-block:: bash
 
-    venvs/insights/bin/python edx_analytics_dashboard/manage.py switch display_verified_enrollment on --create
-    venvs/insights/bin/python edx_analytics_dashboard/manage.py switch enable_course_api on --create
+     $ ~/venvs/insights/bin/python ~/edx_analytics_dashboard/manage.py switch display_verified_enrollment on --create
+     $ ~/venvs/insights/bin/python ~/edx_analytics_dashboard/manage.py switch enable_course_api on --create
 
-#. Start Insights.
+4. Start Insights.
    
    .. code-block:: bash
 
-     cd /edx/app/insights
-     . insights_env
-     venvs/insights/bin/python edx_analytics_dashboard/manage.py runserver 0.0.0.0:8110 --insecure
+     $ ~/venvs/insights/bin/python ~/edx_analytics_dashboard/manage.py runserver 0.0.0.0:8110 --insecure
 
-#. Open the URL `http://127.0.0.1:8110` in a browser on the host. It is important to use the IP address `127.0.0.1` instead of `localhost`, using `localhost` will prevent you from being able to login.
+5. Open the URL ``http://127.0.0.1:8110`` in a browser on the host. It is important to use the IP address ``127.0.0.1`` instead of ``localhost``, using ``localhost`` will prevent you from being able to log in.
 
 ===================================
 Run the Open edX Analytics Pipeline
 ===================================
 
-#. Create a new user in the LMS and enroll in the demo course.
+1. Create a new user in the LMS and enroll in the demo course.
 
-#. Navigate to the courseware and submit answers to a few problems.
+2. Navigate to the courseware and submit answers to a few problems.
 
-#. Navigate to the location where edx-analytics-pipeline project was cloned on the host.
+3. Navigate to the location where edx-analytics-pipeline project was cloned on the host.
    
    .. code-block:: bash
 
-     cd edx-analytics-pipeline
+     $ cd edx-analytics-pipeline
 
-#. Run the enrollment task.
+4. Run the enrollment task.
    
    .. code-block:: bash
 
-     remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
+     # On Mac OS X replace the date command below with $(date -v+1d +%Y-%m-%d)
+     $ remote-task --vagrant-path <path to `analyticstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
         ImportEnrollmentsIntoMysql --local-scheduler --interval-end $(date +%Y-%m-%d -d "tomorrow") --n-reduce-tasks 1
 
-#. Run the answer distribution task.
+5. Run the answer distribution task.
 
    .. code-block:: bash
 
-    remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
+    $ export UNIQUE_NAME=$(date +%Y-%m-%dT%H:%M:%SZ)
+    $ remote-task --vagrant-path <path to `analyticstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
         AnswerDistributionWorkflow --local-scheduler \
           --src hdfs://localhost:9000/data/ \
           --include '*tracking.log*' \
-          --dest hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution_raw/dt=$(date +%Y-%m-%d -d "today")/data \
-          --name devstack_$(date +%Y-%m-%d -d "today") \
+          --dest hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution_raw/$UNIQUE_NAME/data \
+          --name $UNIQUE_NAME \
           --output-root hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution/ \
-          --marker hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution_raw/dt=$(date +%Y-%m-%d -d "today")/marker \
+          --marker hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution_raw/$UNIQUE_NAME/marker \
           --n-reduce-tasks 1

--- a/en_us/install_operations/source/devstack/analytics_devstack.rst
+++ b/en_us/install_operations/source/devstack/analytics_devstack.rst
@@ -192,16 +192,18 @@ Run the Open edX Analytics Pipeline
    
    .. code-block:: bash
 
+     $ export WHEEL_URL=http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise
      # On Mac OS X replace the date command below with $(date -v+1d +%Y-%m-%d)
-     $ remote-task --vagrant-path <path to `analyticstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
+     $ remote-task --vagrant-path <path to `analyticstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wheel-url $WHEEL_URL --wait \
         ImportEnrollmentsIntoMysql --local-scheduler --interval-end $(date +%Y-%m-%d -d "tomorrow") --n-reduce-tasks 1
 
 5. Run the answer distribution task.
 
    .. code-block:: bash
 
+    $ export WHEEL_URL=http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise
     $ export UNIQUE_NAME=$(date +%Y-%m-%dT%H:%M:%SZ)
-    $ remote-task --vagrant-path <path to `analyticstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
+    $ remote-task --vagrant-path <path to `analyticstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wheel-url $WHEEL_URL --wait \
         AnswerDistributionWorkflow --local-scheduler \
           --src hdfs://localhost:9000/data/ \
           --include '*tracking.log*' \

--- a/en_us/install_operations/source/devstack/analytics_devstack.rst
+++ b/en_us/install_operations/source/devstack/analytics_devstack.rst
@@ -202,7 +202,7 @@ Run the Open edX Analytics Pipeline
    .. code-block:: bash
 
     $ export WHEEL_URL=http://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise
-    $ export UNIQUE_NAME=$(date +%Y-%m-%dT%H:%M:%SZ)
+    $ export UNIQUE_NAME=$(date +%Y-%m-%dT%H_%M_%SZ)
     $ remote-task --vagrant-path <path to `analyticstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wheel-url $WHEEL_URL --wait \
         AnswerDistributionWorkflow --local-scheduler \
           --src hdfs://localhost:9000/data/ \

--- a/en_us/install_operations/source/devstack/analytics_devstack.rst
+++ b/en_us/install_operations/source/devstack/analytics_devstack.rst
@@ -42,23 +42,25 @@ Software Prerequisites
 To install and run the Analytics Devstack, you must first install the base
 :ref:`Open edX Developer Stack <Installing the Open edX Developer Stack>`.
 
-You also need to install the Open edX Analytics Configuration tools in order
-to run the Open edX Analytics Pipeline. To install the Open edX Analytics
-Configuration tools follow the instructions below.
+Open edX Analytics Pipeline includes a tool that is used to deploy itself.
+In order to make use of these tools, follow the instructions below.
 
 
 1. Clone the repository.
 
   .. code-block:: bash
 
-     git clone https://github.com/edx/edx-analytics-configuration
+     git clone https://github.com/edx/edx-analytics-pipeline
 
 
-#. Install the project dependencies.
+2. Install the project dependencies.
 
   .. code-block:: bash
 
-     make deps
+     make bootstrap
+
+The system is now ready to start running tasks on the Analytics Devstack
+using the `remote-task` tool.
 
   
 .. _Install the Analytics Devstack:  
@@ -181,24 +183,26 @@ Run the Open edX Analytics Pipeline
 
 #. Create a new user in the LMS and enroll in the demo course.
 
-#. Navigate to the location where edx-analytics-configuration project was cloned.
+#. Navigate to the courseware and submit answers to a few problems.
+
+#. Navigate to the location where edx-analytics-pipeline project was cloned on the host.
    
    .. code-block:: bash
 
-     cd edx-analytics-configuration
+     cd edx-analytics-pipeline
 
 #. Run the enrollment task.
    
    .. code-block:: bash
 
-     bin/remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/batch/config/devstack.cfg --wait \
+     remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
         ImportEnrollmentsIntoMysql --local-scheduler --interval-end $(date +%Y-%m-%d -d "tomorrow") --n-reduce-tasks 1
 
 #. Run the answer distribution task.
 
    .. code-block:: bash
 
-    bin/remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/batch/config/devstack.cfg --wait \
+    remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/config/devstack.cfg --wait \
         AnswerDistributionWorkflow --local-scheduler \
           --src hdfs://localhost:9000/data/ \
           --include '*tracking.log*' \

--- a/en_us/install_operations/source/devstack/analytics_devstack.rst
+++ b/en_us/install_operations/source/devstack/analytics_devstack.rst
@@ -1,0 +1,209 @@
+.. include:: ../links.rst
+
+.. _Installing the Open edX Analytics Developer Stack:
+
+#################################################
+Installing the Open edX Analytics Developer Stack
+#################################################
+
+This chapter is intended for those who are installing and running the Open edX
+Analytics Developer Stack.
+
+.. contents:: Chapter Contents:
+
+
+**********
+Overview
+**********
+
+The Open edX Analytics Developer stack is an extension to the :ref:`Open edX
+Developer Stack <Installing the Open edX Developer Stack>`.
+
+It provides all of the services and tools needed to extend the Open edX
+Analytics Pipeline, Data API and Insights projects.
+
+********************
+Components
+********************
+
+The Analytics Devstack includes the following additional components:
+
+* edX Analytics Data API
+* edX Insights
+
+Analytics Devstack also includes all components needed to run the edX
+Analytics Pipeline, the primary Extract Transform and Load (ETL) tool used to
+exctract and analyze data from the other Open edX services.
+
+**************************
+Software Prerequisites
+**************************
+
+To install and run the Analytics Devstack, you must first install the base
+:ref:`Open edX Developer Stack <Installing the Open edX Developer Stack>`.
+
+You also need to install the Open edX Analytics Configuration tools in order
+to run the Open edX Analytics Pipeline. To install the Open edX Analytics
+Configuration tools follow the instructions below.
+
+
+1. Clone the repository.
+
+  .. code-block:: bash
+
+     git clone https://github.com/edx/edx-analytics-configuration
+
+
+#. Install the project dependencies.
+
+  .. code-block:: bash
+
+     make deps
+
+  
+.. _Install the Analytics Devstack:  
+
+******************************
+Install the Analytics Devstack
+******************************
+
+To install the Analytics Devstack extensions directly from the command line,
+follow the instructions below.
+
+1. Navigate to the directory where you installed the base Open edX Devstack.
+
+  .. code-block:: bash
+
+     cd devstack
+
+#. Login to the base Open edX Devstack.
+   
+   .. code-block:: bash
+
+     vagrant ssh
+
+#. Install the Analytics Devstack extensions.
+   
+   .. code-block:: bash
+
+     cd /edx/app/edx_ansible/edx_ansible/playbooks/edx-east
+     /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook -i localhost, -c local analytics_single.yml
+
+
+****************************
+Using the Analytics Devstack
+****************************
+
+====================
+Run the Open edX LMS
+====================
+
+#. Login to the base Open edX Devstack.
+   
+   .. code-block:: bash
+
+     vagrant ssh
+
+#. Switch to the edxapp user.
+   
+   .. code-block:: bash
+
+     sudo su edxapp
+
+#. Start the LMS.
+   
+   .. code-block:: bash
+     
+     paver devstack lms
+
+===================================
+Run the Open edX Analytics Data API
+===================================
+
+#. Login to the base Open edX Devstack.
+   
+   .. code-block:: bash
+
+     vagrant ssh
+
+#. Switch to the analytics_api user.
+   
+   .. code-block:: bash
+
+     sudo usermod analytics_api -s /bin/bash
+     sudo su analytics_api
+
+#. Start the Data API.
+   
+   .. code-block:: bash
+
+     cd /edx/app/analytics_api
+     . analytics_api_env
+     venvs/analytics_api/bin/python analytics_api/manage.py runserver 0.0.0.0:8100 --insecure
+
+=====================
+Run Open edX Insights
+=====================
+
+#. Login to the base Open edX Devstack.
+   
+   .. code-block:: bash
+
+     vagrant ssh
+
+#. Switch to the insights user.
+   
+   .. code-block:: bash
+
+     sudo usermod insights -s /bin/bash
+     sudo su insights
+
+#. Enable features that are disabled by default.
+
+   .. code-block:: bash
+
+    venvs/insights/bin/python edx_analytics_dashboard/manage.py switch display_verified_enrollment on --create
+    venvs/insights/bin/python edx_analytics_dashboard/manage.py switch enable_course_api on --create
+
+#. Start Insights.
+   
+   .. code-block:: bash
+
+     cd /edx/app/insights
+     . insights_env
+     venvs/insights/bin/python edx_analytics_dashboard/manage.py runserver 0.0.0.0:8110 --insecure
+
+#. Open the URL `http://127.0.0.1:8110` in a browser on the host. It is important to use the IP address `127.0.0.1` instead of `localhost`, using `localhost` will prevent you from being able to login.
+
+===================================
+Run the Open edX Analytics Pipeline
+===================================
+
+#. Create a new user in the LMS and enroll in the demo course.
+
+#. Navigate to the location where edx-analytics-configuration project was cloned.
+   
+   .. code-block:: bash
+
+     cd edx-analytics-configuration
+
+#. Run the enrollment task.
+   
+   .. code-block:: bash
+
+     bin/remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/batch/config/devstack.cfg --wait \
+        ImportEnrollmentsIntoMysql --local-scheduler --interval-end $(date +%Y-%m-%d -d "tomorrow") --n-reduce-tasks 1
+
+#. Run the answer distribution task.
+
+   .. code-block:: bash
+
+    bin/remote-task --vagrant-path <path to `devstack`> --remote-name devstack --override-config ${PWD}/batch/config/devstack.cfg --wait \
+        AnswerDistributionWorkflow --local-scheduler \
+          --src hdfs://localhost:9000/data/ \
+          --include '*tracking.log*' \
+          --dest hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution_raw/dt=$(date +%Y-%m-%d -d "today")/data \
+          --name devstack_$(date +%Y-%m-%d -d "today") \
+          --output-root hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution/ \
+          --marker hdfs://localhost:9000/edx-analytics-pipeline/output/answer_distribution_raw/dt=$(date +%Y-%m-%d -d "today")/marker \
+          --n-reduce-tasks 1

--- a/en_us/install_operations/source/index.rst
+++ b/en_us/install_operations/source/index.rst
@@ -27,6 +27,7 @@ Release>`.
    install_options
    devstack/install_devstack
    devstack/run_devstack
+   devstack/analytics_devstack
    fullstack/install_fullstack
    configuration/index
    analytics/install_analytics


### PR DESCRIPTION
Document the procedure users can execute to run a development environment for the analytics stack. Note that this PR depends on the following PRs in other repos ->

This PR allows you to deploy the analytics stack to a devstack: https://github.com/edx/configuration/pull/2176

This PR allows you to run the analytics pipeline on a devstack: https://github.com/edx/edx-analytics-pipeline/pull/135
