### PR TITLE
Fix typo in link formatting

### DIFF
--- a/en_us/release_notes/source/2015/documentation/doc_0804_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0804_2015.rst
@@ -33,6 +33,6 @@ Building and Running an Open edX Course
   :ref:`opencoursestaff:Numerical Input` sections have clearer
   information about using the **Randomization** setting.
 
-* The ref:`opencoursestaff:Review_Answers` section no longer contains
+* The :ref:`opencoursestaff:Review_Answers` section no longer contains
   references to features on the **Analytics** page of the Instructor Dashboard.
   Course data is available in edX Insights.


### PR DESCRIPTION
@lamagnifica Can I get quick thumbs? A `:ref:` tag was missing the first colon.
