### PR TITLE
Procedure for LTI auth configuration

### DIFF
--- a/en_us/install_operations/source/configuration/lti/index.rst
+++ b/en_us/install_operations/source/configuration/lti/index.rst
@@ -23,6 +23,9 @@ For more information and examples of how course teams might set up a course on
 an external LMS as a consumer of edX course content, see `Using edX as an LTI
 Tool Provider`_ in the *Building and Running an edX Course* guide.
 
+You can also configure LTI authentication between your Open edX installation
+and an external LMS. For more information, see :ref:`Configuring Open edX for
+LTI Authentication`.
 
 .. include:: ../../links.rst
 

--- a/en_us/install_operations/source/configuration/tpa/index.rst
+++ b/en_us/install_operations/source/configuration/tpa/index.rst
@@ -18,6 +18,7 @@ campus or institutional credentials.
    tpa_SAML_SP
    tpa_SAML_IdP
    enable_tpa_edge
+   tpa_LTI
 
 This section includes information for teams involved in identity management at
 Open edX installations, including DevOps (development operations) and IT. The

--- a/en_us/install_operations/source/configuration/tpa/tpa_LTI.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_LTI.rst
@@ -1,0 +1,82 @@
+.. _Configuring Open edX for LTI Authentication:
+
+###############################################################
+Configuring Open edX for LTI Authentication
+###############################################################
+
+After you :ref:`configure your edX instance as an LTI tool provider<Configuring
+an edX Instance as an LTI Tool Provider>`, you can configure LTI authentication
+between your Open edX installation and an LTI tool consumer.
+
+Every learner who accesses content on an Open edX system must have a user
+account. The Open edX system uses the accounts to collect data, including
+grades, for learner interactions with courseware.
+
+When you use LTI authentication between your Open edX system and the system
+that is the tool consumer, when learners first encounter content from your Open
+edX system in the context of the LTI tool consumer they are prompted to
+register Open edX accounts. The Open edX account that each learner creates is
+linked to that learner's credentials for the tool consumer. As a result, after
+the initial account registration the learner is not prompted separately for
+account credentials.
+
+Your organization might prefer this authentication workflow if legal
+requirements or privacy concerns require learners to knowingly establish an
+identity in an Open edX system.
+
+.. contents::
+   :local:
+   :depth: 1
+
+**************************************************
+Configure LTI Authentication
+**************************************************
+
+To configure LTI authentication between your Open edX installation and an LTI
+tool consumer, follow these steps.
+
+.. note:: A consumer key and secret are required. The Django administration 
+ console provides a hexadecimal string for the secret, but does not provide a
+ hexadecimal string for the key. You must use an external tool to generate the
+ key.
+
+#. Sign in to the Django administration console for your base URL. For example,
+   ``http://{your_URL}/admin``.
+
+#. In the **Third_Party_Auth** section, next to **Provider Configuration
+   (LTI)** select **Add**.
+
+#. Select **Enabled**.
+
+#. Enter the **Name** of your Open edX system, as you want it to appear on the
+   registration page that is presented to learners who access Open edX content
+   from this LTI tool consumer.
+
+#. To customize the registration process for learners, you make selections for
+   these optional fields.
+
+  - **Skip Registration Form**: If you select this option, users are not asked
+    to confirm any user account data that is supplied for them by the LTI tool
+    consumer (name, email address, and so on).
+
+    By default, this option is cleared and learners review a registration form
+    with the account details supplied by the tool consumer.
+
+  - **Skip Email Verification**: If you select this option, users are not
+    required to confirm their email addresses, and their accounts are activated
+    immediately upon registration.
+
+    By default, this option is cleared and learners receive an email message
+    and must select a link in that message to activate their user accounts.
+
+6. Enter the following information.
+
+  - **Lti consumer key**: Enter the hexadecimal string of the key.
+  
+  - **Lti consumer secret**: The system generates a hexadecimal string value
+    for this field. Alternatively, you can replace it with a secret generated
+    by an external tool.
+
+7. Optionally, change the default value for the **Lti max timestamp age**.
+
+#. Select **Save** at the bottom of the page. 

--- a/en_us/install_operations/source/configuration/tpa/tpa_providers.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_providers.rst
@@ -15,15 +15,15 @@ provider, and configure each of the three institutions to be identity
 providers, you permit learners who have valid user credentials at any of
 those institutions to access the Open edX site. 
 
-.. You can enable third party authentication between your Open edX system and identity providers that use the SAML 2.0 (Security Assertion Markup Language, version 2.0) or OAuth2 standards for authentication. For more information, see :ref:`Integrating with a SAML Identity Provider` or :ref:`Integrating with an OAuth2 Identity Provider`.
+.. You can enable third party authentication between your Open edX system and identity providers that use the SAML 2.0 (Security Assertion Markup Language, version 2.0) or OAuth2 standards for authentication. 
 
-.. replace the following para with the above para when ready to add OAuth2 
+.. replace the first following sentence with the above when ready to add OAuth2 
 .. - Alison 5 Aug 15
 
 You can enable third party authentication between your Open edX system and
 identity providers that use the SAML 2.0 (Security Assertion Markup Language,
-version 2.0). For more information, see :ref:`Integrating with a SAML Identity
-Provider`.
+version 2.0) standard for authentication. For more information, see
+:ref:`Integrating with a SAML Identity Provider`.
 
 .. Regardless of the standard that the identity provider you want to integrate with uses, you begin by :ref:`enabling the third party authentication feature<Enable the Third Party Authentication Feature>` for your installation.
 
@@ -37,3 +37,9 @@ installation.
 At an institution that has a partner membership with edX, you can :ref:`enable
 third party authentication<Enabling Third Party Authentication Edge>` between
 your institutional authentication systems and the edX Edge site.
+
+If you are using :ref:`edX as an LTI tool provider<Configuring an edX Instance
+as an LTI Tool Provider>` to a external learning management system or
+application, you can set up an authentication workflow between your Open edX
+system and the system that is the LTI tool consumer. For more information, see
+:ref:`Configuring Open edX for LTI Authentication`.


### PR DESCRIPTION
## [DOC-2248](https://openedx.atlassian.net/browse/DOC-2248)

This PR adds an MVP-level procedure for configuring non-anonymous authentication between an Open edX tool provider and an LTI tool consumer. 
- More complete conceptual information, including a comparison between anonymous and Open edX authentication will follow (DOC-2295).
- I did not have access to a tool consumer system that uses this authentication method, so I could not provide any example guidance (albeit system dependent) for setup steps on the TC system.
- I also could not test the registration page or process that learners might see/experience, so that information is not included.
### Date Needed

This feature is already available.
### Reviewers
- [ ] Subject matter expert: @fredsmith 
- [ ] Subject matter expert: @cpennington 
- [ ] Subject matter expert: @ormsbee 
- [x] Doc team review (sanity check): @catong or @srpearce 
- [ ] Product review: @ebporter

FYI: @bradenmacdonald @sarina @jibsheet @mhoeber 
### Sandbox

Screenshot of the Django admin console for Edge:

<img width="1919" alt="screenshot 2015-09-15 11 36 41-2" src="https://cloud.githubusercontent.com/assets/6392274/10031542/d85c0208-614b-11e5-9bad-2467e395ef94.png">
### Testing
- [X] make html ran without unexpected errors
### Post-review
- [ ] Squash commits
- [ ] Add description to release notes task as a comment
- [ ] Update change log
