### PR TITLE
LTI Tool provider setup

### DIFF
--- a/en_us/install_operations/source/configuration/index.rst
+++ b/en_us/install_operations/source/configuration/index.rst
@@ -20,5 +20,6 @@ configuration options.
    enable_badging
    enable_ccx
    tpa/index
+   lti/index
    youtube_api
    ora2_uploads

--- a/en_us/install_operations/source/configuration/lti/configure_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/configure_lti.rst
@@ -1,0 +1,61 @@
+.. _Configuring Credentials for a Tool Consumer:
+
+###############################################################
+Configuring Credentials for a Tool Consumer
+###############################################################
+
+For each external learning management system or application (external LMS) that
+you want to allow access to your edX instances as an LTI tool consumer, you
+create OAuth1 credentials, and then configure your edX instance to allow
+access. Each external LMS that you :ref:`configure as a tool consumer
+<Configure the Tool Consumer>` must have separate credentials.
+
+.. Commenting out the following option until we understand it better, per Dave Ormsbee - Alison 8 Sep 15
+
+.. While each external LMS that you configure as a tool consumer must have separate credentials, you can also choose to create and configure more than one set of credentials for each system.
+
+.. For example, you can configure a single set of credentials for your campus LMS, or you can configure unique credentials for every course that embeds edX content on that remote LMS. The first approach results in faster configuration time. However, the second approach can lessen the disruption and reconfiguration that might result if you have to revoke access for a single course at a later time.
+
+After you complete the configuration of a tool consumer on your edX system, you
+can add the consumer credentials to your external LMS. For examples of how
+course teams might set up a course on an external LMS as a consumer of edX
+course content, see `Using edX as an LTI Tool Provider`_ in the *Building and
+Running an edX Course* guide.
+
+.. _Configure the Tool Consumer:
+
+*********************************
+Configure the Tool Consumer
+*********************************
+
+To configure an LTI tool consumer to have access to your Open edX installation,
+follow these steps.
+
+#. Sign in to the Django administration console for your base URL. For example,
+   ``http://{your_URL}/admin``.
+
+#. In the **LTI Provider** section, next to **LTI Consumers** select
+   **Add**.
+
+#. Enter the following information.
+
+  - **Consumer Name**: An identifying name for the tool consumer.
+
+  - **Consumer Key**: The console generates a unique key value for this
+    tool consumer. Alternatively, you can use an external application to
+    generate the key, and then enter it here.
+  
+  - **Consumer Secret**: The console generates a unique secret value for this
+    tool consumer. Alternatively, you can use an external application to
+    generate the secret, and then enter it here.
+
+  .. important:: Do not supply a value for the **Instance guid** field. The 
+   tool consumer generates and supplies a globally unique identifier.
+
+5. Select **Save** at the bottom of the page.
+
+
+.. include:: ../../links.rst
+
+
+

--- a/en_us/install_operations/source/configuration/lti/enable_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/enable_lti.rst
@@ -1,0 +1,39 @@
+.. _Enable LTI Provider Functionality:
+
+#################################################
+Enable LTI Provider Functionality
+#################################################
+
+LTI provider functionality is provided in the ``lti_provider`` app, located in
+``edx-platform/lms/djangoapps/lti_provider``.
+
+By default, the ``lti_provider`` app is not used by edX installations. To
+enable this functionality throughout the platform, follow these steps.
+
+#. In the ``edx/app/edxapp/lms.env.json`` file, edit the file so that it
+   includes the following line in the features section.
+
+   .. code-block:: json
+
+       "FEATURES" : {
+           ...
+           "ENABLE_LTI_PROVIDER": true
+       }
+
+#. Save the ``edx/app/edxapp/lms.env.json`` file.
+
+#. Run database migrations.
+
+#. Restart the LMS server.
+
+To verify that the LTI provider functionality is enabled, you can check for the
+presence of the following database tables.
+
+::
+
+  lti_provider_gradedassignment
+  lti_provider_lticonsumer
+  lti_provider_ltiuser
+  lti_provider_outcomeservice
+
+If these tables are not present, check that the migrations have run properly.

--- a/en_us/install_operations/source/configuration/lti/index.rst
+++ b/en_us/install_operations/source/configuration/lti/index.rst
@@ -1,0 +1,28 @@
+.. _Configuring an edX Instance as an LTI Tool Provider:
+
+########################################################
+Configuring an edX Instance as an LTI Tool Provider
+########################################################
+
+You can configure your edX instance to be a learning tool interoperability
+(LTI) provider to other systems and applications. You can use this LTI
+capability to present content from an edX course in any application that is
+configured to be a consumer of that content. After you enable your edX instance
+as an LTI tool provider and configure credentials for the tool consumers,
+course teams can reuse course content from the edX instance in contexts other
+than the edX LMS.
+
+.. toctree::
+   :maxdepth: 1
+
+   enable_lti
+   configure_lti
+   settings_lti
+
+For more information and examples of how course teams might set up a course on
+an external LMS as a consumer of edX course content, see `Using edX as an LTI
+Tool Provider`_ in the *Building and Running an edX Course* guide.
+
+
+.. include:: ../../links.rst
+

--- a/en_us/install_operations/source/configuration/lti/settings_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/settings_lti.rst
@@ -1,0 +1,35 @@
+.. _Define Interval for Grade Aggregation:
+
+####################################################
+Define an Interval for Grade Aggregation (Optional)
+####################################################
+
+When an external LMS links to problem components in a graded edX subsection,
+the edX system grades the answers to those problems, and then transfers the
+grades back to the external LMS.
+
+* If the link is to an individual problem component on the edX system, the edX
+  system returns the grade for each learner immediately.
+
+* If the link is to a unit or subsection, you can configure an interval of time
+  for the edX system to delay before returning the grades. The edX system
+  aggregates all of the problems in the unit or subsection that the learner
+  answers during that interval. Aggregating grades can reduce the number of
+  notification messages that learners receive.
+
+By default, the edX system aggregates grades for units and subsections every 15
+minutes.
+
+To change the interval for returning aggregated grades, follow these steps. 
+
+#. In ``edx/app/edxapp/lms.env.json``, change the value for the following
+   parameter.
+   
+   ``LTI_AGGREGATE_SCORE_PASSBACK_DELAY = 15 * 60``
+
+   You specify a time value in seconds.
+
+#. Save the ``/lms/envs/common.py`` file.
+
+#. Restart the Learning Management System processes so that the
+   updated environment configurations are loaded.

--- a/en_us/install_operations/source/front_matter/change_log.rst
+++ b/en_us/install_operations/source/front_matter/change_log.rst
@@ -3,11 +3,14 @@ Change Log
 ############
 
 .. list-table::
-   :widths: 20 70
+   :widths: 30 70
    :header-rows: 1
 
    * - Date
      - Change
+   * - 15 September 2015
+     - Added the :ref:`Configuring an edX Instance as an LTI Tool Provider`
+       section.
    * - 10 August 2015
      - Added the :ref:`Open edX Cypress Release` section.
    * -

--- a/en_us/install_operations/source/links.rst
+++ b/en_us/install_operations/source/links.rst
@@ -98,3 +98,5 @@
 .. _python-social-auth backend documentation: http://python-social-auth.readthedocs.org/en/latest/backends/index.html#social-backends
 
 .. _Python SAML Toolkit: https://github.com/onelogin/python-saml
+
+.. _Using edX as an LTI Tool Provider: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/lti/index.html#using-edx-as-an-lti-tool-provider


### PR DESCRIPTION
## [DOC-2168](https://openedx.atlassian.net/browse/DOC-2168)

Adds specific procedures for enabling the edX as LTI tool provider feature on an edX instance, and configuring credentials for tool consumers. (This does not include procedures for setting up edX as an LTI authentication provider.)
## Date Needed

Feature is already released. Procedures are based on Kevin's work on Edge completed earlier this week. High interest level in the open source community.
## Reviewers
- [x] Subject matter expert: @ormsbee 
- [x] Subject matter expert: @jibsheet 
- [x] Doc team review: @catong or @srpearce 
- [ ] Product review: @ebporter

FYI: @mhoeber, @sarina 
### Testing
- [X] make html ran without unexpected errors
### Post-review
- [x] Squash commits
- [x] Add description to release notes task as a comment
- [x] Update change log
