### PR TITLE
Further reduces prominence of ORA 1 for events

### DIFF
--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -212,16 +212,6 @@ M, N, O
      - Description
    * - ``modify_access``
      - :ref:`Instructor_Event_Types`
-   * - ``oe_feedback_response_selected``
-     - :ref:`ora`
-   * - ``oe_hide_question``
-     - :ref:`ora`
-   * - ``oe_show_full_feedback``
-     - :ref:`ora`
-   * - ``oe_show_question``
-     - :ref:`ora`
-   * - ``oe_show_respond_to_feedback``
-     - :ref:`ora`
    * - ``openassessmentblock.get_peer_submission``
      - :ref:`ora2`
    * - ``openassessmentblock.peer_assess``
@@ -255,10 +245,6 @@ P, Q, R
      - :ref:`navigational`
    * - ``pause_video``
      - :ref:`video`
-   * - ``peer_grading_hide_question``
-     - :ref:`ora`
-   * - ``peer_grading_show_question``
-     - :ref:`ora`
    * - ``play_video``
      - :ref:`video`
    * - ``problem_check``
@@ -295,8 +281,6 @@ P, Q, R
      - :ref:`problem`
    * - ``reset-student-attempts``
      - :ref:`Instructor_Event_Types`
-   * - ``rubric_select``
-     - :ref:`ora`
 
 .. _ST:
 
@@ -328,10 +312,6 @@ S, T
      - :ref:`video`
    * - ``speed_change_video``
      - :ref:`video`
-   * - ``staff_grading_hide_question``
-     - :ref:`ora`
-   * - ``staff_grading_show_question``
-     - :ref:`ora`
    * - ``stop_video``
      - :ref:`video`
    * - ``textbook.pdf.chapter.navigated``

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -3914,10 +3914,13 @@ Instructor Dashboard, the server emits an ``edx.cohort.user_removed`` event.
 Open Response Assessment Events (Deprecated)
 ============================================
 
-**History**: The events in this section recorded interactions with the
-prototype implementation of open response assessment (ORA) problem types. As of
-May 2014, new courses no longer used this implementation for open response
-assessments.
+The events described in this section recorded interactions with the prototype
+implementation of open response assessment (ORA 1) problem types. EdX
+deprecated this feature in May 2014, and removed the ability to add a new ORA 1
+assignment to courses in December 2014.
+
+For more information about events for the current implementation of open
+response assessments, see :ref:`ora2`.
 
 ``oe_hide_question`` and ``oe_show_question``
 ******************************************************************
@@ -4003,9 +4006,7 @@ user hides or redisplays a combined open-ended problem.
 ``peer_grading_hide_question`` and ``peer_grading_show_question``
 ******************************************************************
 
-.. I couldn't find these names in any js file. peer_grading_problem.js includes oe_hide or show_question.
-
-The browser emits ``peer_grading_hide_question`` and
+The browser emits ``peer_grading_hide_question`` and 
 ``peer_grading_show_question`` events when the user hides or redisplays a
 problem that is peer graded.
 
@@ -4032,9 +4033,7 @@ and ``peer_grading_show_problem``.
 ``staff_grading_hide_question`` and ``staff_grading_show_question``
 ********************************************************************
 
-.. staff_grading.js
-
-The browser emits ``staff_grading_hide_question`` and
+The browser emits ``staff_grading_hide_question`` and 
 ``staff_grading_show_question`` events when the user hides or redisplays a
 problem that is staff graded.
 


### PR DESCRIPTION
@explorerleslie I've been meaning to do this for a while. Strips the ORA1 events out of an alphabetized list of reference links, and provides date deprecated as well as completely removed. DOC-430
@catong or @srpearce if you'd be so kind as to check the changes for compliance...
