### PR TITLE
Enrollment count is now only in Insights for partners

### DIFF
--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -36,6 +36,10 @@ August 2015
    * - 
      - Updated the :ref:`Course Data` topic to include descriptions of newly
        added values.
+   * - 
+     - Updated the :ref:`Enrollment` section to remove references to enrollment
+       counts on the Instructor Dashboard. Course enrollment data is available
+       in edX Insights.
    * - 12 August 2015
      - Added the :ref:`Qualtrics Survey` topic.
    * - 5 Aug 2015

--- a/en_us/shared/building_and_running_chapters/running_course/Section_view_enrollment_count.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/Section_view_enrollment_count.rst
@@ -1,0 +1,38 @@
+.. Applies to open edX installations only, feature has been turned off for edx.org and Edge (the data is available in Insights instead).
+.. DOC-2218 A. Hodges 24 Aug 2015
+
+.. _view_enrollment_count:
+
+*************************
+View an Enrollment Count
+*************************
+
+After you create a course, you can access the total number of people who are
+enrolled in it. Note the following information about how this count is
+computed.
+
+* In addition to learners, the enrollment count includes all course team
+  members, including Admins and Staff. (To work with a course in Studio, the
+  LMS, or Insights, you must be enrolled in that course.)
+
+* The enrollment count displays the number of currently enrolled learners and
+  course team members. It is not a historical count of everyone who has ever
+  enrolled in the course.
+
+  .. note:: Learners can unenroll from courses, and course Admins and Staff 
+   can unenroll learners when necessary.
+
+The total number of current enrollees is shown as the sum of the number of
+people who selected each of the certification tracks (verified, professional,
+or honor) that is available for your course.
+
+To view the enrollment count for a course, follow these steps.
+
+#. View the live version of your course.
+
+#. Select **Instructor**, and then select **Course Info** if necessary. 
+
+  The **Enrollment Information** section of the page that opens shows the
+  number of people who are currently enrolled in your course and in each of
+  the certification tracks.
+

--- a/en_us/shared/building_and_running_chapters/running_course/course_enrollment.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/course_enrollment.rst
@@ -4,24 +4,37 @@
 Enrollment
 ##########################
 
-The course creator, and course team members with the Staff and Admin roles, can
-enroll learners in a course, see how many people are enrolled, and, when
-necessary, unenroll learners on the Instructor Dashboard.
-
 Learners can enroll themselves in a course during its defined enrollment
 period. For a ``www.edx.org`` course, enrollment is publicly available to
 anyone who registers an edX account. For other courses, such as those on
 ``edge.edx.org``, enrollment is limited to learners who know the course URL
 and learners you explicitly enroll.
 
+The course creator and course team members with the Staff and Admin roles can
+enroll learners in a course. These course team members can also unenroll
+learners.
+
+.. Feature availability on the instructor dash applies to open edX installations only.
+.. DOC-2218 A. Hodges 24 Aug 2015
+
+.. only:: Open_edX
+
+  Data about course enrollment is available from the Instructor Dashboard and
+  from Insights. For more information, see :ref:`view_enrollment_count`.
+
 .. contents:: Section Contents:
   :local:
   :depth: 1
 
-Data about course enrollment is also available from edX Insights. You access
-Insights from the Instructor Dashboard for your live course: after you select
-**Instructor**, follow the link in the banner at the top of each page. For more
-information, see `Using edX Insights`_.
+.. Feature has been turned off for edx.org and Edge (the data is available in Insights instead).
+.. DOC-2218 A. Hodges 24 Aug 2015
+
+.. only:: Partners
+
+  Data about course enrollment is available from edX Insights. You can access
+  Insights from the Instructor Dashboard for your live course: after you select
+  **Instructor**, follow the link in the banner at the top of each page. For
+  more information, see `Using edX Insights`_.
 
 .. _registration_enrollment:
 
@@ -58,7 +71,7 @@ supplying their email addresses. After the **Enrollment End Date** for a
 course learners can no longer enroll themselves; however, you can still
 explicitly enroll learners.
 
-When you enroll people in a course you have these options:
+When you enroll people in a course, you have the following options.
 
 * **Auto Enroll**. When you choose this option, the people who you enroll do
   not need to complete an explicit course enrollment step. Of the list of email
@@ -117,47 +130,17 @@ To enroll learners or course team members, follow these steps.
 
    .. note:: If your course has a fee, and an organization wants to purchase 
     enrollment for multiple seats in your course at one time, you can create
-    *enrollment codes* for the organization. The organization then distributes
+    enrollment codes for the organization. The organization then distributes
     these enrollment codes to its learners to simplify the enrollment process.
     You can also create coupon codes to give learners a discount when they
     enroll in your course. For more information, see :ref:`Manage Course Fees`.
 
-.. _view_enrollment_count:
+.. only:: Open_edX
 
-***************************
-View an Enrollment Count
-***************************
+   .. include:: ../../../shared/building_and_running_chapters/running_course/Section_view_enrollment_count.rst
 
-After you create a course, you can access the total number of people who are
-enrolled in it. When you view an enrollment count, note the following
-
-* In addition to learners, the enrollment count includes all course team
-  members, including Admins and Staff. (To work with a course in Studio, the
-  LMS, or Insights, you must be enrolled in that course.)
-
-* Learners can unenroll from courses, and course Admins and Staff can
-  unenroll learners when necessary.
-
-  **Note**: The enrollment count displays the number of currently enrolled
-  learners and course team members. It is not a historical count of everyone
-  who has ever enrolled in the course.
-
-The total number of current enrollees is shown as the sum of the number of
-people who selected each of the certification tracks (verified, professional,
-or honor) that are available for your course.
-
-To view the enrollment count for a course, follow these steps.
-
-#. View the live version of your course.
-
-#. Select **Instructor**, and then select **Course Info** if necessary. 
-
-  The **Enrollment Information** section of the page that opens shows the
-  number of people who are currently enrolled in your course and in each of the
-  certification tracks.
-
-You can also view or download a list of the people who are enrolled in the
-course. See :ref:`Student Data`.
+You can view or download a list of the people who are enrolled in the course.
+See :ref:`Student Data`.
 
 .. _view_not_yet_enrolled:
 
@@ -199,13 +182,13 @@ Unenroll Learners from a Course
 *********************************
 
 You can remove learners from a course by unenrolling them. To prevent learners
-from re-enrolling, course enrollment must also be closed. You use Studio to
-set the **Enrollment End Date** for the course to a date in the past. See
-:ref:`Scheduling Your Course`.
+from re-enrolling, course enrollment must also be closed. You use Studio to set
+the **Enrollment End Date** for the course to a date in the past. For more
+information, see :ref:`Scheduling Your Course`.
 
-**Note**: Unenrollment does not delete data for a learner. An unenrolled
-learner's state remains in the database and is reinstated if the learner does
-re-enroll.
+.. note:: Unenrollment does not delete data for a learner. An unenrolled
+   learner's state remains in the database and is reinstated if the learner
+   does re-enroll.
 
 To unenroll learners, you supply the email addresses of enrolled learners. 
 
@@ -220,11 +203,12 @@ To unenroll learners, you supply the email addresses of enrolled learners.
 #. To send learners an email message, leave **Notify students by email**
    selected.
 
-.. note:: The **Auto Enroll** option has no effect when you select
- **Unenroll**.
+   .. note:: The **Auto Enroll** option has no effect when you select
+     **Unenroll**.
 
 5. Select **Unenroll**. The course is no longer listed on the learners'
-   **Current Courses** dashboards, and the learners can no longer contribute to
-   discussions or the wiki or access the courseware.
+   **Current Courses** dashboards, and the learners can no longer access the
+   courseware or contribute to discussions or the wiki.
+
 
 .. _Using edX Insights: http://edx-insights.readthedocs.org/en/latest/


### PR DESCRIPTION
@dsjen @WatsonEmily  @mhoeber @catong 
DOC-1158, AN-4582
Whether or not enrollment counts are shown on the Instructor dashboard is now controlled by a feature flag. For edx.org and Edge, DevOps will change this feature flag and remove enrollment counts from the Instructor dashboard. Teams will be redirected to Insights, where the same enrollment count, calculated on a slightly different schedule, will be available along with additional metrics. We expect this change to be available next week. 
Enrollment counts will remain available on the Instructor dash for Open EdX sites unless a site changes the setting of a feature flag. The expectation is that until the Analytics pipeline and Insights are easier to set up, sites will keep this flag set as is.
@srpearce FYI another feature flag.
