### PR TITLE
Fix description of ECOM-2118 in RN

### DIFF
--- a/en_us/release_notes/source/2015/lms/lms_0916_2015.rst
+++ b/en_us/release_notes/source/2015/lms/lms_0916_2015.rst
@@ -34,7 +34,7 @@ Bug Fixes
 
 * In for-credit courses, credit-eligible assessments were listed on the
   **Progress** page in the order that they were created. They are now sorted by
-  assessment due date. (ECOM-2118)
+  assessment start date. (ECOM-2118)
 
 * When learners select **Show Answer** for dropdown problems, the positioning of
   the correct answer has been fixed so that it now displays in the same way as


### PR DESCRIPTION
In RN for Sept 16, the description for the fix for ECOM-2118 should have described sorting by start date rather than due date.
