### PR TITLE
Update Partner doc with Mobile Assessments

### DIFF
--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -169,7 +169,7 @@ General Exercises and Tools
      - In text input problems, students enter text into a response field. The
        response can include numbers, letters, and special characters such as
        punctuation marks.
-     - Full support
+     - Full support; mobile-ready
    * - :ref:`Word Cloud`
      - Word clouds arrange text that students enter - for example, in response
        to a question - into a colorful graphic that students can see.
@@ -234,26 +234,27 @@ Multiple Choice Exercises and Tools
      - In checkbox problems, the student selects one or more options from a
        list of possible answers. The student must select all the options that
        apply to answer the problem correctly.
-     - Full support
+     - Full support; mobile-ready
    * - :ref:`Dropdown`
      - Dropdown problems allow the student to choose from a collection of
        answer options, presented as a dropdown list. Unlike multiple choice
        problems, whose answers are always visible directly below the question,
        dropdown problems don't show answer choices until the student clicks the
        dropdown arrow.
-     - Full support
+     - Full support; mobile-ready
    * - :ref:`Multiple Choice`
      - In multiple choice problems, students select one option from a list of
        answer options. Unlike with dropdown problems, whose answer choices
        don't appear until the student clicks the drop-down arrow, answer
        choices for multiple choice problems are always visible directly below
        the question.
-     - Full support
+     - Full support; mobile-ready  
    * - :ref:`Multiple Choice and Numerical Input`
      - You can create a problem that combines a multiple choice and numerical
        input problems. Students not only select a response from options that
        you provide, but also provide more specific information, if necessary.
-     - Provisional support
+     - Provisional support; mobile-ready
+
 
 ********************************
 STEM Exercises and Tools
@@ -309,7 +310,7 @@ STEM Exercises and Tools
        integers and a few select constants. You can specify a margin of error,
        and you can specify a correct answer either explicitly or by using a
        Python script.
-     - Full support
+     - Full support; mobile-ready  
    * - :ref:`Periodic Table`
      - An interactive periodic table of the elements shows detailed information
        about each element as the student moves the mouse over the element.
@@ -319,14 +320,9 @@ STEM Exercises and Tools
        shapes by stringing together amino acids.
      - No support
 
-.. The following section lists the types of problems that learners can interact with in the edX mobile app.
-.. Alison, DOC-1840, June 2015
 
-.. only:: Open_edX
+*********************************
+Mobile-Ready Problem Types
+*********************************
 
-  *********************************
-  Mobile-Ready Problem Types
-  *********************************
-
-  .. include:: ../../../shared/exercises_tools/Section_mobile_problems.rst
-
+.. include:: ../../../shared/exercises_tools/Section_mobile_problems.rst

--- a/en_us/shared/students/SFD_mobile.rst
+++ b/en_us/shared/students/SFD_mobile.rst
@@ -19,11 +19,13 @@ Overview of the edX Mobile App
 
 .. only:: Partners
 
-  The edX mobile apps are companions to the `edx.org`_ website. You can use the
-  apps to download course videos so that you can watch them whenever you want
-  to, even without an Internet connection. To access the rest of the course,
-  including course discussions, homework, and quizzes, you use a web browser on
-  a computer.
+  The edX mobile apps are companions to the `edx.org`_ website. You can use
+  the apps to download course videos so that you can watch them whenever you
+  want to, even without an Internet connection. When you have an Internet
+  connection, you can also view course announcements and content, and do some,
+  but not all, of the problems in your assignments. To complete an entire
+  course and participate in course discussions, you use a web browser on a
+  computer.
 
 .. The following paragraph describes the features of the edX mobile app for Open edX (adds notifications, assessments, discussions)
 .. Alison, DOC-1840, June 2015
@@ -33,7 +35,7 @@ Overview of the edX Mobile App
   You can use the edX mobile apps to download course videos so that you can
   watch them whenever you want to, even without an Internet connection. When
   you have an Internet connection, you can also read course announcements,
-  participate in discussions, and get started on homework and other
+  participate in course discussions, and get started on homework and other
   assignments. To complete an entire course, you use a web browser on a
   computer.
 
@@ -72,26 +74,12 @@ Courseware Questions
 Can I take a course entirely on my mobile device?
 ========================================================
 
-.. The following paragraph describes the features of the edX mobile app for partners/edx.org (video only)
-.. Alison, DOC-1840, June 2015
-
-.. only:: Partners
-
-  Not at this time. With the edX mobile app, you can download course videos to
-  watch when you do not have an Internet connection. To complete other work,
-  including readings, homework problems, and exams, use a computer.
-
-.. The following paragraph describes the features of the edX mobile app for Open edX (adds notifications, assessments, discussions)
-.. Alison, DOC-1840, June 2015
-
-.. only:: Open_edX
-
-  Not entirely. With the edX mobile app, you can download course videos to
-  watch when you do not have an Internet connection. When you have an Internet
-  connection, you can also read course announcements and content, participate
-  in discussions, and do some, but not all, of the problems in your
-  assignments. To complete an entire course, you use a web browser on a
-  computer.
+Not entirely. With the edX mobile app, you can download course videos to watch
+when you do not have an Internet connection. When you have an Internet
+connection, you can also read course announcements and content, and do some,
+but not all, of the problems in your assignments. To complete an entire
+course, including participating in course discussions, you use a web browser
+on a computer.
 
 ========================================================
 How do I post questions on the discussion board?


### PR DESCRIPTION
This PR updates the partner "Building and Running an edX Course" guide and the edX Learner's Guide to reflect the types of assessment that are currently supported in the mobile app. Changes include adding a "mobile-ready" indication to the table of exercises and tools support.
https://openedx.atlassian.net/browse/DOC-2117
### Reviewers

Check the appropriate box after each reviewer finishes and gives :+1:.
- [ ] Subject matter expert: @nasthagiri 
- [x] Subject matter expert: @aleffert 
- [x] Doc team review: @lamagnifica  
- [x] Product review: @explorerleslie 
- FYI: 
### Draft HTML Documentation
- [x] http://draft-br-mobile-assessments.readthedocs.org/en/latest/exercises_tools/create_exercises_and_tools.html#introduction-to-exercises-and-tools
### Post-review
- [ ] Squash commits
