### PR TITLE
Documenting COURSE_DISCOVERY_FILTERS setting

### DIFF
--- a/en_us/install_operations/source/configuration/edx_search.rst
+++ b/en_us/install_operations/source/configuration/edx_search.rst
@@ -191,6 +191,14 @@ LMS
 
 * ``ENABLE_COURSE_DISCOVERY``: Enables/disables Course Discovery feature (over
   courses searching and facet filtering)
+ 
+* ``COURSE_DISCOVERY_FILTERS``: If provided, overrides the list of facets 
+  that are used in Course Discovery feature to filter the results.
+  By default, all facets will be displayed. List of available facets includes:
+  
+  * Course organization: ``"org"``
+  * Course type: ``"modes"``
+  * Course language: ``"language"``
 
 * ``SEARCH_ENGINE``: Sets used search engine. There are 2 predefined values,
   but more can be added:


### PR DESCRIPTION
@srpearce, @catong Could you please take a look at the update I did?

I added a reference to `COURSE_DISCOVERY_FILTERS` into documentation so that the Open Source Community members could be aware of it, in case they need to override the filtering facets available in Course Discovery feature.
