### PR TITLE
Adds procedure for changing default ORA2 blacklist

### DIFF
--- a/en_us/install_operations/source/configuration/index.rst
+++ b/en_us/install_operations/source/configuration/index.rst
@@ -23,5 +23,4 @@ configuration options.
    tpa/index
    lti/index
    youtube_api
-   ora2_uploads
-
+   ora2/index

--- a/en_us/install_operations/source/configuration/install_google_drive.rst
+++ b/en_us/install_operations/source/configuration/install_google_drive.rst
@@ -38,12 +38,12 @@ To install the Google Drive XBlock, follow these steps.
 
 #. Save the ``requirements/edx/github.txt`` file.
 
-After you configure the edX Platform to use Google Drive files or a Google
-Calendar, each course team that wants to use it must enable the tool for their
-course. For more information, see these references.
+After you configure the edX Platform, to use Google Drive files or a Google
+Calendar in a course, you must add the XBlock to the advanced settings for the
+course. For more information, see the following topics in the *Building and
+Running an Open edX Course* guide.
 
 * :ref:`opencoursestaff:Enable the Google Drive Files Tool`
 * :ref:`opencoursestaff:Enable the Google Calendars Tool`
-
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/ora2/index.rst
+++ b/en_us/install_operations/source/configuration/ora2/index.rst
@@ -1,0 +1,23 @@
+.. _Configuring Open Response Assessments:
+
+########################################################
+Configuring Open Response Assessments
+########################################################
+
+You can change the default configuration for the Open Response Assessment
+(ORA2) application. You can change the default file storage system or change
+the default set of files that learners are prohibited from submitting.
+
+.. toctree::
+   :maxdepth: 1
+
+   ora2_uploads
+   ora2_blacklist
+
+For more information and examples of how course teams might set up an open
+response assessment, see :ref:`opencoursestaff:Open Response Assessments 2` in
+the *Building and Running an Open edX Course* guide.
+
+
+.. include:: ../../../../links/links.rst
+

--- a/en_us/install_operations/source/configuration/ora2/ora2_blacklist.rst
+++ b/en_us/install_operations/source/configuration/ora2/ora2_blacklist.rst
@@ -1,0 +1,45 @@
+
+.. include:: ../../../../links/links.rst
+
+.. _Configuring ORA2 to Prohibit Submission of File Types:
+
+###############################################################
+Configuring ORA2 to Prohibit Submission of File Types
+###############################################################
+
+Course teams can configure open response assessments so that learners can
+upload files along with their text responses. During the peer review stage of
+the assessment, one or more other learners downloads the submitted file and
+reads the response. 
+
+To protect learners from exposure to files with malicious content, the ORA2
+application identifies a set of file types that learners are not permitted to
+upload in a "blacklist".
+
+To add or remove file types from the blacklist, follow these steps.
+
+#. In the ORA-2 repository, use an editor to open the `submission_mixin.py`_
+   file.
+
+#. Locate the ``FILE_EXT_BLACK_LIST`` parameter in the file. By default, this
+   parameter lists the following file types.
+   
+   ::
+
+     FILE_EXT_BLACK_LIST = [
+         'exe', 'msi', 'app', 'dmg', 'com', 'pif', 'application', 'gadget',
+         'msp', 'scr', 'hta', 'cpl', 'msc', 'jar', 'bat', 'cmd', 'vb', 'vbs',
+         'jse', 'ws', 'wsf', 'wsc', 'wsh', 'scf', 'lnk', 'inf', 'reg', 'ps1',
+         'ps1xml', 'ps2', 'ps2xml', 'psc1', 'psc2', 'msh', 'msh1', 'msh2', 'mshxml',
+         'msh1xml', 'msh2xml', 'action', 'apk', 'app', 'bin', 'command', 'csh',
+         'ins', 'inx', 'ipa', 'isu', 'job', 'mst', 'osx', 'out', 'paf', 'prg',
+         'rgs', 'run', 'sct', 'shb', 'shs', 'u3p', 'vbscript', 'vbe', 'workflow',
+     ]
+
+#. Add or remove values from this list. 
+
+#. Save your changes to ``submission_mixin.py``.
+
+#. Restart the Studio (CMS) and Learning Management System (LMS) processes so
+   that your updates are loaded.
+

--- a/en_us/install_operations/source/configuration/ora2/ora2_uploads.rst
+++ b/en_us/install_operations/source/configuration/ora2/ora2_uploads.rst
@@ -1,8 +1,10 @@
+.. include:: ../../../../links/links.rst
+
 .. _Configuring ORA2 to Upload Files to Alternative Storage Systems:
 
-################################################################
+###############################################################
 Configuring ORA2 to Upload Files to Alternative Storage Systems
-################################################################
+###############################################################
 
 By default, the Open Response Assessment (ORA2) application stores files that
 learners upload in an Amazon S3 bucket.
@@ -31,4 +33,3 @@ must complete the following steps.
 
 .. to do - used shared file with cypress release notes
 
-.. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/front_matter/change_log.rst
+++ b/en_us/install_operations/source/front_matter/change_log.rst
@@ -8,6 +8,9 @@ Change Log
 
    * - Date
      - Change
+   * - 21 October 2015
+     - Added the :ref:`Configuring ORA2 to Prohibit Submission of File Types`
+       section.
    * - 20 October 2015
      - Added the :ref:`Add Keys to the LMS Configuration File` topic.
    * - 5 October 2015

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -80,6 +80,8 @@
 
 .. _requirements/edx/github.txt: https://github.com/edx/edx-platform/blob/master/requirements/edx/github.txt
 
+.. _submission_mixin.py: https://github.com/edx/edx-ora2/blob/a4ce7bb00190d7baff60fc90fb613229565ca7ef/openassessment/xblock/submission_mixin.py
+
 .. _edx-platform: https://github.com/edx/edx-platform
 
 .. _edx configuration repository: https://github.com/edx/configuration


### PR DESCRIPTION
## [DOC-2258](https://openedx.atlassian.net/browse/DOC-2258)

Describes how sys admins can change the contents of the file upload blacklist. The configuration/ora2/ora_blacklist.rst file contains all of the info for this story, although I relocated a file and set up a new subdirictory for all ora2 configuration topics.

This is the last of 3 planned doc PRs for changes in ORA2 functionality contributed by @xcompass at UBC in https://github.com/edx/edx-ora2/pull/708.

The other doc PRs are #543 for course teams and #544 for learners.
### Reviewers
- [ ] Subject matter expert: @xcompass
- [x] Doc team review (dev edit): @mhoeber 
- [x] Product review: @explorerleslie 

FYI: @sarina 
### Sandbox
- [ ] https://studio-file-upload.sandbox.edx.org/
### Testing
- [x] make html ran without unexpected errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Update change log
- [x] Squash commits
