### PR TITLE
Rewords references to Open edX releases

### DIFF
--- a/en_us/install_operations/source/birch.rst
+++ b/en_us/install_operations/source/birch.rst
@@ -86,7 +86,7 @@ Vagrant box directly or by running ``vagrant up`` when installing
 :ref:`Devstack <Installing the Open edX Developer Stack>` or
 :ref:`Fullstack <Installing Open edX Fullstack>`.
 
-See the `Open edX Named Releases Wiki page`_ to access the latest Vagrant
+See the `Open edX Releases Wiki page`_ to access the latest Vagrant
 boxes.
 
 See `Vagrant's documentation on boxes`_ for more information.
@@ -103,7 +103,7 @@ connection is temporarily lost while you are downloading the Vagrant box
 through BitTorrent, you can later continue the download without data loss or
 corruption.
 
-See the `Open edX Named Releases Wiki page`_ to access the latest Vagrant
+See the `Open edX Releases Wiki page`_ to access the latest Vagrant
 boxes.
 
 See `BitTorrent`_ for more information.

--- a/en_us/install_operations/source/configuration/youtube_api.rst
+++ b/en_us/install_operations/source/configuration/youtube_api.rst
@@ -68,7 +68,7 @@ To set your YouTube API key in Ansible's configuration file, complete the follow
 #. Save and close the file.
 
 #. Run Ansible so that it applies your YouTube API key to your Open edX
-   installation. If you are running the Cypress named release, run the
+   installation. If you are running the Open edX Cypress release, run the
    following command.
 
    .. code-block:: bash

--- a/en_us/install_operations/source/cypress.rst
+++ b/en_us/install_operations/source/cypress.rst
@@ -85,7 +85,7 @@ Vagrant box directly or by running ``vagrant up`` when installing
 :ref:`Devstack <Installing the Open edX Developer Stack>` or
 :ref:`Fullstack <Installing Open edX Fullstack>`.
 
-See the `Open edX Named Releases Wiki page`_ to access the latest Vagrant
+See the `Open edX Releases Wiki page`_ to access the latest Vagrant
 boxes.
 
 See `Vagrant's documentation on boxes`_ for more information.
@@ -101,7 +101,7 @@ connection is temporarily lost while you are downloading the Vagrant box
 through BitTorrent, you can later continue the download without data loss or
 corruption.
 
-See the `Open edX Named Releases Wiki page`_ to access the latest Vagrant
+See the `Open edX Releases Wiki page`_ to access the latest Vagrant
 boxes.
 
 See `BitTorrent`_ for more information.

--- a/en_us/install_operations/source/index.rst
+++ b/en_us/install_operations/source/index.rst
@@ -14,9 +14,8 @@ associated applications.
 This document applies to the most recent version of the Open edX Platform; that
 is, it applies to the *master* branch of the edX Platform.
 
-This document also contains instructions for instaling named releases of Open
-edX. The most recent named release of Open edX is :ref:`Cypress <Open edX
-Cypress Release>`.
+This document also contains instructions for installing Open edX releases. The
+most recent release of Open edX is :ref:`Cypress <Open edX Cypress Release>`.
 
 .. toctree::
    :numbered:

--- a/en_us/install_operations/source/links.rst
+++ b/en_us/install_operations/source/links.rst
@@ -1,4 +1,4 @@
-.. _Open edX Named Releases Wiki page: https://openedx.atlassian.net/wiki/display/DOC/Named+Releases
+.. _Open edX Releases Wiki page: https://openedx.atlassian.net/wiki/display/DOC/Open+edX+Releases
 
 .. _YouTube Data API v3: https://developers.google.com/youtube/v3/
 .. _instructions for obtaining authorization credentials: https://developers.google.com/youtube/registering_an_application

--- a/en_us/open_edx_release_notes/source/index.rst
+++ b/en_us/open_edx_release_notes/source/index.rst
@@ -2,8 +2,7 @@
 Open edX Release Notes
 ####################################
 
-The *Open edX Release Notes* provide information about the Open edX named
-releases.
+The *Open edX Release Notes* provide information about the Open edX releases.
 
 .. toctree::
    :numbered:

--- a/en_us/release_notes/source/coming_soon.rst
+++ b/en_us/release_notes/source/coming_soon.rst
@@ -22,9 +22,9 @@ conference.
 Open edX Dogwood Release
 *********************************
 
-The next named release for Open edX, Dogwood, is scheduled for release in late
-November 2015. To stay up to date about the expected contents and progress of
-the release, refer to the `Open edX wiki page for Dogwood`_.
+The next release for Open edX, Dogwood, is scheduled for late November 2015. To
+stay up to date about the expected contents and progress of the release, refer
+to the `Open edX wiki page for Dogwood`_.
 
 
 


### PR DESCRIPTION
@jbarciauskas @mhoeber please take a look. I did not change any references to commands or file locations (save the wiki page), only inline use of “named release”. Fixes DOC-2228.
