### PR TITLE
Adds enhanced ORA2 file upload features for course teams

### DIFF
--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -23,10 +23,10 @@ October 2015
    * - Date
      - Change
    * - 21 October 2015
-     - Added information to the :ref:`PA Allow Images` topic about specifying
-       additional file types for learners to upload.
-   * -
      - Added the :ref:`Oppia Exploration Tool` topic.
+   * -
+     - Added information about specifying additional file types for learners to
+       upload to the :ref:`PA Allow Images` topic.
    * - 14 October 2015
      - Added a note with support information to the beginning of each exercise
        or tool topic.

--- a/en_us/open_edx_course_authors/source/front_matter/change_log.rst
+++ b/en_us/open_edx_course_authors/source/front_matter/change_log.rst
@@ -13,10 +13,10 @@ October 2015
    * - Date
      - Change
    * - 21 October 2015
-     - Added information to the :ref:`PA Allow Images` topic about specifying
-       additional file types for learners to upload.
-   * -
      - Added the :ref:`Oppia Exploration Tool` topic.
+   * -
+     - Added information about specifying additional file types for learners to
+       upload to the :ref:`PA Allow Images` topic.
    * - 14 October 2015
      - Added a note with support information to the beginning of each exercise
        or tool topic.

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -556,11 +556,13 @@ O
 
 **Open Response Assessment**
 
-  A type of assignment that allows learners to answer using text and,
-  optionally, an image, as in a short essay. Learners then evaluate each
+  A type of assignment that allows learners to answer with text, as in a short
+  essay and, optionally, an image or other file. Learners then evaluate each
   others' work by comparing each response to a rubric created by the course
-  team. These assignments can also include a self assessment, in which
-  learners compare their own responses to the rubric.
+  team.
+
+  These assignments can also include a self assessment, in which learners
+  compare their own responses to the rubric.
 
   For more information, see `Open Response Assessments`_.
 

--- a/en_us/shared/students/SFD_certificates.rst
+++ b/en_us/shared/students/SFD_certificates.rst
@@ -17,13 +17,13 @@ Overview
 .. only:: Partners
 
   Nearly every course on edx.org offers a certificate when you complete the
-  course successfully. 
+  course successfully.
 
   A certificate includes your name, the name of the course, and the edX partner
   university that created the course. Verified certificates also include the
   names of one or more members of the course team.
 
-  .. note:: 
+  .. note::
     A small number of edX courses do not offer certificates. For evidence that
     you completed the course, you can print a copy of the **Progress** page in
     the course.
@@ -41,7 +41,7 @@ Certificates and Your Name
 You must ensure that if you earn a certificate, it accurately displays your
 full name.
 
-Your certificate uses the full name that appears on your dashboard. 
+Your certificate uses the full name that appears on your dashboard.
 Before your course ends, make sure that the name on your dashboard is
 correct. For more information, see :ref:`SFD Basic Information`.
 
@@ -50,13 +50,13 @@ Certificates, Grades, and Credit
 =================================
 
 Certificate do not include grades or specify the number of credit hours
-that the course might earn at a university. 
+that the course might earn at a university.
 
 .. only:: Partners
 
 In addition, transcripts are not available for edX course work.
 
-  .. Note:: 
+  .. Note::
     Some edX courses offer academic credit. These courses have different
     requirements and steps for earning certificates. For more information, see
     :ref:`SFD Academic Course Credit Index`.
@@ -137,7 +137,7 @@ Certificate Types
     before the deadline for verification in that course. For more information,
     see :ref:`SFD Verify Your Identity`.
 
-    .. note:: When you verify your identity for one course, you verify your 
+    .. note:: When you verify your identity for one course, you verify your
      identity for all edX courses. Verification is effective for one year. If
      you enroll in another verified course within that year, you do not have to
      verify your identity again.
@@ -258,21 +258,11 @@ Certificate** in the certificate header.
 To print your certificate in the most professional looking format, note the
 following guidelines.
 
-* Print the certificate in landscape orientation. 
+* Do not print the header or footer. Depending on your system, you might need
+  to clear this option.
 
-  To set landscape orientation in Firefox browsers, from the **File** menu,
-  select **Page Setup**. Then select the landscape orientation icon and select
-  **OK**.
-
-* Do not print the header or footer. 
-
-* Set the margins to the minimum space available. 
-
-* Print background graphics.
-
-Depending on your system, you might need to set these options when printing
-your certificate.
-
+* Set the margins to the minimum space available. Depending on your system, you
+  might need to select the **Minimum** option for the margins.
 
 *************************
 PDF Certificates
@@ -323,7 +313,7 @@ issue certificates less frequently. For more information about your course's
 specific certificate schedule, see the About page or the **Course Info** tab
 for your course.
 
-.. _SFD On Demand Certificates: 
+.. _SFD On Demand Certificates:
 
 ======================
 On-Demand Certificates
@@ -345,9 +335,9 @@ certificate, you see the following message at the top of the course
       you qualified for a certificate!"
 
 You can request your certificate at any time after you have qualified for the
-certificate. 
+certificate.
 
-.. Caution:: 
+.. Caution::
  The grade that you see on your dashboard reflects your grade at that time you
  requested the certificate. If you complete more assignments to raise your
  grade, the grade listed on your dashboard is not updated.
@@ -414,6 +404,6 @@ To receive your certificate at any time after you qualify, follow these steps.
        Backpack to share your badge.
 
        .. image:: ../../shared/students/Images/SFD_MozillaBackpackShareDialog.png
-        :width: 500 
+        :width: 500
         :alt: Dialog with instructions that opens when you select the Mozilla
             Backpack share icon.

--- a/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
+++ b/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
@@ -4,20 +4,22 @@
 Accessing Assignment and Learner Metrics
 ##########################################
 
-After your open response assessment assignment has been released, you can access
+After you release an open response assessment assignment, you can access
 information about the number of learners in each step of the assignment or the
 performance of individual learners. This information is available in the
 **Course Staff Information** section at the end of each assignment. To access
-learner information, open the assignment in the courseware, scroll to the bottom of the
-assignment, and then select the black **Course Staff Information** banner.
+learner information, open the assignment in the courseware, scroll to the
+bottom of the assignment, and then select the black **Course Staff
+Information** banner.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CourseStaffInfo_Collapsed.png
-   :alt: The Course Staff Information banner at the bottom of the peer assessment
+   :alt: The Course Staff Information banner at the bottom of the peer
+    assessment.
 
 When you access a specific learner's information for an open response
-assessment, you can view his responses and, if necessary, :ref:`cancel the
-learner's submission<Remove a learner response from peer grading>` so that it is
-not included in peer assessments.
+assessment, you can view his responses and uploaded files. If necessary, you
+can :ref:`cancel the learner's submission<Remove a learner response from peer
+grading>` so that it is not forwarded to peers for assessment.
 
 .. _PA View Metrics for Individual Steps:
 
@@ -42,7 +44,7 @@ of learners who are currently working through (but have not completed) each
 step of the problem.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CourseStaffInfo_Expanded.png
-   :alt: The Course Staff Information box expanded, showing problem status
+   :alt: The Course Staff Information box expanded, showing problem status.
 
 .. _Access Information for a Specific Learner:
 
@@ -50,10 +52,11 @@ step of the problem.
 Access Information for a Specific Learner
 ***********************************************
 
-You can access information about an individual learner's performance on a peer
-assessment assignment, including:
+You can access the following information about an individual learner's
+performance on a peer assessment assignment.
 
 * The learner's response. 
+* Any files that the learner uploaded.
 * The peer assessments that other learners performed on the learner's
   response, including feedback on individual criteria and on the overall
   response.
@@ -62,14 +65,14 @@ assessment assignment, including:
   responses.
 * The learner's self assessment.
 
-In the following example, you can see the performance information for a specific
-learner. This learner's response received one peer assessment, and the learner
-completed a peer assessment on one other learner's response. The learner also
-completed a self assessment.
+In the following example, you can see the performance information for a
+specific learner. This learner's response received one peer assessment, and the
+learner completed a peer assessment on one other learner's response. The
+learner also completed a self assessment.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_SpecificStudent.png
    :width: 500
-   :alt: Report showing information about a learner's response
+   :alt: Report showing information about a learner's response.
 
 To determine whether this learner has received the required number of
 assessments from other learners and has completed the required number of
@@ -89,21 +92,27 @@ Learner Information`.
 Access a Specific Learner's Information
 =======================================
 
-#. In the LMS, go to the peer assessment assignment that you want to see.
-   
-#. Scroll to the bottom of the problem, and select the black **Course Staff
-   Information** banner.
-   
-#. In the **Get Student Info** box, enter the learner's username, and select
-   **Submit**.
+Before you can access information about a specific learner's assignment, you
+need the learner's username. For more information, see :ref:`View and download
+student data`.
 
-The learner's information appears below the **Get Student Info** box.
+#. In the LMS, go to the peer assessment assignment that you want to access.
+   
+#. Scroll to the bottom of the problem, and then select **Course Staff
+   Information**.
+   
+#. In the **Get Student Info** box, enter the learner's username, and then
+   select **Submit**.
 
-The following example shows:
+The learner's response appears along with additional available information. If
+the learner uploaded a file along with her response, you can select **View the
+file associated with this submission** to review or download it.
+
+The example that follows includes this information for an assessment.
 
 * The learner's response. 
 * The two peer assessments for the response.
-* The two peer assessments the learner completed.
+* The two peer assessments that the learner completed.
 * The learner's self assessment.
 
 For a larger view, select the image so that it opens by itself in the browser
@@ -111,7 +120,7 @@ window, and then click anywhere on the image that opens.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_SpecificStudent_long.png
    :width: 250
-   :alt: Report showing information about a learner's response
+   :alt: Report showing information about a learner's response.
 
 
 .. _Remove a learner response from peer grading:
@@ -129,55 +138,53 @@ other learners.
 
 .. note:: Removing a learner's submission is an irreversible action. 
 
-When you cancel an inappropriate submission, the response is immediately removed
-from the pool of submissions available for peer assessment. If the inappropriate
-response has already been sent to other learners for peer assessment, it is also
-removed from their queue. However, if any learner has already graded the
-inappropriate response, it is counted as one of the submissions they have
-graded.
+When you cancel an inappropriate submission, the response is immediately
+removed from the pool of submissions available for peer assessment. If the
+inappropriate response has already been sent to other learners for peer
+assessment, it is also removed from their queue. However, if any learner has
+already graded the inappropriate response, it is counted as one of the
+submissions they have graded.
 
 .. note:: After you remove an inappropriate response from peer assessment, you
-   decide whether the learner who submitted that response is allowed to submit a
-   replacement response. If you do not want to allow the learner to submit a
+   decide whether the learner who submitted that response is allowed to submit
+   a replacement response. If you do not want to allow the learner to submit a
    replacement response, you do not need to take any additional action. The
    learner receives a grade of zero for the entire submission. To allow the
-   learner to resubmit a response for a cancelled submission, :ref:`reset the
+   learner to resubmit a response for a canceled submission, :ref:`reset the
    learner's attempts for the problem<reset_attempts>`.
 
 Remove a submission from peer assessment by completing these steps.
 
-#. In the LMS, go to the peer assessment assignment that contains the submission
-   you want to remove.
+#. In the LMS, go to the peer assessment assignment that contains the
+   submission you want to remove.
    
 #. Scroll to the bottom of the problem, then select the black **Course Staff
    Information** banner.
    
 #. Scroll down to the **Get Student Info** box, enter the learner's username in
-   the box, and select **Submit**. 
+   the box, and select **Submit**.
 
    The learner's information appears below the **Get Student Info** box.
    
-#. Scroll down to the **Student Response** section and locate the submission you
-   want to remove.
+#. Select **Remove Submission from Peer Grading**.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/ORA_RemoveSubmission.png
-   :alt: Dialog allowing comments to be entered when removing a learner submission
+   :alt: Dialog allowing comments to be entered when removing a learner submission.
    
-5. Enter a comment to document or explain the removal. This comment appears to
-   the learner when she views her response in the open response assessment
-   problem.
+5. Enter a comment to explain the removal. This comment appears to the learner
+   when she views her response in the open response assessment problem.
    
-#. Click **Remove submission**. 
+#. Select **Remove submission**. 
 
-   The inappropriate submission is removed from peer assessment. When you access
-   this learner's information again, instead of the response, you see a note
-   showing the date and time that the submission was removed, and the comments
-   that you entered.
+   The inappropriate submission is removed from peer assessment. When you
+   access this learner's information again, instead of the response, you see a
+   note showing the date and time that the submission was removed, and the
+   comments that you entered.
 
    Removed submissions are also removed from the list of Top Responses if they
    were previously listed.
    
-.. image:: ../../../../shared/building_and_running_chapters/Images//ORA_CancelledStudentResponse.png
+.. image:: ../../../../shared/building_and_running_chapters/Images/ORA_CancelledStudentResponse.png
    :alt: The date, time and comment for removal of a learner response is shown instead of the original response.  
 
 
@@ -192,7 +199,7 @@ and :ref:`remove from peer assessment<Remove a learner response from peer
 grading>`, locate the specific submission by following these steps.
 
 #. Ask the person who reported the incident to send you a sample of text from
-   the inappropriate post.
+   the inappropriate response.
 
 #. Contact your edX Partner Manager to request a data download of ORA
    responses for your course.
@@ -200,10 +207,11 @@ grading>`, locate the specific submission by following these steps.
    You will receive the download as a spreadsheet or in .csv file format.
 
 #. Search the spreadsheet for text that matches the sample text from the
-   inappropriate post.
+   inappropriate response.
 
 #. From any matching entries in the spreadsheet, locate the username of the
    learner who posted the submission.
 
 #. Make a note of the username, and follow the steps to :ref:`remove a learner
    response from peer grading<Remove a learner response from peer grading>`.
+

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -4,17 +4,12 @@
 Create an Open Response Assessment Assignment
 #############################################
 
+Creating an open response assessment is a multi-step process. This section
+covers each step in detail.
 
-Creating an open response assessment is a multi-step process. Each step is covered in detail below.
-
-* :ref:`PA Create Component`
-* :ref:`PA Add Prompt`
-* :ref:`PA Add Rubric`
-* :ref:`PA Specify Name and Dates`
-* :ref:`PA Select Assignment Steps`
-* :ref:`PA Specify Step Settings`
-* :ref:`PA Show Top Responses`
-* :ref:`PA Test Assignment`
+.. contents::
+  :local:
+  :depth: 2
 
 For more information about the components of an open response assessment, see
 :ref:`Open Response Assessments 2`. For information about viewing metrics and
@@ -28,13 +23,23 @@ ORA Assignment Information`.
 Step 1. Create the Component
 ******************************
 
-To create the component for your open response assessment, complete these steps.
+To create the component for your open response assessment, complete these
+steps.
 
 #. In Studio, open the unit where you want to create the open response
-   assessment.   
-#. Under **Add New Component**, select **Problem**, select the **Advanced** tab,
-   and then select **Peer Assessment**.
-#. In the Problem component that appears, select **Edit**.
+   assessment.
+
+#. Under **Add New Component**, select **Problem**.
+
+#. Select **Advanced**, and then select **Peer Assessment**.
+
+#. In the problem component that appears, select **Edit**.
+
+   You use this component editor to add prompts and the rubric, and to specify
+   other settings for the open response assessment component.
+
+#. Select **Save** each time you complete an editing session. You can continue
+   to edit the problem until you publish the unit.
 
 .. note:: After you publish an ORA assignment, you can no longer change the
    structure of the rubric or the point values associated with each criterion
@@ -52,22 +57,25 @@ Step 2. Add Prompts
 
 To add prompts, or questions, complete these steps.
 
-#. In the open response assessment component editor, select the **Prompt** tab.
+.. note:: If you want to add text formatting to the prompt, or include an
+ image, see :ref:`Add Formatting or Images to a Prompt`.
+
+#. In the open response assessment component editor, select **Prompt**.
 #. Add the text of your question in the text field. Replace any default text if
    necessary.
 #. Select **Add a Prompt** to add another prompt in the problem.
 
+.. _Add Formatting or Images to a Prompt:
 
 ========================================
 Add Formatting or Images to a Prompt
 ========================================
 
-Currently, you cannot add text formatting or images inside the Peer Assessment
-component. To include formatting or images within the text of a prompt, you
-can add an HTML component that contains your text above the Peer Assessment
-component, and leave the text field in the **Prompt** tab blank. The
-instructions for the peer assessment still appear above the **Your Response**
-field.
+Currently, you cannot format text or add images inside the Peer Assessment
+component. To include formatting or images in a prompt, you can add an HTML
+component that contains your text above the Peer Assessment component, and
+leave the text field in the **Prompt** tab blank. The instructions for the peer
+assessment still appear above the **Your Response** field.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_HTMLComponent.png
       :alt: A peer assessment that has an image in an HTML component
@@ -76,25 +84,34 @@ field.
 .. _PA Allow Images:
 
 ============================================
-Allow Learners to Submit Images (optional)
+Allow Learners to Submit Files (optional)
 ============================================
 
-To allow learners to submit an image with a response, complete these steps.
+Before you enable this feature for your open response assessment, be sure to
+read about its limitations and best practices. For more information, see
+:ref:`Asking Learners to Upload Other Files in Responses`.
 
-#. In the open response assessment component editor, select the **Settings** tab.
-#. For **Allow Image Responses**, select **True**.
+To allow learners to submit a file along with their text responses, follow
+these steps.
 
-.. note:: 
- 
-   * The image file must be a .jpg or .png file, and it must be smaller than 5
-     MB in size. 
-   * Currently, course teams cannot see any of the images that
-     learners submit. Images are not visible in the body of the assignment in
-     the courseware, and they are not included in the course data package.
-   * You can allow learners to upload an image, but you cannot require it.
-   * Learners can only submit one image with each response.     
-   * All responses must contain text. Learners cannot submit a response that
-     contains only an image.
+#. In the open response assessment component editor, select **Settings**.
+
+#. Set **Allow File Upload** to one of these options.
+
+  * **Image File**
+  * **PDF or Image File**
+  * **Custom File Types**
+
+#. If you select **Custom File Types**, the **File Types** field appears. Enter
+   the file extensions, separated by commas, of the types of files that
+   you want learners to submit.
+
+   .. note:: To reduce the potential for problems from files with malicious
+    content, learners cannot upload certain file types. For more information,
+    see :ref:`Asking Learners to Upload Other Files in Responses`.
+
+#. Verify that the text of the prompt describes the file type or types that
+   learners can upload.
 
 .. _PA Add Rubric:
 
@@ -114,21 +131,38 @@ For each step below, replace any default text with your own text.
    individual criteria. See step 2.4 below for instructions. For more
    information, see :ref:`Feedback Options`.
 
-To add the rubric, complete these steps.
+To add the rubric, follow these steps.
 
 #. In the open response assessment component editor, select the **Rubric** tab.
-#. In the first **Criterion** section, enter the name and prompt text of your first criterion.
-#. In the first **Option** section, enter the name, explanation, and point value for the first option.
-#. In the next **Option** section, enter the name, explanation, and point value for the next option.
-#. Repeat step 4 for each option. If you need to add more options, select **Add Option**.
-#. Next to **Feedback for This Criterion**, select a value in the dropdown list.
 
-   * If you do not want learners to provide feedback for this individual criterion, select **None**.
-   * If you want to require learners to provide feedback, select **Required**.
-   * If you want to allow learners to provide feedback, but not require it, select **Optional**.
+#. In the first **Criterion** section, enter the name and prompt text of your
+   first criterion.
 
-7. Follow the instructions in steps 2-6 to add your remaining criteria. If you need to add more criteria, select **Add Criterion** at the end of the list of criteria.
-#. Include instructions for learners to provide overall written feedback on their peers' responses. You can leave the default text in the **Feedback Instructions** field or replace it with your own text.
+#. In the first **Option** section, enter the name, explanation, and point
+   value for the first option.
+
+#. In the next **Option** section, enter the name, explanation, and point value
+   for the next option.
+
+#. Repeat step 4 for each option. If you need to add more options, select **Add
+   Option**.
+
+#. Next to **Feedback for This Criterion**, select a value in the dropdown
+   list.
+
+  * If you do not want learners to provide feedback for this individual
+    criterion, select **None**.
+  * If you want to require learners to provide feedback, select **Required**.
+  * If you want to allow learners to provide feedback, but not require it,
+    select **Optional**.
+
+7. Follow the instructions in steps 2-6 to add your remaining criteria. If you
+   need to add more criteria, select **Add Criterion** at the end of the list
+   of criteria.
+
+#. Include instructions for learners to provide overall written feedback on
+   their peers' responses. You can leave the default text in the **Feedback
+   Instructions** field or replace it with your own text.
 
 .. note:: After you publish an ORA assignment, you can no longer change the
    structure of the rubric or the point values associated with each criterion
@@ -144,17 +178,20 @@ To add the rubric, complete these steps.
 Provide Only Comment Fields for Individual Criteria
 ==========================================================
 
-When you add a comment field to a criterion, the comment field appears below the
-options for the criterion. You can also provide a comment field, but no options.
+When you add a comment field to a criterion, the comment field appears below
+the options for the criterion. You can also provide a comment field, but no
+options.
 
-In the following image, the first criterion has a comment field but no options. The second includes options, but does not have a comment field.
+In the following image, the first criterion has a comment field but no options.
+The second includes options, but does not have a comment field.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_0_Option_Criteria.png
 
 To provide a comment field without options, complete these steps.
 
 #. In the criterion, select **Remove** to remove, or delete, all the options.
-#. Next to **Feedback for This Criterion**, select **Required** in the dropdown list.
+#. Next to **Feedback for This Criterion**, select **Required** in the dropdown
+   list.
 
 
 .. _PA Specify Name and Dates:
@@ -204,7 +241,7 @@ student responses, complete these steps.
 Step 5. Select Assignment Steps
 ****************************************
 
-Open response assessment assignments can include learner training, peer assessment, and self assessment steps. 
+Open response assessment assignments can include learner training, peer assessment, and self assessment steps.
 
 .. note:: If you include a learner training step, you must also include a peer
    assessment step. The learner training step must come before peer or self
@@ -225,7 +262,7 @@ To add steps to the open response assignment, complete these actions.
    * **Step: Peer Assessment**
    * **Step: Self Assessment**
 
-   Select the check boxes for the steps that you want the assignment to include. 
+   Select the check boxes for the steps that you want the assignment to include.
 
 #. (optional) To change the order of the steps, drag the steps into the order
    that you want.
@@ -306,10 +343,10 @@ Self Assessment
 For the self assessment step, you specify when the step starts and ends.
 
 #. Locate the **Step: Self Assessment** heading.
-   
+
 #. Next to **Start Date** and **Start Time**, enter the date and time when
    learners can begin assessing their peers' responses.
-   
+
 #. Next to **Due Date** and **Due Time**, enter the date and time by which all
    peer assessments must be complete.
 
@@ -329,7 +366,7 @@ To allow learners to see the top-scoring responses for the assignment, you
 specify a number on the **Settings** tab.
 
 #. In the component editor, select the **Settings** tab.
-   
+
 #. In the **Top Responses** field, specify the number of responses that you
    want to appear in the **Top Responses** section below the learner's final
    score. If you do not want this section to appear, set the number to 0. The
@@ -349,9 +386,9 @@ Step 8. Test the Assignment
 ******************************
 
 To test your assignment, set up the assignment in your course, set the section
-or subsection date in the future, and ask a group of beta users to submit
+or subsection date in the future, and ask a group of beta testers to submit
 responses and grade each other. The beta testers can then let you know if they
-found the question and the rubric easy to understand or if they had any problems
-with the assignment.
+found the question and the rubric easy to understand or if they had any
+problems with the assignment.
 
 For more information about beta testing, see :ref:`Beta_Testing`.

--- a/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
+++ b/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
@@ -22,7 +22,8 @@ Open response assessments allow the course team to assign questions that might
 not have definite answers, such as text responses or short essays. Learners
 submit responses to questions, then each learner and the learner's  peers
 compare the responses to a rubric that you create. You can also allow learners
-to upload an image to accompany a text response.
+to upload an image, a .pdf file, or another file of a type that you specify
+to accompany a text response.
 
 Open response assessments can include both peer assessments and self
 assessments. In peer assessments, learners compare their peers' responses to a
@@ -51,15 +52,11 @@ by step instructions, see the following sections.
 * :ref:`PA Create an ORA Assignment`
 * :ref:`Accessing ORA Assignment Information`
 
-  
 For information about viewing metrics and learner responses for released open
-response assessments, see :ref:`Accessing ORA Assignment Information`.  
+response assessments, see :ref:`Accessing ORA Assignment Information`.
 
 For information about the learner experience with open response assessments,
-see `Open Response Assessments <http://edx-guide-for-
-students.readthedocs.org/en/latest/SFD_ORA.html>`_ in the `edX Guide for
-Learners <http://edx-guide-for-
-students.readthedocs.org/en/latest/index.html>`_.
+see `Open Response Assessments <http://edx-guide-for-students.readthedocs.org/en/latest/SFD_ORA.html>`_ in the `edX Guide for Learners <http://edx-guide-for-students.readthedocs.org/en/latest/index.html>`_.
 
 
 .. _Best Practices for ORA:
@@ -71,11 +68,11 @@ Best Practices for Open Response Assessments
 Open response assessments can be a powerful teaching tool, but they are more
 effective in some situations than in others. In general, open response
 assessments are best suited to open-ended or project-based assignments with
-subjective essay answers and discussion. For example, open response
-assessments work well in humanities assignments where learners are encouraged
-to make subjective assessments of text or images, but they might not be the
-ideal tool in chemistry assignments where there are definitively correct or
-incorrect answers to questions.
+subjective essay answers and discussion. For example, open response assessments
+work well in humanities assignments where learners are encouraged to make
+subjective assessments of text, images, or other contributions, but they might
+not be the ideal tool in chemistry assignments where there are definitively
+correct or incorrect answers to questions.
 
 EdX suggests that you follow these guidelines and best practices when you use
 open response assessments in your courses.
@@ -93,7 +90,7 @@ open response assessments in your courses.
 
 * Provide an ungraded practice ORA assignment prior to the first graded ORA
   assignment in the course, so that learners can understand the peer grading
-  process and get the most out of the eventual graded ORA assignment. 
+  process and get the most out of the eventual graded ORA assignment.
 
 * Consider using ungraded ORA assignments to generate learner interaction and
   feedback without affecting grades.
@@ -144,7 +141,7 @@ elements:
 
 * The :ref:`rubric <PA Rubric>`. One rubric is used to grade all the prompts in
   the assessment.
-  
+
 * One or more :ref:`assessment steps <PA Assessment Steps>`. Assignments can
   include a learner training step, a peer assessment step, and a self
   assessment step.
@@ -165,42 +162,98 @@ Prompts
 Each **prompt**, or question, that you want your learners to answer, appears
 near the top of the page, followed by a field where the learner enters a
 response. You can require your learners to enter text as a response, or you can
-allow your learners to both enter text and upload an image.
+allow your learners to both enter text and upload another file, such as an
+image or document.
 
-.. note:: If learners upload an image, the image file must be a .jpg or .png 
- file, and it must be smaller than 5 MB in size.
+.. note:: Uploaded files must be smaller than 5 MB in size. If learners upload
+ an image, the file must be in .jpg, .gif, or .png format.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_QandRField.png
    :width: 500
-   :alt: Single ORA question and its corresponding blank response field
+   :alt: Single ORA question and its corresponding blank response field.
 
 When you write each question, you can include helpful information for your
 learners, such as what they can expect after they submit responses, or the
-approximate number of words or sentences that their response should have. 
+approximate number of words or sentences that their response should have.
 
 .. note:: Each learner is limited to a total word count of 10,000 for all
    responses in an ORA assignment.
 
 For more information, see :ref:`PA Add Prompt`.
 
+.. _Asking Learners to Upload Other Files in Responses:
 
-Asking Learners to Upload Images in Responses
-***********************************************
+Asking Learners to Upload Other Files in Responses
+*******************************************************
 
-In open response assessments, you can ask your learners to upload an image as
-part of their response. If you do this, however, keep the following points in
-mind.
+For an open response assessment, you can ask your learners to upload an image,
+a .pdf file, or a file of another type as a part of their responses. Other
+learners evaluate the responses and their accompanying files during the peer
+assessment. Offering the option to upload a file in addition to a text response
+can give learners the opportunity to use tools and develop skills that are
+relevant to your course.
 
-* You cannot require your learners to upload an image. You can only allow it.
+Before you decide to ask learners to upload other files along with their text
+responses, however, you should be aware of the following limitations and best
+practices.
 
-* All responses must include some text. Learners cannot submit a response that
-  contains only an image.
+* During the peer review process, learners download the files that other
+  learners uploaded. To reduce the potential for problems from files with
+  malicious content, learners cannot upload files with certain file extensions.
+  For a complete list, see :ref:`Prohibited File Extensions`.
 
-* Learners can submit only one image with each response.
+* Course teams can only access uploaded files for one learner at a time.
+  Uploaded file content is not included in the reports of answer submissions
+  available from the Instructor Dashboard, and course data packages do not
+  include any of the uploaded files.
 
-.. note:: Currently, course teams cannot see any of the images that learners
-   submit. Images are not visible in the body of the assignment in the
-   courseware, and they are not included in the course data package.
+* You cannot require your learners to upload files. You can only give them the
+  option to do so.
+
+* All responses must include some response text. Learners cannot submit a
+  response that contains only an uploaded file.
+
+* Learners can submit only one file with each response.
+
+* Files must be smaller than 5MB in size.
+
+* Image files must be in .jpg, .gif, or .png format.
+
+For more information, see :ref:`PA Allow Images`.
+
+.. _Prohibited File Extensions:
+
+Prohibited File Extensions
+***************************
+
+This topic lists the set of file extensions that learners are prohibited from
+uploading as part of an open response assessment on edx.org or edX Edge. When
+you define a set of custom file types for learners to upload with their
+responses, you cannot specify these file types. The extensions on this list are
+selected and maintained by the development operations team at edX, and are
+subject to change.
+
+.. only:: Open_edX
+
+  This set of file extensions is provided as the default for Open edX
+  installations. Open edX system administrators can update this list. For more
+  information, see :ref:`installation:Configuring ORA2 to Prohibit Submission
+  of File Types`.
+
+.. list-table::
+   :widths: 15 75
+
+   * - A through I
+     - .action, .apk, .app, .application, .bat, .bin, .cmd, .com, .command,
+       .cpl, .csh, .dmg, .exe, .gadget, .hta, .inf, .ins, .inx, .ipa,
+       .isu
+   * - J through P
+     - .jar, .job, .jse, .lnk., msc, .msh, .msh1, .msh2, .mshxml, .msh1xml,
+       .msh2xml, .msi, .msp, .mst, .osx, .out, .paf, .pif, .prg, psc1, .psc2,
+       .ps1, .ps1xml, .ps2, .ps2xml
+   * - Q through Z
+     - .reg, .rgs, .run, .scf, .scr, .sct, .shb, .shs, .u3p, .vb, .vbe, .vbs,
+       .vbscript, .workflow .ws, .wsc, .wsf, .wsh
 
 .. _PA Rubric:
 
@@ -214,7 +267,7 @@ grading. Learners compare their peers' responses to the rubric.
 
 Rubrics consist of *criteria* and *options*.
 
-* Each criterion has a *name*, a *prompt*, and one or more *options*. 
+* Each criterion has a *name*, a *prompt*, and one or more *options*.
 
    * The name is a very short summary of the criterion, such as "Ideas" or
      "Content". Criterion names generally have just one word. Because the system
@@ -226,7 +279,7 @@ Rubrics consist of *criteria* and *options*.
      .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CriterionName.png
         :alt: A final score page with call-outs for the criterion names
 
-   * The prompt is a description of the criterion. 
+   * The prompt is a description of the criterion.
 
    * Options describe how well the response satisfies the criterion.
 
@@ -288,10 +341,10 @@ points possible)
        dynastic disagreement between Edward III and Philip VI, leading to the
        Hundred Years' War.
 
-.. note:: For peer grading, the most effective rubrics are as concrete 
-   and specific as possible. Many novice learners will be unqualified 
+.. note:: For peer grading, the most effective rubrics are as concrete
+   and specific as possible. Many novice learners will be unqualified
    to make the types of value judgments required for more holistic
-   rubrics. In addition, edX suggests using clear, simple language in 
+   rubrics. In addition, edX suggests using clear, simple language in
    rubrics.
 
 
@@ -365,7 +418,7 @@ above the response.
 
   Learning to Assess Responses
   Your assessment differs from the instructor's assessment of this response. Review the
-  response and consider why the instructor may have assessed it differently. Then, try 
+  response and consider why the instructor may have assessed it differently. Then, try
   the assessment again.
 
 For each of the criteria, the learner sees one of the following two messages,
@@ -562,7 +615,7 @@ given for each criterion, as follows.
    individual assessor. Therefore, the score for the response is not the median
    of the scores that each individual peer assessor gave the response.
 
-For information on grades for learner submissions that you have cancelled and
+For information on grades for learner submissions that you have canceled and
 removed from peer assessment, refer to :ref:`Remove a learner response from peer
 grading`.
 
@@ -604,7 +657,7 @@ in height in the list. (For longer responses, learners can scroll to see the
 entire response.) EdX recommends that you specify 20 or fewer responses to
 prevent the page from becoming too long.
 
-.. note:: It may take up to an hour for a high-scoring response to appear in 
+.. note:: It may take up to an hour for a high-scoring response to appear in
  the **Top Responses** list.
 
    If a high-scoring response is :ref:`removed from peer assessment<Remove a


### PR DESCRIPTION
## [DOC-1635](https://openedx.atlassian.net/browse/DOC-1635)

ORA2 file upload feature is expanded to allow uploads of an additional image file type, an image or PDF file, or files of a type specified by the course team. 
See https://openedx.atlassian.net/browse/OSPR-683
https://github.com/edx/edx-ora2/pull/708
https://github.com/edx/edx-ora2/pull/646

Separate doc PRs will follow with documentation for learners and for Open edX devops.
### Date Needed

This feature is currently expected to be released week of 15 September.
### Reviewers
- [X] Subject matter expert: @xcompass
- [x] Doc team review (copyedit): @srpearce you know ORA2
- [x] Product review: @explorerleslie 

FYI: @catong @sstack22 @JAAkana @sarina @nedbat @smagoun 
### Sandbox
- [ ] https://studio-file-upload.sandbox.edx.org/
### Testing
- [X] make html ran without unexpected errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Update change log
- [x] Squash commits
