### PR TITLE
Adds problem-answer report and interpretation for submission history

### DIFF
--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -26,6 +26,10 @@ September 2015
      - Added the :ref:`View the Course Structure API for the Usage ID` topic.
    * -
      - Added the :ref:`Setting Up Course Certificates` topic.
+   * - 
+     - Updated the :ref:`Student_Answer_Submission` section to include topics
+       about the downloadable student state report and the submission history
+       report.
    * - 2 September 2015
      - Added the :ref:`Using edX as an LTI Tool Provider` section.
 

--- a/en_us/open_edx_course_authors/source/front_matter/change_log.rst
+++ b/en_us/open_edx_course_authors/source/front_matter/change_log.rst
@@ -8,12 +8,16 @@ September 2015
 ****************
 
 .. list-table::
-   :widths: 15 70
+   :widths: 30 70
    :header-rows: 1
 
    * - Date
      - Change
-   * - 2 Sep 2015
+   * - 9 September 2015
+     - Updated the :ref:`Student_Answer_Submission` section to include topics
+       about the downloadable student state report and the submission history
+       report.
+   * - 2 September 2015
      - Added the :ref:`Setting Up Course Certificates` topic.
 
 
@@ -22,12 +26,11 @@ August 2015
 ****************
 
 .. list-table::
-   :widths: 15 70
+   :widths: 30 70
    :header-rows: 1
 
    * - Date
      - Change
-
    * - 26 August 2015
      - Several additions were made to provide information about awarding
        partial credit for problems.
@@ -54,7 +57,7 @@ July 2015
 ****************
 
 .. list-table::
-   :widths: 15 70
+   :widths: 30 70
    :header-rows: 1
 
    * - Date
@@ -78,7 +81,6 @@ July 2015
        and hints in common problems.
        
        * :ref:`Adding Feedback and Hints to a Problem`
-       
        * :ref:`Use Feedback in a Checkbox Problem`
        * :ref:`Use Hints in a Checkbox Problem`
        * :ref:`Use Feedback in a Dropdown Problem` 
@@ -96,7 +98,7 @@ Apr-Jun 2015
 *****************
 
 .. list-table::
-   :widths: 20 70
+   :widths: 30 70
    :header-rows: 1
 
    * - Date
@@ -127,7 +129,7 @@ Jan-Mar 2015
 *****************
 
 .. list-table::
-   :widths: 20 70
+   :widths: 30 70
    :header-rows: 1
 
    * - Date

--- a/en_us/shared/building_and_running_chapters/building_course/lti/lti_address_content.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/lti/lti_address_content.rst
@@ -137,6 +137,9 @@ older courses. If you are using a spreadsheet to organize your location
 identifiers, you can select the usage ID value, and then copy and paste it into
 the spreadsheet. 
 
+To close the Staff Debug viewer, click on the browser page outside of the
+viewer.
+
 For more information, see :ref:`Staff Debug Info`.
 
 .. _View the Page Source for the Usage ID:

--- a/en_us/shared/building_and_running_chapters/running_course/course_answers.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/course_answers.rst
@@ -6,7 +6,8 @@ Answer Data
 
 To review student answers to the problems in your course, you can review the
 answer submitted by a selected student for a specific problem or download a
-course-wide report of answer data.
+course-wide report of any student answers to a specific problem. You can also
+download an answer distribution report for course problems.
 
 .. contents::
  :local:
@@ -17,13 +18,26 @@ available from edX Insights. For more information, see `Using edX Insights`_.
 
 .. _Student_Answer_Submission:
 
-************************************************************
-Check a Student's Answer Submission and Submission History
-************************************************************
+*****************************
+Student Answer Submissions
+*****************************
 
-For a single student and problem, you can review the exact response submitted,
-the number of attempts made, and the date and time of the submission. You
-identify the student by supplying a username.
+You can review a single student's complete submission history for a specific
+problem, or the answers submitted by all students for that problem. For either
+a single student or all students, you can review the exact response submitted,
+the number of attempts made, and the date and time of the submission.
+
+.. contents::
+ :local:
+ :depth: 1
+
+============================================================
+View One Student's Submission History
+============================================================
+
+Before you can check the answer or answers submitted by a student, you need the
+student's username. For more information about how to obtain usernames, see
+:ref:`View and download student data`.
 
 To review a response submitted by a student, follow these steps.
 
@@ -39,10 +53,248 @@ To review a response submitted by a student, follow these steps.
    select **View History** at the end of the page.
 
   Information about the response or responses provided by the student displays.
+  For more information, see :ref:`Interpret a Student Submission History`.
 
 To close the Submission History Viewer, click on the browser page outside of
 the viewer.
+
+.. _Interpret a Student Submission History:
+
+============================================================
+Interpret a Student's Submission History
+============================================================
+
+The Submission History Viewer shows every timestamped database record of the
+interactions between a student and a problem, which can include processes
+completed both in the browser and on the server. These records appear with the
+most recent interaction at the top of the Submission History Viewer, followed
+by each previous interaction.
+
+This topic provides an example submission history for a capa problem with
+guidelines that can help you interpret a submission history. The number and
+complexity of the records that appear in this report vary based on the type of
+problem and the settings and features defined.
+
+**Record 1: Problem Viewed (Server)**
+
+The first interaction, shown at the bottom of the Submission History, records
+when the server delivered the problem component to the browser for the student
+to view.
+
+.. code-block:: json
+
+  #1: 2015-09-04 08:34:53+00:00 (America/New_York time)
+
+  Score: None / None
+
+  {
+    "input_state": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": {}
+    }, 
+    "seed": 1
+  }
+
+
+**Record 2: Problem Checked (Browser)**
+
+The next interaction shown as you scroll up from the bottom records when the
+student selected **Check** in the browser to submit an answer. Note that this
+record does not contain the actual answer submitted.
+
+.. code-block:: json
+
+  #2: 2015-09-04 08:35:03+00:00 (America/New_York time)
+
+  Score: 0.0 / 1.0
+
+  {
+    "input_state": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": {}
+    }, 
+    "seed": 1
+  }
+
+
+**Record 3: Problem Checked (Server)**
+
+The next interaction records the results of the server processing that occurred
+after the student submitted the answer. This record includes
+``student_answers`` with the submitted answer value, along with ``attempts``,
+``correctness``, and other values.
+
+.. code-block:: json
+
+  #3: 2015-09-03 18:15:10+00:00 (America/New_York time)
+
+  Score: 0.0 / 1.0
+
+  {
+    "attempts": 1, 
+    "correct_map": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": {
+        "answervariable": null, 
+        "correctness": "incorrect", 
+        "hint": "", 
+        "hintmode": null, 
+        "msg": "", 
+        "npoints": null, 
+        "queuestate": null
+      }
+    }, 
+    "done": true, 
+    "input_state": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": {}
+    }, 
+    "last_submission_time": "2015-09-03T18:15:10Z", 
+    "seed": 1, 
+    "student_answers": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": "Nanjing"
+    }
+  }
+
+
+**Record 4: Problem Retried (Browser)**
+
+When a problem gives students multiple attempts at the right answer, and the
+student tries again, an additional record is added when a student selects
+**Check** again. The server has not yet processed the new submission, so the
+data in the record is almost identical to the data in record 3.
+
+**Record 5: Problem Retried (Server)**
+
+The most recent interaction in this example records the results after the
+student attempts the problem again and submits a different answer. Note the
+differences between values in this record and in record 3, including the
+reported ``Score`` and the values for ``student_answers``, ``attempts``, and
+``correctness``.
+
+.. code-block:: json
+
+  #5: 2015-09-03 18:15:17+00:00 (America/New_York time)
+
+  Score: 1.0 / 1.0
+
+  {
+    "attempts": 2, 
+    "correct_map": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": {
+        "answervariable": null, 
+        "correctness": "correct", 
+        "hint": "", 
+        "hintmode": null, 
+        "msg": "", 
+        "npoints": null, 
+        "queuestate": null
+      }
+    }, 
+    "done": true, 
+    "input_state": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": {}
+    }, 
+    "last_submission_time": "2015-09-03T18:15:17Z", 
+    "seed": 1, 
+    "student_answers": {
+      "i4x-edx-DemoX-problem-2363f9b08ed04be5a21e5a32511dd30a_2_1": "Nanjing University"
+    }
+  }
+
+
+.. _Student_Problem_Answers:
+
+============================================================
+Report All Students' Answer Submissions
+============================================================
+
+Before you can download a report of all student answers for a problem, you need
+the :ref:`unique identifier<find_URL>` of the problem that you want to
+investigate.
+
+To download a report of the answers submitted for a problem by every student,
+follow these steps.
+
+#. View the live version of your course.
+
+#. Select **Instructor**, and then select **Data Download**.
+
+#. In the **Reports** section, enter the **Problem location** . For capa
+   problems, you can use the **Staff Debug Info** option to :ref:`find this
+   identifier<find_URL>` for a problem.
    
+#. Select **Download a CSV of problem responses**.
+
+#. At the bottom of the page, select the
+   ``{course_id}_student_state_from_{problem_location}_{date}.csv`` file. 
+
+#. Use a text editor or spreadsheet application to open the file. For more
+   information, see :ref:`Interpret the Student State Report`.
+
+.. _Interpret the Student State Report:
+
+============================================================
+Interpret the Student State Report
+============================================================
+
+The Student State report contains a row for each student who has viewed a
+problem or submitted an answer for the problem, identified by username. The
+**State** column reports the results of the server processing for each
+student's most recently submitted answer.
+
+When you open the report, the value in the **State** column appears on a single
+line. This value is a record in JSON format. An example record for a text input
+capa problem follows.
+
+``{"correct_map": {"2363f9b08ed04be5a21e5a32511dd30a_2_1": {"hint": "", "hintmode": null, "correctness": "correct", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}}, "input_state": {"2363f9b08ed04be5a21e5a32511dd30a_2_1": {}}, "last_submission_time": "2015-09-03T18:15:17Z", "attempts": 2, "seed": 1, "done": true, "student_answers": {"2363f9b08ed04be5a21e5a32511dd30a_2_1": "Nanjing University"}}``
+
+You can use a JSON "pretty print" tool or script to make the value in the
+**State** column more readable, as in the following example.
+
+.. code-block:: json
+
+  {
+    "correct_map": {
+      "2363f9b08ed04be5a21e5a32511dd30a_2_1": {
+        "hint": "",
+        "hintmode": null,
+        "correctness": "correct",
+        "msg": "",
+        "answervariable": null,
+        "npoints": null,
+        "queuestate": null
+      }
+    },
+    "input_state": {
+      "2363f9b08ed04be5a21e5a32511dd30a_2_1": {
+      
+      }
+    },
+    "last_submission_time": "2015-09-03T18:15:17Z",
+    "attempts": 2,
+    "seed": 1,
+    "done": true,
+    "student_answers": {
+      "2363f9b08ed04be5a21e5a32511dd30a_2_1": "Nanjing University"
+    }
+  }
+
+When you add line breaks and spacing to the value in the **State** column for
+this capa problem, it becomes possible to recognize its similarity to the
+server problem check records in the Submission History. For more information,
+see :ref:`Interpret a Student Submission History`.
+
+A **State** value that appears as follows indicates a learner who has viewed a
+capa problem, but not yet submitted an answer.
+
+  ``{"seed": 1, "input_state": {"i4x-edX-DemoX_1-problem-05c289c5ad3d47d48a77622c4a81ec36_2_1": {}}}``
+
+For open response assessment problems, the **State** value appears as follows
+for learners who have submitted an answer.
+
+  ``{"submission_uuid": "c359b484-5644-11e5-a166-0a4a2062d211", "no_peers": false}``
+
+For open response assessment problems, ``"no_peers": false`` indicates that the
+learner has completed at least one peer assessment, while ``"no_peers": true``
+indicates that no peer assessments have been submitted.
+
 .. _Student_Answer_Distribution:
 
 ****************************************
@@ -269,3 +521,4 @@ answer(s) can guide future changes to the courseware.
 
 
 .. _Using edX Insights: http://edx-insights.readthedocs.org/en/latest/
+.. _Problem Interaction Events: http://edx.readthedocs.org/projects/devdata/en/latest/internal_data_formats/tracking_logs.html#problem

--- a/en_us/shared/building_and_running_chapters/running_course/course_grades.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/course_grades.rst
@@ -10,22 +10,14 @@ make adjustments to student grading for a problem, for a single student or all
 students. For information about the grading data that you can access and the
 changes you can make, see the following topics.
 
-* :ref:`Review_grades`
+.. contents::
+ :local:
+ :depth: 1
 
-* :ref:`Access_grades`
-
-* :ref:`problem_report`
-
-* :ref:`gradebook`
-
-* :ref:`check_student_progress`
-
-* :ref:`Adjust_grades`
-
-To review student answers to the problems in your course, you can check the
-answer submitted by a specified student for a selected problem, download
-course-wide answer data, or review a graph of all answer data for a selected
-problem. See :ref:`Review_Answers`.
+To review student answers to course problems, you can check the answer
+submissions for a specific problem, either for a selected student or for all
+students. You can also review answer distribution data for all of the problems.
+See :ref:`Review_Answers`.
 
 For information about how you establish a grading policy and work with the
 Problem components in your course, see :ref:`Establish a Grading Policy` or
@@ -233,8 +225,8 @@ Generate a Problem Grade Report for Enrolled Students (All Courses)
 
 For any course, you can calculate grades for problems and generate a report
 that can be downloaded. The problem grade report for a course shows the number
-points that each learner has earned for each problem and the number of
-possible points for every problem in the course and the . In addition, the
+of points that each learner has earned for each problem, and the number of
+possible points for every problem in the course. In addition, the
 report shows the final grade score for each learner.
 
 To generate and download the problem grade report for the learners who are
@@ -293,7 +285,7 @@ The problem grade report includes two columns for every problem that is
 included in your grading configuration. For each homework, lab, midterm, or
 final exam problem, there is one column for earned points, and one column for
 possible points. In addition, the report shows the final grade score for each
-learner, espressed as a decimal.
+learner, expressed as a decimal.
 
 .. image:: ../../../shared/building_and_running_chapters/Images/Problem_Grade_Report_Example.png
   :alt: An example problem grade report shown in Excel, showing the decimal
@@ -424,7 +416,7 @@ To view the **Progress** page for a learner, follow these steps.
 
    .. image:: ../../../shared/building_and_running_chapters/Images/Student_Progress_list.png
     :alt: Bottom portion of a Progress page for the same student with the 
-          score acheived for each problem in the first course subsection 
+          score achieved for each problem in the first course subsection 
 
 =============================================
 Interpret the Student Progress Page
@@ -458,7 +450,7 @@ represented; however, the student's "total" of 43% is on the far right.
 
 .. image:: ../../../shared/building_and_running_chapters/Images/Student_Progress.png
  :alt: Progress page for a student also included on the grade report: includes 
-       a column graph with the grade acheived for each assignment 
+       a column graph with the grade achieved for each assignment 
 
 The chart on the **Progress** page includes y-axis labels for the grade ranges
 defined for the course. In this example, Pass is set to 60%, so at the end of
@@ -528,7 +520,7 @@ change is unavoidable, you can make the following adjustments.
   single learner or for all learners enrolled in the course. See
   :ref:`reset_attempts`.
 
-* Delete a learners's database history, or "state", completely for a problem.
+* Delete a learner's database history, or "state", completely for a problem.
   You can only delete learner state for one learner at a time. For example, you
   realize that a problem needs to be rewritten after only a few of your
   students have answered it. To resolve this situation, you rewrite the problem
@@ -633,7 +625,7 @@ See :ref:`find_URL`. To rescore a problem:
 
 .. note:: You can use a similar procedure to rescore the submission for a 
  problem by a single student. You work in the **Student-Specific Grade
- Adjustment** section of the page to enter both the student’s email address or
+ Adjustment** section of the page to enter both the student's email address or
  username and the unique problem identifier, and then click **Rescore Student
  Submission**.
 
@@ -701,7 +693,7 @@ attempts for all students:
 
 .. note:: You can use a similar procedure to reset problem attempts for a 
  single student. You work in the **Student-Specific Grade Adjustment** section
- of the page to enter both the student’s email address or username and the
+ of the page to enter both the student's email address or username and the
  unique problem identifier, and then click **Reset Student Attempts**.
 
 .. _delete_state:
@@ -742,6 +734,6 @@ See :ref:`find_URL`.
 #. Click **Instructor**, then click **Student Admin**. 
 
 #. In the **Student-Specific Grade Adjustment** section of the page, enter both
-   the student’s email address or username and the unique problem identifier,
+   the student's email address or username and the unique problem identifier,
    and then click **Delete Student State for Problem**.
    


### PR DESCRIPTION
[DOC-2217](https://openedx.atlassian.net/browse/DOC-2217) 
Moves a report from the legacy dashboard to the Data Download page of the Instructor dashboard.
https://github.com/edx/edx-platform/pull/9147
Aligned nicely with [DOC-2204](https://openedx.atlassian.net/browse/DOC-2204) so I included that as well, rather than repeating info.
### Date Needed

Open source contribution is merged and will be released week of 9 Sept. 
### Reviewers

Check the appropriate box after each reviewer finishes and gives :+1:.
- [X] Subject matter expert: @itsjeyd 
- [x] Subject matter expert: @sarina 
- [x] Doc team review: @srpearce or @catong 
- [ ] Product review: 

FYIs: @ormsbee , @JAAkana , @explorerleslie 
### Testing
- [X] make html ran without unexpected errors
### Post-review
- [ ] Squash commits
- [X] Release notes
- [X] Change log
