### PR TITLE
Ahodges/oppia events

### DIFF
--- a/en_us/data/source/front_matter/change_log.rst
+++ b/en_us/data/source/front_matter/change_log.rst
@@ -5,6 +5,20 @@ Change Log
 ###########
 
 
+**********************
+October-December 2015
+**********************
+
+.. list-table::
+   :widths: 20 70
+   :header-rows: 1
+
+   * - Date
+     - Change
+   * - 27 Oct 2015
+     - Added new events for interactions with :ref:`Oppia
+       explorations<content>` to the Events in the Tracking Logs section.
+
 
 **********************
 July-September 2015
@@ -18,7 +32,7 @@ July-September 2015
      - Change
    * - 16 Sept 2015
      - Added new events for :ref:`teams<student_teams_events>` to the
-       :ref:`Tracking Logs` section.
+       Events in the Tracking Logs section.
    * - 2 Sept 2015
      - Added new events for :ref:`digital certificates <certificate_events>`.
    * - 6 Aug 2015
@@ -26,10 +40,10 @@ July-September 2015
        the files in data packages.
    * - 8 Jul 2015
      - Added new events for :ref:`polls and surveys<Poll and Survey Events>` to
-       the :ref:`Tracking Logs` section.
+       the Events in the Tracking Logs section.
    * - 1 Jul 2015
      - Added new events for :ref:`problem hints<problem>` to the
-       :ref:`Tracking Logs` section.
+       Events in the Tracking Logs section.
 
 
 **********************
@@ -47,12 +61,12 @@ April-June 2015
        the :ref:`Tracking Logs` section.
    * - 8 Jun 2015
      - Added descriptions of the ``video_show_cc_menu`` and
-       ``video_hide_cc_menu`` events to the 
+       ``video_hide_cc_menu`` events to the
        :ref:`video interaction events<video>` section.
    * - 19 May 15
      - Added information about new course team report events to the
        :ref:`Tracking Logs` section.
-   * - 11 May 2015 
+   * - 11 May 2015
      - Updated the descriptions of the ``pause_video``, ``play_video``, and
        ``stop_video`` :ref:`video interaction events<video>` to include the
        effects of a **Video Start Time** or **Video Stop Time**.
@@ -85,7 +99,7 @@ January-March 2015
    * - 5 Mar 2015
      - Added new events for contributions to discussion forums to the
        :ref:`Tracking Logs` section.
-   * - 
+   * -
      - Added events for the display of :ref:`Google components<content>` to the
        Tracking Logs section.
    * - 3 Mar 2015
@@ -134,7 +148,7 @@ October-December 2014
    * - 10/23/14
      - Added examples of the format used to identify course components to the
        :ref:`Student_Info` and :ref:`Tracking Logs` sections.
-   * - 
+   * -
      - Updated the ``child_render`` event to reflect the name change for the
        ``child_id`` member field. See :ref:`Tracking Logs`.
    * - 10/20/14
@@ -146,7 +160,7 @@ October-December 2014
    * - 10/07/14
      - Added new student and course team events relating to cohort use to the
        :ref:`Tracking Logs` section.
-   * - 
+   * -
      - Removed information about XML course formats. See the :ref:`olx:edX Open
        Learning XML Guide` for information about building XML courses.
 
@@ -204,9 +218,9 @@ April-June 2014
    * - 06/27/14
      - Made a correction to the ``edx.forum.searched`` event name in the
        :ref:`Tracking Logs` section.
-   * - 
+   * -
      - Added the ``stop_video`` event to the :ref:`Tracking Logs` section.
-   * - 
+   * -
      - Updated the ``seek_video`` event in the :ref:`Tracking Logs` section.
    * - 06/23/14
      - Added a :ref:`Preface` with resources for course teams, developers,
@@ -217,11 +231,11 @@ April-June 2014
    * - 05/22/14
      - Added descriptions of five video- and problem-related events to the
        :ref:`Tracking Logs` section.
-   * - 
+   * -
      - Added the new ``edx.forum.searched`` event to the
        :ref:`Tracking Logs` section.
    * - 05/06/14
-     - Added enrollment event types to the :ref:`Tracking Logs` section. 
+     - Added enrollment event types to the :ref:`Tracking Logs` section.
    * - 05/05/14
      - Removed information on the Poll module. See
        :ref:`partnercoursestaff:Poll` in *Building and Running an edX Course*.
@@ -229,11 +243,11 @@ April-June 2014
      - Removed information on the Word Cloud tool. See
        :ref:`partnercoursestaff:Word Cloud` in *Building and Running an edX
        Course*.
-   * - 
+   * -
      - Removed information on CustomResponse XML and Python Script. See
        :ref:`partnercoursestaff:Write Your Own Grader` in the  *Building and
        Running an edX Course* guide.
-   * - 
+   * -
      - Removed information on Formula Equation Input. See
        `partnercoursestaff:Math Expression Input` in the *Building and Running
        an edX Course* guide.
@@ -243,7 +257,7 @@ April-June 2014
    * - 04/25/14
      - Added new event types to the :ref:`Tracking Logs` section for
        interactions with PDF files.
-       
+
 
 **********************
 January-March 2014

--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -5,7 +5,7 @@ Alphabetical Event List
 #######################
 
 
-:ref:`ABC` - :ref:`DEF` - :ref:`GHI` - :ref:`JKL` - :ref:`MNO` 
+:ref:`ABC` - :ref:`DEF` - :ref:`GHI` - :ref:`JKL` - :ref:`MNO`
 - :ref:`PQR` - :ref:`ST` - :ref:`UVWXYZ`
 
 .. _ABC:
@@ -70,7 +70,7 @@ D, E, F
    * - ``edx.certificate.shared``
      - :ref:`certificate_events`
    * - ``edx.certificate.evidence_visited``
-     - :ref:`certificate_events`    
+     - :ref:`certificate_events`
    * - ``edx.cohort.created``
      - :ref:`student_cohort_events`
    * - ``edx.cohort.creation_requested``
@@ -83,7 +83,7 @@ D, E, F
      - :ref:`student_cohort_events`
    * - ``edx.course.enrollment.activated``
      - :ref:`enrollment` and :ref:`instructor_enrollment`
-   * - ``edx.course.enrollment.deactivated`` 
+   * - ``edx.course.enrollment.deactivated``
      - :ref:`enrollment` and :ref:`instructor_enrollment`
    * - ``edx.course.enrollment.mode_changed``
      - :ref:`enrollment`
@@ -110,27 +110,27 @@ D, E, F
    * - ``edx.librarycontentblock.content.assigned``
      - :ref:`library_events`
    * - ``edx.librarycontentblock.content.removed``
-     - :ref:`library_events`     
+     - :ref:`library_events`
    * - ``edx.problem.hint.demandhint_displayed``
      - :ref:`problem`
    * - ``edx.problem.hint.feedback_displayed``
      - :ref:`problem`
    * - ``edx.team.activity_updated``
-     - :ref:`student_teams_events`  
+     - :ref:`student_teams_events`
    * - ``edx.team.changed``
-     - :ref:`student_teams_events`     
+     - :ref:`student_teams_events`
    * - ``edx.team.created``
      - :ref:`student_teams_events`
    * - ``edx.team.deleted``
-     - :ref:`student_teams_events`     
+     - :ref:`student_teams_events`
    * - ``edx.team.learner_added``
      - :ref:`student_teams_events`
    * - ``edx.team.learner_removed``
      - :ref:`student_teams_events`
    * - ``edx.team.page_viewed``
-     - :ref:`student_teams_events`  
+     - :ref:`student_teams_events`
    * - ``edx.team.searched``
-     - :ref:`student_teams_events`   
+     - :ref:`student_teams_events`
    * - ``edx.video.bumper.dismissed``
      - :ref:`pre-roll`
    * - ``edx.video.bumper.loaded``
@@ -250,6 +250,12 @@ M, N, O
      - :ref:`ora2`
    * - ``openassessment.upload_file``
      - :ref:`ora2`
+   * - ``oppia.exploration.completed``
+     - :ref:`content`
+   * - ``oppia.exploration.loaded``
+     - :ref:`content`
+   * - ``oppia.exploration.state.changed``
+     - :ref:`content`
 
 .. _PQR:
 
@@ -389,7 +395,7 @@ U, V, W, X, Y, Z
      - :ref:`Poll and Survey Events`
    * - ``xblock.survey.view_results``
      - :ref:`Poll and Survey Events`
-       
+
 
 
 ..   * - ``problem_graded``

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -2175,7 +2175,7 @@ information about interactions with problems.
 
 These events were designed for the problem types implemented in the edX
 platform by the ``capa_module.py`` XBlock. Problem types that are implemented
-by other XBlocks, such as :ref:`open response assessments<ora2>` or :ref:`polls
+by other XBlocks, such as :ref:`open response assessments<ora2>`, :ref:`polls
 and surveys<Poll and Survey Events>`, are instrumented with different events.
 
 For more information about designing problems to include hints, feedback, or
@@ -3644,23 +3644,21 @@ Third-Party Content Events
 
 This section includes descriptions of the following events.
 
-* ``edx.googlecomponent.calendar.displayed``
-* ``edx.googlecomponent.document.displayed``
+.. contents::
+  :local:
+  :depth: 1
 
 EdX courses can include components that present content that is hosted by a
 third party. The server emits events when third-party content is shown to
 students.
 
-``edx.googlecomponent.calendar.displayed`` and ``edx.googlecomponent.document.displayed``
-*********************************************************************************************
+``edx.googlecomponent.calendar.displayed``
+***********************************************
 
 The server emits an ``edx.googlecomponent.calendar.displayed`` event when a
-Google Calendar component is shown in the LMS. The server emits an
-``edx.googlecomponent.document.displayed`` event when a Google Drive file,
-such as a document, spreadsheet, or image, is shown in the LMS.
-
-For more information about adding Google calendars or Google Drive files
-to a course, see :ref:`partnercoursestaff:Create Exercises`.
+Google Calendar component is shown in the LMS. For more information about
+adding Google calendars to a course, see :ref:`partnercoursestaff:Google
+Calendar Tool`.
 
 **Event Source**: Server
 
@@ -3677,14 +3675,119 @@ to a course, see :ref:`partnercoursestaff:Create Exercises`.
      - Details
    * - ``displayed_in``
      - string
-     - 'img' for Google Drive image files.
-
-       'iframe' for Google Calendars and for Google Drive files of other
+     - 'iframe' for Google Calendars and for Google Drive files of other
        types.
+
+       'img' for Google Drive image files.
 
    * - ``url``
      - string
      - The URL of the image file or of the file loaded by the iFrame.
+
+
+``edx.googlecomponent.document.displayed``
+************************************************
+
+The server emits an ``edx.googlecomponent.document.displayed`` event when a
+Google Drive file, such as a document, spreadsheet, or image, is shown in the
+LMS. For more information about adding Google Drive files to a course, see
+:ref:`partnercoursestaff:Google Drive Files Tool`.
+
+**Event Source**: Server
+
+**History**: Added 5 Mar 2015.
+
+``event`` **Member Fields**:
+
+The ``edx.googlecomponent.document.displayed`` events include the following
+``event`` member fields. These fields serve the same purpose for events of this
+type as for the ``edx.googlecomponent.calendar.displayed`` events.
+
+* ``displayed_in``
+* ``url``
+
+
+``oppia.exploration.completed``
+***********************************************
+
+The server emits an ``oppia.exploration.completed`` event when a user completes
+an interaction with an Oppia exploration component. Oppia explorations do not
+emit grading events. For more information about adding Oppia explorations to a
+course, see :ref:`partnercoursestaff:Oppia Exploration Tool`.
+
+**Event Source**: Server
+
+**History**: Added 21 Oct 2015.
+
+``event`` **Member Fields**:
+
+The ``oppia.exploration.completed`` events include the following ``event``
+member fields. These fields serve the same purpose for events of this type as
+for the ``oppia.exploration.state.changed`` events.
+
+* ``exploration_id``
+* ``exploration_version``
+
+
+``oppia.exploration.loaded``
+***********************************************
+
+The server emits an ``oppia.exploration.loaded`` event when an Oppia
+exploration component is shown in the LMS. For more information about adding
+Oppia explorations to a course, see :ref:`partnercoursestaff:Oppia Exploration
+Tool`.
+
+**Event Source**: Server
+
+**History**: Added 21 Oct 2015.
+
+``event`` **Member Fields**:
+
+The ``oppia.exploration.loaded`` events include the following ``event`` member
+fields. These fields serve the same purpose for events of this type as for the
+``oppia.exploration.state.changed`` events.
+
+* ``exploration_id``
+* ``exploration_version``
+
+
+``oppia.exploration.state.changed``
+***********************************************
+
+The server emits an ``oppia.exploration.state.changed`` event when a user
+interacts with an Oppia exploration component by submitting an answer. Answers
+are not incorrect or correct. All answer submissions change the state of the
+exploration. For more information about adding Oppia explorations to a course,
+see :ref:`partnercoursestaff:Oppia Exploration Tool`.
+
+**Event Source**: Server
+
+**History**: Added 21 Oct 2015.
+
+``event`` **Member Fields**:
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``exploration_id``
+     - string
+     - The unique identifier of the Oppia exploration.
+   * - ``exploration_version``
+     - string
+     - The version number for the Oppia exploration.
+   * - ``new_state_name``
+     - string
+     - The name of the state that the exploration was changed to by the
+       submitted answer.
+   * - ``old_state_name``
+     - string
+     - The name of the state the exploration was in when the user submitted an
+       answer.
+
 
 .. _AB_Event_Types:
 


### PR DESCRIPTION
## [DOC-2342](https://openedx.atlassian.net/browse/DOC-2342)

Adds the events for Oppia explorations, described on the https://openedx.atlassian.net/wiki/display/AN/Oppia+XBlock+Event+Design wiki page.

See course team doc PR https://github.com/edx/edx-documentation/pull/616. This feature should be available on stage when the release is cut on Monday.
### Date Needed

21 Oct 2015
### HTML Version

https://draft-20151016-oppia-events.readthedocs.org/en/latest/internal_data_formats/tracking_logs.html#oppia-exploration-completed
### Reviewers
- [x] Subject matter expert: @seanlip
- [x] Doc team review (level): @mhoeber 
- [x] Product review: @explorerleslie 

FYI: @stroilova , @sarina 
### Testing
- [x] Ran en_us/make without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Update change log
- [x] Squash commits
