### PR TITLE
DOC-1954 Glossary additions

### DIFF
--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -308,6 +308,17 @@ E
 
   For more information, see `What is Studio?`_.
 
+.. _embargo:
+
+**Embargo**
+
+  An embargo is an official ban on trade or commercial activity with a
+  particular country. For example, due to U.S. federal regulations, edX cannot
+  offer certain courses (for example, particular advanced STEM courses) on the
+  edx.org website to learners in embargoed countries. Learners cannot access
+  restricted courses from an embargoed country. In some cases, depending on the
+  terms of the embargo, learners cannot access any edX courses at all.
+
 
 .. _Exercises:
 
@@ -816,6 +827,21 @@ V
 W
 ****
 
+.. _Whitelist:
+
+**Whitelist**
+
+  In edX courses, a whitelist is a list of learners who are being provided with
+  a particular privilege. For example, whitelisted learners can be specified as
+  being eligible to receive a certificate in a course, regardless of whether
+  they would otherwise have qualified based on their grade.
+
+  In the grade report for a course, whitelisted learners have a value of "Yes"
+  in the **Certificate Eligible** column, regardless of the grades they
+  attained. For information about the grade report, see `Interpret the Grade
+  Report`_.
+
+
 .. _Wiki:
 
 **Wiki**
@@ -904,3 +930,4 @@ XYZ
 .. _LON-CAPA: http://www.lon-capa.org/
 .. _Open Response Assessments: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html
 .. _Adding a Pre-Roll Video: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/create_video.html#adding-a-pre-roll-video
+.. _Interpret the Grade Report: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/running_course/course_grades.html#access-grades


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DOC-1954
Add "whitelist" and "embargo" to the glossary as they are used in explaining what values might occur in what situation in the "Certificate Eligible" column of the grade report.
@explorerleslie Can you take a quick first look, please? Thanks!
