### PR TITLE
Correct description of how Edge and edx-lti.org interact

### DIFF
--- a/en_us/shared/building_and_running_chapters/building_course/lti/lti_address_content.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/lti/lti_address_content.rst
@@ -10,7 +10,7 @@ then format the identifiers into an LTI URL.
 
 .. contents:: 
    :local:
-   :depth: 1
+   :depth: 2
 
 Using a tool like a spreadsheet can be helpful to organize the course ID and
 the usage IDs that correspond to each piece of course content you want to

--- a/en_us/shared/building_and_running_chapters/building_course/lti/lti_prepare_content.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/lti/lti_prepare_content.rst
@@ -10,8 +10,7 @@ Preparing to Reuse Course Content
   you create a duplicate version of the course. You use the duplicate course
   specifically as a source of content for your external LMS. Based on
   configuration choices your organization makes for using edX as an LTI tool
-  provider, you might be asked to create the duplicate course on edX Edge, on
-  the ``edx-lti.org`` site, or on another host site.
+  provider, you might be asked to create the duplicate course on edX Edge or on another host site.
 
 .. only:: Open_edX
 
@@ -83,11 +82,12 @@ To create the duplicate course, follow these steps.
 #. In Studio on edX Edge, export the course. For more information, see
    :ref:`Export a Course`.
    
-#. In Studio on your organization's host site for LTI courses, create a course.
-   This is the duplicate course.
+#. In Studio on your organization's host site for LTI courses (either edX Edge
+   or your organization's own LTI site), create a course. This is the duplicate
+   course.
    
    .. note:: If your organization uses edX Edge as the host site, be sure to
-    give the duplicate course a different name or run.
+    give the duplicate course a different, distinguishing name or run.
 
 #. In the duplicate course, import the tar.gz file that you exported in step 1.
    For more information, see :ref:`Import a Course`.


### PR DESCRIPTION
@jibsheet and @srpearce please take a quick look at this correction for me. 
The doc should not give the impression that edx-lti.org acts as the host site for any courses. Either Edge or an open source instance set up by the partner org will be the host.
