### PR TITLE
DOC: User profiles on mobile

### DIFF
--- a/en_us/shared/getting_started/dashboard_settings_profile.rst
+++ b/en_us/shared/getting_started/dashboard_settings_profile.rst
@@ -158,7 +158,6 @@ information.
 
 * **Education Completed**: The highest level of education that you have
   completed.
-
 * **Gender**: The gender you identify as.
 
 * **Year of Birth**: The year that you were born.
@@ -174,6 +173,7 @@ To view or change this information, follow these steps.
    (optional)** section, and then make your changes.
 
 EdX saves your changes automatically.
+
 
 ==========================================
 Link or Unlink a Social Media Account
@@ -202,32 +202,41 @@ Exploring the Profile Page
 *************************************
 
 Your edX profile allows you to share information about yourself with the edX
-community. Your profile can include an image that identifies you on the edX
-site as well as your location and other biographical information. Course teams
-and other learners in your courses can view your profile.
+community. Course teams and other learners in your courses can view your
+profile. You can share either a limited profile or a full profile.
 
-You can share a limited profile or a full profile.
+Your profile always includes your username. Optionally, and if you are over 13
+years of age, you can also share a profile picture, your location, and other
+biographical information.
 
-.. note:: Learners under 13 years of age can only share a limited profile.
+A limited profile shares only your username and an optional profile picture.
 
-A limited profile can include only your username and an image.
+.. note:: If you are under 13 years of age, you can only share a limited
+   profile and you cannot share a profile picture.
 
 .. image:: ../../../shared/images/SFD_Prof_Limited.png
  :width: 400
  :alt: A learner's limited profile showing only username and image.
 
-A full profile can include biographical information.
+A full profile includes biographical information in addition to your username
+and profile image.
 
 .. image:: ../../../shared/images/SFD_Prof_Full.png
  :width: 500
  :alt: A learner's full profile with location, language, and short
      biographical paragraph.
 
+
+.. _Create or Edit a Limited Profile:
+
 ================================
 Create or Edit a Limited Profile
 ================================
 
 A limited profile includes only your username and, optionally, an image.
+
+.. note:: If you are under 13 years of age, your limited profile only includes
+   your username. You cannot add a profile picture.
 
 To create or edit a limited profile, follow these steps.
 
@@ -259,8 +268,8 @@ Create or Edit a Full Profile
 ================================
 
 .. note:: You must specify your year of birth on the **Account Settings** page
-     before you share a full profile. If you are under age 13, you can only
-     share a limited profile.
+   before you share a full profile. If you are under 13 years of age, you
+   can share only a :ref:`limited profile <Create or Edit a Limited Profile>`.
 
 A full profile can include the following information. Your username and
 country or region are required.
@@ -332,4 +341,5 @@ username on the **Active Threads** page, and the learner's profile page.
   :width: 600
   :alt: Image of a discussion with a learner's username circled, an image of
       that learner's active threads page in the course discussions, and an
-      image of the learner's profile.
+      image of the learner's profile
+

--- a/en_us/shared/students/Section_mobile_gettingstarted.rst
+++ b/en_us/shared/students/Section_mobile_gettingstarted.rst
@@ -20,10 +20,44 @@ account. You also provide the following information.
 * Your name.
 * The username that will identify you to course teams and to other learners.
 * A password.
-* Your country or region. 
+* Your country or region.
 
 After you create your account, you can find courses that interest you and
 enroll in them.
+
+
+===========================================
+How do I create or edit my user profile?
+===========================================
+
+After you have created and activated your edX account, you can edit your user
+profile. Your edX profile allows you to share information about yourself with
+the edX community. Course teams and other learners in your courses can view
+your profile when they select your linked username in forums. You can share
+either a limited profile or a full profile.
+
+Your profile always includes your username. A limited profile shares only your
+username and an optional profile picture. A full profile includes biographical
+information in addition to your username and profile image.
+
+.. note:: If you are under 13 years of age, you can only share a limited
+   profile, and you cannot share a profile picture.
+
+To create or edit your profile details in the mobile app, select your username
+or profile picture. Select **Edit** to edit your profile details. In your profile
+details, select **Change** next to the camera icon to change your profile
+picture.
+
+If you are over 13 years of age, you can share more information about yourself
+by changing your limited profile to a full profile. You can indicate your
+primary language and location and, in the **About Me** section, you can add
+additional details such as your learning goals and other interests. To share a
+full profile, select **Full Profile**.
+
+.. note:: You must specify your birth year before you can share a full
+   profile. If you are under 13 years of age, you cannot create a full
+   profile.
+
 
 ==================================================
 How do I find courses to take?


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DOC-2371
This PR adds a section to the "edX Mobile app" section of the Learners' Guide for creating/editing user profiles. It also includes modifications to existing doc for desktop user profiles doc to clarify that limited profiles for users under 13 do not include profile images.
### Reviewers

Reviewers, please check the box next to your name after you have reviewed and given :+1:.
- [x] Subject matter expert: @aleffert 
- [x] Subject matter expert: @bguertin
- [ ] Subject matter expert: @mikekatz 
- [x] Doc team review: @srpearce 
- [x] Product review: @explorerleslie 
### Draft HTML output
- [x] Mobile app -- http://draft-mobile-user-profiles.readthedocs.org/en/latest/SFD_mobile.html#how-do-i-create-or-edit-my-user-profile
- [x] Desktop -- http://draft-mobile-user-profiles.readthedocs.org/en/latest/sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-profile-page
### Post-review
- [x] Squash commits
