### PR TITLE
Updates the SAML SP configuration to use lms.auth.json

### DIFF
--- a/en_us/install_operations/source/configuration/install_google_drive.rst
+++ b/en_us/install_operations/source/configuration/install_google_drive.rst
@@ -4,22 +4,23 @@
 Adding the Google Drive and Google Calendar XBlock
 ######################################################
 
-In the Open edX Birch release, course teams can embed Google calendars and
-Google Drive files in courseware.
+Beginning with the Open edX Birch release, course teams can embed Google
+calendars and Google Drive files in courseware.
 
-To enable this feature on your instance of Open edX, you install the `Google Drive XBlock`_.
+To enable this feature on your instance of Open edX, you install the
+`Google Drive XBlock`_.
 
 For information about using Google calendars and Google Drive files in courses,
 see the *Building and Running an Open edX Course* guide.
 
-.. Note::  
+.. Note::
   Before proceeding, review :ref:`Guidelines for Updating the Open edX
   Platform`.
 
 To install the Google Drive XBlock, follow these steps.
 
-#. In the edX Platform installation directory, edit the file
-   ``requirements/edx/github.txt``
+#. In the edX Platform installation directory, edit the
+   ``requirements/edx/github.txt`` file.
 
 #. Add a line to include the XBlock utilities.
 
@@ -29,7 +30,7 @@ To install the Google Drive XBlock, follow these steps.
      utils.git@349d6e05dbd553e1f18d3ad1f7ca02c0497f39d7#egg=xblock-utils
 
 #. Add a line to add the Google Drive XBlock.
-   
+
    .. code-block:: bash
 
      git+https://github.com/edx-solutions/xblock-google-drive.
@@ -37,8 +38,12 @@ To install the Google Drive XBlock, follow these steps.
 
 #. Save the ``requirements/edx/github.txt`` file.
 
-After you configure the edX Platform, to use Google Drive files or a Google
-Calendar in a course, you must add the XBlock to the advanced settings for the
-course. See  * :ref:`opencoursestaff:Enable Additional Exercises and Tools`.
+After you configure the edX Platform to use Google Drive files or a Google
+Calendar, each course team that wants to use it must enable the tool for their
+course. For more information, see these references.
+
+* :ref:`opencoursestaff:Enable the Google Drive Files Tool`
+* :ref:`opencoursestaff:Enable the Google Calendars Tool`
+
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
@@ -1,14 +1,13 @@
 .. _Configuring your Installation as a SAML Service Provider:
 
 ###############################################################
-Configuring your Installation as a SAML Service Provider 
+Configuring your Installation as a SAML Service Provider
 ###############################################################
 
-The first step in configuring your Open edX installation to act as a SAML SP
-(service provider) is to create a credential key pair to ensure secure data
-transfers with identity providers. To complete the configuration procedure, you
-configure your Open edX installation as a SAML service provider which creates
-your metadata XML file.
+The first step in configuring your Open edX installation to act as a SAML SP is
+to create a credential key pair to ensure secure data transfers with identity
+providers. To complete the configuration procedure, you configure your Open edX
+installation as a SAML SP, which creates your metadata XML file.
 
 .. contents::
    :local:
@@ -27,13 +26,83 @@ To generate the keys for your Open edX installation, follow these steps.
 
 #. On your local computer or on the server, open Terminal or a Command Prompt
    and run the following command.
-   
+
    ``openssl req -new -x509 -days 3652 -nodes -out saml.crt -keyout saml.key``
 
-#. Provide information at each prompt. 
-   
+#. Provide information at each prompt.
+
 Two files, ``saml.crt`` and ``saml.key``, are created in the directory where
 you ran the command.
+
+.. _Add Keys to the LMS Configuration File:
+
+**************************************************
+Add Keys to the LMS Configuration File
+**************************************************
+
+.. note:: Configuration settings added to the ``lms.auth.json`` file are reset
+ to their default values when you use Ansible to update edx-platform.
+
+To configure your Open edX installation with your public and private SAML keys,
+follow these steps.
+
+#. Open the ``edx/app/edxapp/lms.auth.json`` file in your text editor.
+
+#. Edit the file to add a section for the SAML keys. For example,
+   ``# SAML KEYS``.
+
+#. In the new section, add the ``SOCIAL_AUTH_SAML_SP_PUBLIC_CERT`` parameter
+   followed by a colon (:), a space, and the YAML literal style indicator (|).
+
+   .. code:: json
+
+    # SAML KEYS
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: |
+
+#. Open the ``saml.crt`` file, copy its entire contents, and then paste them
+   onto the line after the ``SOCIAL_AUTH_SAML_SP_PUBLIC_CERT`` parameter.
+
+   .. code:: json
+
+    # SAML KEYS
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: |
+    -----BEGIN CERTIFICATE-----
+    SWP6P/C1ypaYkmS...
+       ...j9+hjvbBf3szk=
+    -----END CERTIFICATE-----
+
+#. Add the ``SOCIAL_AUTH_SAML_SP_PRIVATE_KEY`` parameter followed by a colon
+   (:), a space, and the YAML literal style indicator (|).
+
+   .. code:: json
+
+    # SAML KEYS
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: |
+    -----BEGIN CERTIFICATE-----
+    SWP6P/C1ypaYkmS...
+       ...j9+hjvbBf3szk=
+    -----END CERTIFICATE-----
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: |
+
+#. Open the ``saml.key`` file, copy its entire contents, and then paste them
+   onto the line after the ``SOCIAL_AUTH_SAML_SP_PRIVATE_KEY`` parameter.
+
+   .. code:: json
+
+    # SAML KEYS
+    SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: |
+    -----BEGIN CERTIFICATE-----
+    SWP6P/C1ypaYkmS...
+       ...j9+hjvbBf3szk=
+    -----END CERTIFICATE-----
+    SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: |
+    -----BEGIN RSA PRIVATE KEY-----
+    W1icmlkZN+FtM5h...
+       ...s/psgLDn38Q==
+    -----END RSA PRIVATE KEY-----
+
+#. Save and close the ``lms.env.json`` file.
+
 
 **************************************************
 Configure your Installation as a Service Provider
@@ -52,21 +121,15 @@ these steps.
 
 #. Enter the following information.
 
-  - **Private key**: Use a text editor to open the ``saml.key`` file, and then
-    copy the RSA private key into this field.
-  
-  - **Public key**: Use a text editor to open the ``saml.crt`` file, and then
-    copy the certificate into this field.
-  
   - **Entity ID**: Enter a URI for the server. To ensure that this value
     uniquely identifies your site, the naming convention that edX recommends is
     to include the server's domain name. For example,
     ``http://saml.mydomain.com/``.
-  
+
   - **Organization Info**: Use the format in the example that follows to
     specify a language and locale code and identifying information for your
     installation.
-    
+
     .. code:: json
 
      {
@@ -78,19 +141,25 @@ these steps.
      }
 
   - **Other config str**: Define the security settings for the IdP metadata
-    files. For more information about the security settings, see the `Python SAML Toolkit`_. An example follows.
-    
+    files. For more information about the security settings, see the
+    `Python SAML Toolkit`_. An example follows.
+
     .. code:: json
 
-     { 
+     {
         "SECURITY_CONFIG": {
-          "signMetadata": false, 
+          "signMetadata": false,
           "metadataCacheDuration": ""
         }
      }
 
-5. Select **Save** at the bottom of the page. You can direct identity providers
-   to ``{your LMS URL}/auth/saml/metadata.xml`` for your metadata file.
+#. Optionally, you can save your public and private keys in the Django
+   administration console. Because this procedure saves your credentials in the
+   database, edX recommends that you use the ``lms.auth.json`` file instead.
+   For more information, see :ref:`Add Keys to the LMS Configuration File`.
+
+#. Select **Save**. You can direct identity providers to
+   ``{your LMS URL}/auth/saml/metadata.xml`` for your metadata file.
 
 *******************************************************
 Ensure that the SAML Authentication Backend is Loaded

--- a/en_us/install_operations/source/configuration/youtube_api.rst
+++ b/en_us/install_operations/source/configuration/youtube_api.rst
@@ -92,8 +92,8 @@ To set your YouTube API key by editing JSON files, complete the following
 steps.
 
 #. Find the `edx-platform`_ repository on your Open edX server. If you are
-   running Devstack or Fullstack, the directory is ``/edx/app/edxapp/edx-
-   platform``.
+   running Devstack or Fullstack, the directory is
+   ``/edx/app/edxapp/edx-platform``.
 
 #. In the directory *above* your repository, there should be several JSON
    files, including ``lms.auth.json`` and ``cms.auth.json``. If you are running
@@ -102,10 +102,11 @@ steps.
 #. Open the ``lms.auth.json`` file in your text editor.
 
 #. Find the line for the YouTube API key.
+
    ``"YOUTUBE_API_KEY": "PUT_YOUR_API_KEY_HERE",``
 
-   Replace ``PUT_YOUR_API_KEY_HERE`` with your YouTube API key. Ensure
-   that the YouTube API key is within by quotation marks.
+   Replace ``PUT_YOUR_API_KEY_HERE`` with your YouTube API key. Verify
+   that the YouTube API key is between the quotation marks.
 
 #. Save and close the file.
 

--- a/en_us/install_operations/source/front_matter/change_log.rst
+++ b/en_us/install_operations/source/front_matter/change_log.rst
@@ -8,6 +8,8 @@ Change Log
 
    * - Date
      - Change
+   * - 20 October 2015
+     - Added the :ref:`Add Keys to the LMS Configuration File` topic.
    * - 5 October 2015
      - Added the :ref:`Enabling Social Sharing of Courses and Certificates`
        section.
@@ -24,7 +26,7 @@ Change Log
      - Added the :ref:`Open edX Cypress Release` section.
    * -
      - Added the :ref:`YouTube_API` section.
-   * - 
+   * -
      - Added the :ref:`Configuring ORA2 to Upload Files to Alternative Storage
        Systems` section.
    * - 6 Aug 2015
@@ -35,11 +37,11 @@ Change Log
      - Added the :ref:`Enable CCX` section.
    * - 8 June 2015
      - Added :ref:`Enable edX Search`.
-   * - 
+   * -
      - Added :ref:`Enable Certificates`.
-   * - 
+   * -
      - Added :ref:`Enable Badging`.
-   * - 
+   * -
      - Updated the :ref:`Setting up the Mobile Applications` section to include
        configuration for push notifications.
    * - 28 May 2015
@@ -49,7 +51,7 @@ Change Log
        edX Partner Portal` and the :ref:`The Open edX Portal`.
    * - 24 Feb 2015
      - Updated for the :ref:`Open edX Birch Release`.
-   * - 
+   * -
      - Added the section :ref:`Configuring the Open edX Platform`.
    * - 20 Jan 2015
      - Added the section :ref:`Installing edX Insights`.


### PR DESCRIPTION
## [DOC-2230](https://openedx.atlassian.net/browse/DOC-2230)

Immediately after release, a security problem was detected in that the SAML credentials were stored in the database. @jibsheet added configuration parameters to replace the original Django admin console fields, although those fields remain in place.

@jibsheet please note that you provided the names of the config parameters both with and without the EDXAPP_ prefix. I included it, but please let me know if Open edX folks will use the version without.
### Date Needed

This change is already available.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @jibsheet
- [x] Doc team review (copyedit): @srpearce 
### Testing
- [x] Ran en_us/make without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment
- [ ] Update change log
- [ ] Squash commits
