### PR TITLE
Make the locations of the torrent file more generic

### DIFF
--- a/en_us/install_operations/source/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/devstack/install_devstack.rst
@@ -37,7 +37,7 @@ Devstack includes the following edX components:
 * edX Studio
 * Discussion Forums
 * Open Response Assessments (ORA)
-  
+
 Devstack also includes a demo edX course.
 
 **************************
@@ -67,8 +67,8 @@ software.
 
 * A Network File System (NFS) client, if your operating system does not include
   one. Devstack uses VirtualBox Guest Editions to share folders through NFS.
-  
-.. _Install DevStack:  
+
+.. _Install DevStack:
 
 **************************
 Install DevStack
@@ -86,20 +86,20 @@ computer.
 #. Ensure the ``nfsd`` client is running.
 
 #. Create the ``devstack`` directory and navigate to it in the command prompt.
-   
+
    .. code-block:: bash
 
      mkdir devstack
      cd devstack
 
 #. Download the Devstack Vagrant file.
-   
+
    .. code-block:: bash
 
      curl -L https://raw.github.com/edx/configuration/master/vagrant/release/devstack/Vagrantfile > Vagrantfile
 
 #. Install the Vagrant ``vbguest`` plugin.
-   
+
    .. code-block:: bash
 
      vagrant plugin install vagrant-vbguest
@@ -132,7 +132,9 @@ You can use BitTorrent to download the box file.  Follow all of the
 instructions in :ref:`Install DevStack`, but instead of downloading
 the Vagrant file with curl, do this:
 
-#. Download the Devstack `Torrent`_ file.
+#. Download the Torrent file for the latest Open edX release.
+   See the `Open edX Releases Wiki page`_ to find out what the latest Open edX
+   release is, and where to download the Torrent file.
 
 #. When you have the file on your computer, add the virtual machine using the
    following command.
@@ -162,7 +164,7 @@ To resolve the error, follow these steps.
 
 #. Stop the VPN.
 #. Type ``vagrant halt``.
-#. Open Virtualbox.   
+#. Open Virtualbox.
 #. Navigate to **Preferences > Network > Host-only Networks** and remove the
    most-recently-created host-only network.
 #. Type ``vagrant up``.

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -51,7 +51,7 @@
 .. _VirtualEnv: http://www.virtualenv.org/en/latest/
 
 .. _VirtualEnv Installation: https://virtualenv.pypa.io/en/latest/installation.html
-         
+
 .. _VirtualEnvWrapper: http://virtualenvwrapper.readthedocs.org/en/latest
 
 .. _XBlock SDK: https://github.com/edx/xblock-sdk
@@ -101,14 +101,6 @@
 .. _S3.py: https://github.com/edx/edx-ora2/blob/a4ce7bb00190d7baff60fc90fb613229565ca7ef/openassessment/fileupload/backends/s3.py
 
 .. EDX VMs
-
-.. _Birch Devstack BitTorrent: https://s3.amazonaws.com/edx-static/vagrant-images/birch-2-devstack.box?torrent
-
-.. _Birch Fullstack BitTorrent: https://s3.amazonaws.com/edx-static/vagrant-images/birch-2-fullstack.box?torrent
-
-.. _Birch Devstack: https://s3.amazonaws.com/edx-static/vagrant-images/birch-2-devstack.box
-
-.. _Birch Fullstack: https://s3.amazonaws.com/edx-static/vagrant-images/birch-2-fullstack.box
 
 .. _iOS: http://github.com/edx/edx-app-ios
 .. _Android: http://github.com/edx/edx-app-android
@@ -198,7 +190,7 @@
 
 .. _Proctoring Software System Requirements: http://clientportal.softwaresecure.com/support/index.php?/Knowledgebase/Article/View/252/0/system-requirements-remote-proctor-now
 
-.. _Proctoring Software System Requirements: http://clientportal.softwaresecure.com/support/index.php?/Knowledgebase/Article/View/252/0/system-requirements-remote-proctor-now 
+.. _Proctoring Software System Requirements: http://clientportal.softwaresecure.com/support/index.php?/Knowledgebase/Article/View/252/0/system-requirements-remote-proctor-now
 
 .. _Vagrant's documentation on boxes: http://docs.vagrantup.com/v2/boxes.html
 
@@ -224,8 +216,6 @@
 .. _VirtualBox: https://www.virtualbox.org/wiki/Downloads
 
 .. _Vagrant: http://www.vagrantup.com/downloads.html
-
-.. _Torrent: https://s3.amazonaws.com/edx-static/vagrant-images/20141118-lavash-devstack.box?torrent
 
 .. _VirtualBox Guest Editions: http://www.virtualbox.org/manual/ch04.html
 


### PR DESCRIPTION
[This page still references the lavash torrent file](http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/devstack/install_devstack.html#install-devstack-using-the-torrent-file), which is incredibly outdated. We should make this documentation more generic when it comes to Open edX releases.
