### PR TITLE
Reworded a11y note for google blocks and for 2 other tools

### DIFF
--- a/en_us/shared/exercises_tools/google_calendar.rst
+++ b/en_us/shared/exercises_tools/google_calendar.rst
@@ -12,13 +12,14 @@ This topic describes how to embed Google calendars in your course.
   :local:
   :depth: 2
 
+Before you make content from an external site available through your course, be
+sure to review the content to ensure that it is accessible to people with
+disabilities. For more information, see :ref:`Accessibility Best Practices for
+Course Content Development`.
+
 You can also add Google Drive files, such as documents, spreadsheets, and
 images, to your course. For more information, see :ref:`Google Drive Files
 Tool`.
-
-Be sure to review all supplemental materials to assure that they are accessible
-before making them available through your course. For more information, see
-:ref:`Accessibility Best Practices for Course Content Development`.
 
 .. note:: Google services are not available in some regions and countries.
   If Google services are not available in a learner's area, the learner might

--- a/en_us/shared/exercises_tools/google_docs.rst
+++ b/en_us/shared/exercises_tools/google_docs.rst
@@ -13,12 +13,13 @@ spreadsheets, and images, in your course.
    :local:
    :depth: 2
 
+Before you make content from an external site available through your course, be
+sure to review the content to ensure that it is accessible to people with
+disabilities. For more information, see :ref:`Accessibility Best Practices for
+Course Content Development`.
+
 You can also use :ref:`Google calendars<Google Calendar Tool>` in courseware.
 For more information, see :ref:`Google Calendar Tool`.
-
-Be sure to review all supplemental materials to assure that they are accessible
-before making them available through your course. For more information, see
-:ref:`Accessibility Best Practices for Course Content Development`.
 
 .. note:: Google services are not available in some regions and countries. If
   Google services are not available in a learner's area, the learner might see

--- a/en_us/shared/exercises_tools/iframe.rst
+++ b/en_us/shared/exercises_tools/iframe.rst
@@ -6,45 +6,75 @@ IFrame Tool
 
 .. note:: EdX offers provisional support for this tool.
 
-An IFrame allows you to integrate ungraded exercises and tools from any Internet site into the body of your course. The IFrame appears inside an HTML component, and the exercise or tool appears inside the IFrame. IFrames can include your own tools or third-party tools. 
+An IFrame allows you to integrate ungraded exercises and tools from any
+Internet site into the body of your course. The IFrame appears inside an HTML
+component, and the exercise or tool appears inside the IFrame. IFrames can
+include your own tools or third-party tools.
 
 .. image:: ../../../shared/building_and_running_chapters/Images/IFrame_1.png
   :alt: IFrame tool showing a Euler line exercise
   :width: 500
 
-IFrames are well-suited for tools that demonstrate a concept but that won't be graded or store student data. If you want to add a graded tool or exercise, add the tool as a :ref:`custom JavaScript problem<Custom JavaScript>` or an :ref:`LTI component<LTI Component>`. 
+Before you make content or a tool from an external site available through your
+course, be sure to review the content or tool to ensure that it is accessible
+to people with disabilities. For example, in addition to testing the IFrame
+components that you add to your course, you can ask third party providers to
+confirm that a tool is accessible, and, if available, contact your on campus
+accessibility support services for additional guidance. For more information,
+see :ref:`Accessibility Best Practices for Course Content Development`.
 
-For more information about IFrames, see the `IFrame specification <http://www.w3.org/wiki/HTML/Elements/iframe>`_.
+IFrames are well-suited for tools that demonstrate a concept but that won't be
+graded or store student data. If you want to add a graded tool or exercise, add
+the tool as a :ref:`custom JavaScript problem<Custom JavaScript>` or an
+:ref:`LTI component<LTI Component>`.
+
+For more information about IFrames, see the `IFrame specification
+<http://www.w3.org/wiki/HTML/Elements/iframe>`_.
 
 ****************************
 Create an IFrame Tool
 ****************************
 
-To add an exercise or tool in an IFrame, you'll create an IFrame HTML component and add the URL of the page that contains the exercise or tool to the component. You can also add text and images both before and after the IFrame.
+To add an exercise or tool in an IFrame, you'll create an IFrame HTML component
+and add the URL of the page that contains the exercise or tool to the
+component. You can also add text and images both before and after the IFrame.
 
-.. note:: The URL of the page that contains the exercise or tool must start with ``https`` instead of ``http``. If the URL starts with ``http``, you have to work with the owner of that page to find out if an ``https`` version is available. Some websites do not allow their content to be embedded in IFrames.
+.. note:: The URL of the page that contains the exercise or tool must start
+ with ``https`` instead of ``http``. If the URL starts with ``http``, work with
+ the owner of that page to find out if an ``https`` version is available. Some
+ websites do not allow their content to be embedded in IFrames.
 
-#. Under **Add New Component**, click **html**, and then click **IFrame**.
+#. Under **Add New Component**, select **HTML**, and then select **IFrame**.
 
-#. In the new component that appears, click **Edit**.
+#. In the new component, select **Edit**.
 
-#. In the toolbar in the component editor, click **HTML**.
+#. In the component editor toolbar, select **HTML**.
 
-#. In the HTML source code editor, locate the following HTML (line 7). This HTML includes the ``<iframe>`` element:
+#. In the HTML source code editor, locate the following HTML (line 7). This
+   HTML includes the ``<iframe>`` element.
 
    .. code-block:: html
 
       <p><iframe src="https://studio.edx.org/c4x/edX/DemoX/asset/eulerLineDemo.html" width="402" height="402" marginwidth="0" marginheight="0" frameborder="0" scrolling="no">You need an iFrame capable browser to view this.</iframe></p>
 
-5. Replace the default URL in the **src** attribute (**https://studio.edx.org/c4x/edX/DemoX/asset/eulerLineDemo.html**) with the URL of the page that contains the exercise or tool. **This URL must start with https**. Make sure you don't delete the quotation marks that surround the URL.
+5. Replace the default URL in the ``src`` attribute
+   (https://studio.edx.org/c4x/edX/DemoX/asset/eulerLineDemo.html) with the
+   URL of the page that contains the exercise or tool. **This URL must start
+   with https**. Make sure that you do not delete the quotation marks that
+   surround the URL.
 
-#. Change the attributes in the IFrame element to specify any other settings that you want. For more information about these settings, see :ref:`IFrame Settings`. You can also change the text between the opening and closing ``<iframe>`` tags. A student only sees this text if the student uses a browser that does not support IFrames.
+#. Change the attributes in the IFrame element to specify any other settings
+   that you want. For more information about these settings, see :ref:`IFrame
+   Settings`. You can also change the text between the opening and closing
+   ``<iframe>`` tags. Learners see this text only when they use a browser that
+   does not support IFrames.
 
-7. Click **OK** to close the HTML source code editor and return to the Visual editor.
+#. Select **OK** to close the HTML source code editor and return to the Visual
+   editor.
 
 #. In the Visual editor, replace the default text with your own text.
 
-#. Click **Save**.
+#. Select **Save**.
 
 .. _IFrame Settings:
 
@@ -52,31 +82,51 @@ To add an exercise or tool in an IFrame, you'll create an IFrame HTML component 
 IFrame Settings
 ======================
 
-To specify settings for your IFrame, you'll add, remove, or change the attributes inside the opening ``<iframe>`` tag. The ``<iframe>`` tag **must** contain a **src** attribute that specifies the URL of the web page you want. Other attributes are optional. 
+To specify settings for your IFrame, you add, remove, or change the
+attributes inside the opening ``<iframe>`` tag. The ``<iframe>`` tag **must**
+contain a ``src`` attribute and a ``title`` attribute. Other attributes are
+optional.
 
 You can add these attributes in any order you want.
 
 .. list-table::
    :widths: 20 80
    :header-rows: 1
- 
+
    * - Attribute
      - Description
-   * - **src** (required)
-     - Specifies the URL of the page that contains the exercise or tool.
-   * - **width** and **height** (optional)
-     - Specify the width and height of the IFrame, in pixels or as a percentage. To specify the value in pixels, enter numerals. To specify a percentage, enter numerals followed by a percent sign.
+   * - ``src`` (required)
+     - Specifies the URL of the page that contains the exercise or tool,
+       beginning with https.
+   * - ``title`` (required)
+     - Describes the content or its purpose in the context of the course.
+   * - ``width`` and ``height`` (optional)
+     - Specify the width and height of the IFrame, in pixels or as a
+       percentage. To specify the value in pixels, enter numerals. To specify a
+       percentage, enter numerals followed by a percent sign.
 
-       If you don't specify the width and height, the IFrame uses the dimensions that the linked page has set. These dimensions vary by website. If you change the width and height of the IFrame, the content from the linked page may be resized, or only part of the content may appear.
+       If you do not specify the width and height, the IFrame uses the
+       dimensions that the linked page has set. These dimensions vary by
+       website. If you change the width and height of the IFrame, the content
+       from the linked page might be resized, or only part of the content may
+       appear.
 
-   * - **marginwidth** and **marginheight** (optional)
-     - Specify the size of the space between the edges of the IFrame and your exercise or tool, in pixels.
-   * - **frameborder** (optional)
-     - Specifies whether a border appears around your IFrame. If the value is 0, no border appears. If the value is any positive number, a border appears.
-   * - **scrolling** (optional)
-     - Specifies whether a scrollbar appears to help users see all of the IFrame's content if your IFrame is smaller than the exercise or tool it contains. For example, if the content in your IFrame is very tall, you can set the IFrame's height to a smaller number and add a vertical scroll bar for users, as in the first image below.
+   * - ``marginwidth`` and ``marginheight`` (optional)
+     - Specify the size of the space between the edges of the IFrame and your
+       exercise or tool, in pixels.
+   * - ``frameborder`` (optional)
+     - Specifies whether a border appears around your IFrame. If the value is
+       0, no border appears. If the value is any positive number, a border
+       appears.
+   * - ``scrolling`` (optional)
+     - For an IFrame that is smaller than the exercise or tool it contains,
+       specifies whether a scrollbar appears to help users access all of the
+       IFrame's content. For example, if the content in your IFrame is very
+       tall, you can set the IFrame's height to a smaller number and add a
+       vertical scroll bar for users, as in the first image below.
 
-For example, compare how the different settings in each of the ``<iframe>`` elements below affect the IFrame. 
+For example, compare how the different settings in each of the ``<iframe>``
+elements below affect the IFrame.
 
 .. code-block:: html
 
@@ -91,7 +141,8 @@ For example, compare how the different settings in each of the ``<iframe>`` elem
       <p><iframe src="https://studio.edx.org/c4x/edX/DemoX/asset/eulerLineDemo.html" width="550" height="250" marginwidth="30" marginheight="60" frameborder="1" scrolling="no">You need an iFrame capable browser to view this.</iframe></p>
 
 .. image:: ../../../shared/building_and_running_chapters/Images/IFrame_4.png
-   :alt: 
+   :alt:
    :width: 500
 
-For more information about IFrame attributes, see the `IFrame specification <http://www.w3.org/wiki/HTML/Elements/iframe>`_.
+For more information about IFrame attributes, see the `IFrame specification
+<http://www.w3.org/wiki/HTML/Elements/iframe>`_.

--- a/en_us/shared/exercises_tools/lti_component.rst
+++ b/en_us/shared/exercises_tools/lti_component.rst
@@ -16,6 +16,14 @@ specifications.
    :local:
    :depth: 2
 
+Before you make tools from an external site available through your course, be
+sure to review the tools to ensure that they are accessible to people with
+disabilities. For example, in addition to testing the LTI components that you
+add to your course, you can ask third party providers to confirm that a tool is
+accessible, and, if available, contact your on campus accessibility support
+services for additional guidance. For more information, see :ref:`Accessibility
+Best Practices for Course Content Development`.
+
 *********************
 Overview
 *********************

--- a/en_us/shared/exercises_tools/oppia.rst
+++ b/en_us/shared/exercises_tools/oppia.rst
@@ -17,9 +17,9 @@ explorations in your course.
   :depth: 2
 
 Before you make content from an external site available through your course, be
-sure to review the content to ensure that it is accessible. For more
-information, see :ref:`Accessibility Best Practices for Course Content
-Development`.
+sure to review the content to ensure that it is accessible to people with
+disabilities. For more information, see :ref:`Accessibility Best Practices for
+Course Content Development`.
 
 *********
 Overview


### PR DESCRIPTION
## [DOC-1896](https://openedx.atlassian.net/browse/DOC-1896)

I started by standardizing the wording used re: a11y in the Oppia and 2 Google XBlocks. Then I noted this doc story, and expanded the effort to include an expanded version of the note for LTI and IFrame components.
### Date Needed

Today if possible.
### Reviewers
- [x] Subject matter expert: @cptvitamin 
- [x] Doc team review (copy edit): @mhoeber 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
