### PR TITLE
Incorporates Chris' comments on a11y change

### DIFF
--- a/en_us/release_notes/source/2015/studio/studio_0909_2015.rst
+++ b/en_us/release_notes/source/2015/studio/studio_0909_2015.rst
@@ -1,7 +1,7 @@
 
-This release includes styling changes to the **Unit** page in Studio to
-improve accessibility. It is now easier to navigate to the options in the **Add
-New Component** section of this page. It is also easier to make selections from
-the list of choices that appears when you select the **Advanced** option.
-(TNL-2153)
+This release includes changes to the **Unit** page in Studio to improve
+accessibility. It is now easier to use a keyboard to navigate to the options in
+the **Add New Component** section of this page. It is also easier to use a
+keyboard to make selections from the list of choices that appears when you
+select the **Advanced** option. (TNL-2153)
 


### PR DESCRIPTION
https://github.com/edx/edx-documentation/pull/536/files#r39071300

removed the word “styling” 
added “use a keyboard to” 2x

@catong, would you mind taking a look at these changes to today's release notes, based on @clrux release notes comments?
