### PR TITLE
Rewrote to make it clearer that configuration is needed

### DIFF
--- a/en_us/course_authors/source/building_course/lti/index.rst
+++ b/en_us/course_authors/source/building_course/lti/index.rst
@@ -4,15 +4,22 @@
 Using edX as an LTI Tool Provider
 ######################################
 
-The edX Edge site is configured to be a learning tool interoperability (LTI)
-provider to other systems and applications. You can use this LTI capability to
-present content from an edX course on Edge in any application that is
-configured to be a consumer of that content. As a result, you can reuse edX
-course content, including advanced problem types and videos, in contexts other
-than the edX LMS. Examples include courses running on Canvas, Blackboard, and
-other learning management systems and applications.
+The edX Edge site can be configured to be a learning tool interoperability
+(LTI) provider to other systems and applications that partner institutions use.
+After initial configuration and testing between Edge and your system or
+application is complete, course teams can use this feature to reuse Edge course
+content, including advanced problem types and videos, in an on campus or in
+house learning management system. Examples currently include courses running on
+Canvas and Blackboard.
 
-You use the topics in this section to prepare your course for reuse.
+.. note:: Support for this feature is currently provisional. EdX is working 
+ with a set of early adopter partners to support further testing of this
+ feature with additional learning management systems.
+
+.. This note ^ can be removed after we get a better sense of how we'll do testing with new consumers, and regression testing for code changes. We'll also need to provide some direction on how they would line up this work (probably though Partner Manager) - Alison 16 Sept 15
+
+You use the topics in this section to prepare a course for reuse in another
+context.
 
 .. toctree::
    :maxdepth: 2

--- a/en_us/release_notes/source/2015/lms/lms_0916_2015.rst
+++ b/en_us/release_notes/source/2015/lms/lms_0916_2015.rst
@@ -27,8 +27,8 @@ Bug Fixes
   checkpoint were incorrectly shown a message indicating that they had missed
   the re-verification deadline. This issue has been resolved. Learners can
   continue to check whether they satisfied the verification or credit
-  requirement on their **Progress** pages. A green checkmark appears next to the
-  verification requirement when submitted photos are approved by the
+  requirement on their **Progress** pages. A green checkmark appears next to
+  the verification requirement when submitted photos are approved by the
   verification service. The verification process can take 24 hours or more.
   (ECOM-2225)
 
@@ -36,9 +36,9 @@ Bug Fixes
   **Progress** page in the order that they were created. They are now sorted by
   assessment start date. (ECOM-2118)
 
-* When learners select **Show Answer** for dropdown problems, the positioning of
-  the correct answer has been fixed so that it now displays in the same way as
-  it does for other problem types such as numerical input. (OSPR-794)
+* When learners select **Show Answer** for dropdown problems, the positioning
+  of the correct answer has been fixed so that it now displays in the same way
+  as it does for other problem types such as numerical input. (OSPR-794)
 
 * When learners select **Show Answer** for math expression input problems, the
   answer display and the loading animation have been improved. (OSPR-808)


### PR DESCRIPTION
Fixes @DOC-2271

@jibsheet @mhoeber 

In the initial version, I did not surface that course teams could not use the feature until it was configured on both of the systems being integrated. I also learned that we are not yet ready to even have partners contact their Partner Managers to set up configuration, as this is in a pilot stage and support is provisional.
