### PR TITLE
Course structure API as source for IDs

### DIFF
--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -22,6 +22,8 @@ September 2015
 
    * - Date
      - Change
+   * - 9 September 2015
+     - Added the :ref:`View the Course Structure API for the Usage ID` topic.
    * - 2 September 2015
      - Added the :ref:`Using edX as an LTI Tool Provider` section.
 

--- a/en_us/shared/building_and_running_chapters/building_course/lti/lti_address_content.rst
+++ b/en_us/shared/building_and_running_chapters/building_course/lti/lti_address_content.rst
@@ -12,9 +12,11 @@ then format the identifiers into an LTI URL.
    :local:
    :depth: 2
 
-Using a tool like a spreadsheet can be helpful to organize the course ID and
-the usage IDs that correspond to each piece of course content you want to
-include in an external LMS.
+You might find using a tool like a spreadsheet helpful as a way to organize the
+course ID and each of the usage IDs that correspond to the course content you
+want to include in an external LMS.
+
+.. _Find the Course ID:
 
 ********************
 Find the Course ID
@@ -27,22 +29,25 @@ The identifier for your course can be in one of these formats.
 
 * ``{org}/{course}/{run}``, for example, ``edX/DemoX/2014``
  
+Courses created since Fall 2014 typically have an ID that uses the first
+format, while older courses have IDs that use the second format.
+
 To find the course ID for your course, follow these steps.
 
 #. In the edX LMS, open your course.
 
-#. In the URL, find the course ID.
+#. In the URL shown by your browser, find the course ID.
 
-For example, you open the edX DemoX course to the course info page. The URL is
-``https://edx.org/courses/edX/DemoX/2014/info``. From the URL, you determine
-that the course ID is ``edX/DemoX/2014``.
+For example, you open the Blended Learning with edX course to the course info
+page. The URL for its course info page is
+``https://courses.edx.org/courses/course-v1:edX+BlendedX+1T2015/info``. From
+the URL, you determine that the course ID is ``course-v1:edX+BlendedX+1T2015``.
 
-Another example is the Blended Learning with edX course. The URL for its course
-info page is
-``https://courses.edx.org/courses/course-v1:edX+BlendedX+1T2015/info``, and its
-course ID is ``course-v1:edX+BlendedX+1T2015``.
+Another example is the edX DemoX course. The URL is 
+``https://edge.edx.org/courses/edX/DemoX/2014/info``, and its course ID is
+``edX/DemoX/2014``.
 
-The course ID is the same for every piece of course content.
+The same course ID applies to every item of content in the course.
 
 ****************************************
 Finding the Usage ID for Course Content
@@ -51,52 +56,16 @@ Finding the Usage ID for Course Content
 The identifier for a specific component, unit, or subsection in your course can
 be in one of these formats.
 
-* ``{key type}:{org}+{course}+{run}+type@{type}@{display name}``, for example, 
-  ``block-v1:edX+DemoX+2014+type@sequential+block@basic_questions``
+* ``{key type}:{org}+{course}+{run}+type@{type}+block@{display name}``, for
+  example, ``block-v1:edX+DemoX+2014+type@sequential+block@basic_questions``
 
 * ``i4x:;_;_{org};_{course};_{type};_{display name}``, for example, 
   ``i4x:;_;_edX;_DemoX;_sequential;_basic_questions``
 
-To find the usage ID for a unit or a component in an edX course, you can either
-view staff debug info for it in the edX LMS, or view the page source. 
+Courses created since Fall 2014 typically have usage IDs in the first format,
+while older courses have usage IDs in the second format.
 
-To find the usage ID for a subsection, you view the page source.
-
-==========================================
-View Staff Debug Info for the Usage ID
-==========================================
-
-To find the usage ID for a unit or component, follow these steps.
-
-#. In the edX LMS, open your course.
-
-#. Select **Courseware**, and then go to the page that contains the unit or
-   component.
-
-#. Select **Staff Debug Info**.
-
-#. To find the usage ID for a component, locate the **location**. 
-   
-   For example, ``location = i4x://edX/DemoX.1/problem/b141f4b4e91942cb970cf5fdf44326b2``
-
-#. To find the usage ID for a unit, scroll down to locate the **parent**. 
-   
-   For example, ``parent  i4x://edX/DemoX.1/vertical/b8e5b1ff1e4746179491d85528111b8b``
-
-If you are using a spreadsheet to organize your location identifiers, you can
-select the usage ID value, which begins with ``i4x://`` in these examples, and
-then use copy and paste to add it.
-
-For more information, see :ref:`Staff Debug Info`.
-
-==========================================
-View the Page Source for the Usage ID
-==========================================
-
-To find the usage ID for a subsection, unit, or component, you view the
-page source for that page of the edX course. 
-
-In the page source, the following terms are used to indicate subsections,
+The following terms are used in the usage identifiers to indicate subsections,
 units, and components.
 
 .. list-table::
@@ -111,6 +80,73 @@ units, and components.
      - vertical
    * - component
      - problem, html, or video
+
+The example usage IDs shown above include the word "sequential", so they
+indicate subsections in a course.
+
+Several methods are available to help you find the usage IDs for items in your
+course.
+
+To find the usage ID for a unit or a component in an edX course, you can use
+any of these methods.
+
+* :ref:`View staff debug info<View Staff Debug Info for the Usage ID>` for it
+  in the edX LMS.
+
+* :ref:`View the page source<View the Page Source for the Usage ID>`.
+
+* :ref:`View the course structure<View the Course Structure API for the Usage
+  ID>`.
+
+To find the usage ID for a subsection in an edX course, you can use one of
+these methods.
+
+* :ref:`View the page source<View the Page Source for the Usage ID>`.
+
+* :ref:`View the course structure API<View the Course Structure API for the
+  Usage ID>`.
+
+.. note:: You must have the Staff or Admin role in a course to follow any 
+ of these procedures for finding usage IDs.
+
+.. _View Staff Debug Info for the Usage ID:
+
+==========================================
+View Staff Debug Info for the Usage ID
+==========================================
+
+To find the usage ID for a unit or component in the LMS, follow these steps.
+
+#. In the edX LMS, open your course.
+
+#. Select **Courseware**, and then go to the page that contains the unit or
+   component.
+
+#. Select **Staff Debug Info**.
+
+#. To find the usage ID for a component, find the **location**. 
+   
+   For example, ``location = block-v1:edX+BlendedX+1T2015+type@html+block@2114b1b8fd7947d28fba53414459ff01``
+
+#. To find the usage ID for a unit, scroll down to find the **parent**. 
+   
+   For example, ``parent  block-v1:edX+BlendedX+1T2015+type@vertical+block@ae7d9c34c2f34f7aa793ed7b55543ae5``
+
+The usage ID value begins with ``block-v1`` for newer courses or ``i4x://`` for
+older courses. If you are using a spreadsheet to organize your location
+identifiers, you can select the usage ID value, and then copy and paste it into
+the spreadsheet. 
+
+For more information, see :ref:`Staff Debug Info`.
+
+.. _View the Page Source for the Usage ID:
+
+==========================================
+View the Page Source for the Usage ID
+==========================================
+
+To find the usage ID for a subsection, unit, or component, you view the
+HTML page source for that page of the edX course. 
 
 To find the usage ID for a subsection, unit, or component, follow these steps.
 
@@ -155,10 +191,82 @@ search again, and find the usage ID for the second problem in the assignment,
 
 If you are using a spreadsheet to organize your location identifiers, you can
 select the usage ID value within the quotation marks or ``&#34;`` ISO codes,
-and then use copy and paste to add it.
+and then copy and paste it into the spreadsheet.
+
+.. _View the Course Structure API for the Usage ID:
+
+===============================================
+View the Course Structure API for the Usage ID
+===============================================
+
+The edX course structure API (application program interface) exposes
+information about your course, including the usage identifiers for every item
+it contains, in JSON format. 
+
+To view this API for your course, you browse to a URL with the following
+format.
+
+  ``https://{host}/api/course_structure/v0/course_structures/{course_id}`` 
+
+You must have the Staff or Admin role for a course to view its course
+structure API.
+
+To find usage IDs for your course in the course structure API, follow these
+steps.
+
+#. In your browser, enter the URL for the course structure API. 
+   
+   For example, to access the course structure API for the edX Demo course on
+   Edge, you enter this URL.
+
+   ``https://edge.edx.org/api/course_structure/v0/course_structures/course-v1:edX+DemoX+Demo_Course`` 
+
+#. Press Enter. The course structure API appears in the browser.
+
+#. Scroll down to verify that an ``HTTP 200 OK`` message appears.
+
+   If you received a different HTTP response value, make sure that you have the
+   Staff or Admin role for the course, and that you have entered the URL
+   correctly.
+
+The API shows the ``root`` usage ID for your course, followed by the set of
+``blocks`` that the course contains. Each block provides information about one
+item in your course, using the sequential, vertical, and problem, html, or
+video identifiers. Each block includes the ``display_name`` that is defined for
+each item, which can help you locate specific subsections, units, and
+components.
+
+For example, this block is for a unit (vertical) that contains a single video
+component (indicated by the value for ``children``).
+
+.. code-block:: json
+
+  {
+      "block-v1:edX+231_LTI+Fall_2015+type@vertical+block@7b3606b362c74222ba2d0c06e433df08": {
+          "id": "block-v1:edX+231_LTI+Fall_2015+type@vertical+block@7b3606b362c74222ba2d0c06e433df08", 
+          "type": "vertical", 
+          "parent": null, 
+          "display_name": "1st Video", 
+          "graded": false, 
+          "format": null, 
+          "children": [
+              "block-v1:edX+231_LTI+Fall_2015+type@video+block@fe187ddccab84398aa051f6937a213a7"
+          ]
+      }, 
+
+The usage ID for this unit is the value for ``"id"``. 
+
+  ``block-v1:edX+231_LTI+Fall_2015+type@vertical+block@7b3606b362c74222ba2d0c06e433df08``
+
+The usage ID begins with ``block-v1`` for newer courses or ``i4x://`` for
+older courses. 
+
+If you are using a spreadsheet to organize your location identifiers, you
+can select the usage ID value within the quotation marks, and then copy and
+paste it into the spreadsheet.
 
 ************************
-Construct the LTI URL
+Constructing the LTI URL
 ************************
 
 To identify the edX content that you want to include in an external LMS, you


### PR DESCRIPTION
## [DOC-2247](https://openedx.atlassian.net/browse/DOC-2247)

@ormsbee and @jibsheet pointed me to the course structure API as a source of the usage IDs that teams must have to create LTI links to edX course content. For teams that have some API or JSON background, it is likely to be more useful than the other two methods already described. 
### Date Needed

This is not needed on a specific release schedule. However, it adds a (potentially) more useable way of obtaining required identifiers for the LTI feature. LTI is already in release.
### Reviewers
- [X] Subject matter expert: @ormsbee 
- [ ] Subject matter expert: @jibsheet 
- [X] Doc team review: @mhoeber 
- [ ] Product review: @ebporter
- [ ] Partner support: @JAAkana 
### Testing
- [X] make html ran without unexpected errors
### Post-review
- [X] Squash commits
- [ ] ~~Add description to release notes task as a comment~~
- [X] Update change log
