### PR TITLE
Removes requirement to add problems individually

### DIFF
--- a/en_us/shared/building_and_running_chapters/building_course/lti/lti_canvas_example.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/lti/lti_canvas_example.rst
@@ -21,7 +21,7 @@ To use edX course content in the Canvas LMS, you add a new app to the course and
    ``https://edx-lti.org/lti_provider/courses/course-v1:edX+DemoX+2014/block-v1:edX+DemoX+Demo_Course+type@problem+block@d2e35c1d294b4ba0b3b1048615605d2a``.
 
    .. image:: ../../../../shared/building_and_running_chapters/Images/lti_edit_problem_Canvas.png
-     :alt: The Canvas page where you add an enternal tool and supply the LTI
+     :alt: The Canvas page where you add an external tool and supply the LTI
          URL.
 
    For more information, see :ref:`Determining Content Addresses`.

--- a/en_us/shared/building_and_running_chapters/building_course/lti/lti_grade_content.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/lti/lti_grade_content.rst
@@ -4,13 +4,16 @@
 Grading Remote Content
 #####################################
 
-When you include an edX problem component in an external LMS, learner responses
-are graded by the edX system. Learner scores are then transferred back to the
-external LMS. This exchange between an external LMS, the edX system, and back
-to the external LMS is near real time. It can take a few moments to complete.
+When you include the problem components in a graded edX subsection in an
+external LMS, the edX system grades the learner responses to those problems.
+The edX system then transfers the learner scores back to the external LMS. This
+exchange between an external LMS, the edX system, and the external LMS again is
+near real time. It can take a few moments to complete this exchange for a
+single problem component, and up to several minutes to return aggregated scores
+of all of the problems in a unit or subsection.
 
-When you include edX problem components in an external LMS, note the
-following requirements.
+When you include edX problem components in an external LMS, note the following
+requirements.
 
 * The edX problem component must be in one of the graded subsections in your
   course.
@@ -22,9 +25,5 @@ following requirements.
   the LTI material must be eligible to get a grade for the assignment; that is,
   a learner and not a TA or course designer.
 
-* The LTI URL that you construct for the external LMS must be for a single
-  problem component. (In the edX LMS, **Check** appears once below each problem
-  component.)
-  
 For more information about constructing an LTI URL for a course component, see
 :ref:`Determining Content Addresses`.

--- a/en_us/shared/building_and_running_chapters/building_course/lti/lti_prepare_content.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/lti/lti_prepare_content.rst
@@ -10,7 +10,8 @@ Preparing to Reuse Course Content
   you create a duplicate version of the course. You use the duplicate course
   specifically as a source of content for your external LMS. Based on
   configuration choices your organization makes for using edX as an LTI tool
-  provider, you might be asked to create the duplicate course on edX Edge or on another host site.
+  provider, you might be asked to create the duplicate course on edX Edge or on
+  another host site.
 
 .. only:: Open_edX
 
@@ -49,11 +50,6 @@ considerations.
   IDs, such as content experiments and cohorts, are not designed to provide
   results for external use. To use features like these for your course, you
   should plan to set them up in the external LMS.
-
-* Currently, the edX platform does not aggregate learner scores for problem
-  components. As a result, for grades to be passed from the edX platform back
-  to the external LMS, you must create links to each problem component in a
-  graded subsection individually, rather than to a complete unit or subsection.
 
 * To ensure that edX content remains available without interruption, edX course
   content appears in the external LMS regardless of the start, end, or
@@ -106,10 +102,10 @@ units, and subsections you want to include.
 
 Using an organizational tool, such as a spreadsheet, can be helpful. For
 example, you can use a spreadsheet column to identify the type of content (for
-example, component, unit, graded subsection, ungraded subsection), and add the
-display names to the next column. Additional columns can contain the values
-that you use to construct the addresses for your LTI links. For more
-information about addressing content, see :ref:`Determining Content Addresses`.
+example, component, unit, subsection), and add their display names to the next
+column. Additional columns can contain the values that you use to construct the
+addresses for your LTI links. For more information about addressing content,
+see :ref:`Determining Content Addresses`.
 
 Optionally, you can streamline the contents of units and subsections by
 removing components, or disable course features that you do not plan to use.
@@ -135,7 +131,7 @@ removing components, or disable course features that you do not plan to use.
    * - Internal Links
      - No
    * - Problem Components
-     - Yes (link to components in graded subsections individually)
+     - Yes
    * - Randomized Content Block Problem Components
      - No
    * - Video Components


### PR DESCRIPTION
## [DOC-2242](https://openedx.atlassian.net/browse/DOC-2242)

Previously, teams using edX content in an external LTI consumer system had to link to each graded problem at the component level for grading to be passed back and forth to edX. Now, grades are aggregated on the edX system to the unit and subsection levels, so teams can link to any hierarchical level in the course structure and still have grades pass correctly to a consumer system. 

See OSPR-713, https://github.com/edx/edx-platform/pull/9023
## Date Needed

This enhancement has been merged and is expected to release week of 9 Sept.
## Reviewers
- [ ] Subject matter expert: @mcgachey
- [ ] Subject matter expert: @ormsbee 
- [x] Doc team review: @srpearce 
- [ ] Product review: @ebporter
- [ ] Partner Support: @JAAkana or @sstack22

FYI: @sarina, @mhoeber
## Testing
- [X] make html ran without unexpected errors
## Post-review
- [ ] Squash commits
-  ~~Add description to release notes task as a comment~~
- [ ] Update change log
