### PR TITLE
Update Segment analytics API key instructions

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -1009,7 +1009,7 @@ Example: Mobile App-Emitted ``edx.video.played`` Event
         "component": "videoplayer",
         "received_at": "2014-12-09T03:57:56.373000+00:00",
         "course_id": "edX/DemoX/Demo_Course",
-        "path": "/segmentio/event",
+        "path": "/segment/event",
         "user_id": 99999999,
         "org_id": "edX",
         "application": {

--- a/en_us/developers/source/analytics.rst
+++ b/en_us/developers/source/analytics.rst
@@ -372,18 +372,19 @@ platform will transmit a variety of metrics to data dog. Running ``git grep
 dog_stats_api`` will give a pretty good overview of the usage of data dog to
 track operational metrics.
 
-Segment.IO
+Segment
 *****************
 
-A selection of events can be transmitted to segment.io in order to take
+A selection of events can be transmitted to `Segment`_ in order to take
 advantage of a wide variety of analytics-related third party services such as
-Mixpanel and Chartbeat. It is enabled in the LMS if the ``SEGMENT_IO_LMS``
-feature flag is enabled and the ``SEGMENT_IO_LMS_KEY`` key is set to a valid
-segment.io API key in the ``lms.auth.json`` file. Additionally, the setting
-``EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST`` in the ``lms.auth.json`` file can be
-used to specify event names that should be emitted to segment.io from normal
-`tracker.emit()` calls. Events specified in this whitelist will be sent to both
-the tracking logs and segment.io.
+Mixpanel and Chartbeat. It is enabled in the LMS if the ``SEGMENT_KEY``
+key is set to a valid Segment API key in the ``lms.auth.json`` file. Additionally, 
+the setting ``EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST`` in the ``lms.auth.json`` 
+file can be used to specify event names that should be emitted to Segment 
+from normal ``tracker.emit()`` calls. Events specified in this whitelist will be 
+sent to both the tracking logs and Segment.  Similarly, it is enabled in Studio 
+if the ``SEGMENT_KEY`` key is set to a valid Segment API key in the
+``cms.auth.json`` file.
 
 Google Analytics
 *****************
@@ -408,3 +409,4 @@ continue to be supported.
 .. _event-tracking documentation: http://event-tracking.readthedocs.org/en/latest/overview.html#event-tracking
 .. _data dog: http://www.datadoghq.com/
 .. _dogapi: http://pydoc.datadoghq.com/en/latest/
+.. _Segment: https://segment.com/

--- a/en_us/developers/source/process/code-considerations.rst
+++ b/en_us/developers/source/process/code-considerations.rst
@@ -137,7 +137,7 @@ Analytics
   * Are you increasing the amount of logging in any major way?
 
 * Are you sending appropriate/enough information to MixPanel,
-  Google Analytics, Segment IO?
+  Google Analytics, Segment?
 
 Collaboration
 =============


### PR DESCRIPTION
Segment analytics tracking is now enabled simply by setting the `SEGMENT_KEY` field.  Documentation updated to reflect the new configuration instructions and added instructions for setting up Segment in Studio.

Segment has rebranded from `Segment.io` to just `Segment`.  Documentation updated to reflect the new name change.

@edx/edx-documentation-admin 
