### PR TITLE
XBlock tutorial overview

### DIFF
--- a/en_us/xblock-tutorial/source/overview/introduction.rst
+++ b/en_us/xblock-tutorial/source/overview/introduction.rst
@@ -14,13 +14,13 @@ This section introduces XBlocks.
 Overview
 ***************
 
-The XBlock specification is a component architecture developped by edX to 
-make it easier to create new online educational experiences. While it was 
-created by an organization with a focus in education, the technology has applications
-for any web app that needs to use multiple independent components that are displayed on 
-a single web page. 
+The XBlock specification is a component architecture designed to 
+make it easier to create new online educational experiences. 
+XBlock was developed by edX, which has a focus in education, but the technology 
+can be used in web applications that need to use multiple independent 
+components and display those components on a single web page. 
 
-From edX's perspective, an XBlock developer 
+An XBlock developer 
 does not need to download and run the entire edx-platform developer stack 
 or to know anything about the technolgies that edX uses provide the XBlock 
 runtime. Instead, XBlock developers writing with edX in mind can work from the 
@@ -33,12 +33,13 @@ allowing an XBlock developer to control the display of other XBlocks to compose
 lessons, sections, and entire courses.
 
 *****************************
-XBlock Specification and Runtimes
+XBlock API and Runtimes
 *****************************
 
-A web-app can turn itself into an :ref:`XBlock runtime<XBlock Runtimes>` by 
-implementing the XBlock specification. XBlock runtimes can compose web 
-pages out of XBlocks that were developped by programmers who do not need 
+Any web application can be an :ref:`XBlock runtime<XBlock Runtimes>` by 
+implementing the XBlock API. Note that the XBlock API is not a RESTful API.
+XBlock runtimes can compose web 
+pages out of XBlocks that were developed by programmers who do not need 
 to know anything about the other components a web page might be using or 
 displaying. 
 
@@ -65,6 +66,12 @@ edX Platform`.
 ***********************
 XBlocks for Developers
 ***********************
+
+Developers can select from functionality developed by the openedX community by 
+installing an XBlock on their instance of openedX. Developers can integrate 
+new or propriety functionality for use in XBlock runtimes by developing a 
+new XBlock using the supported XBlock API.
+
 
 XBlocks are like miniature web applications: they maintain state in a storage
 layer, render themselves through views, and process user actions through

--- a/en_us/xblock-tutorial/source/overview/introduction.rst
+++ b/en_us/xblock-tutorial/source/overview/introduction.rst
@@ -22,7 +22,7 @@ components and display those components on a single web page.
 
 An XBlock developer 
 does not need to download and run the entire edx-platform developer stack 
-or to know anything about the technolgies that edX uses provide the XBlock 
+or to know anything about the technologies that edX uses provide the XBlock 
 runtime. Instead, XBlock developers writing with edX in mind can work from the 
 xblock-sdk and deploy their work on any platform that is compatible with XBlocks. 
 
@@ -67,8 +67,8 @@ edX Platform`.
 XBlocks for Developers
 ***********************
 
-Developers can select from functionality developed by the openedX community by 
-installing an XBlock on their instance of openedX. Developers can integrate 
+Developers can select from functionality developed by the Open edX community by 
+installing an XBlock on their instance of Open edX. Developers can integrate 
 new or propriety functionality for use in XBlock runtimes by developing a 
 new XBlock using the supported XBlock API.
 

--- a/en_us/xblock-tutorial/source/overview/introduction.rst
+++ b/en_us/xblock-tutorial/source/overview/introduction.rst
@@ -14,59 +14,64 @@ This section introduces XBlocks.
 Overview
 ***************
 
-As a developer, you build XBlocks that course teams use to create independent
-course components that work seamlessly with other components in an online
-course.
+The XBlock specification is a component architecture developped by edX to 
+make it easier to create new online educational experiences. While it was 
+created by an organization with a focus in education, the technology has applications
+for any web app that needs to use multiple independent components that are displayed on 
+a single web page. 
 
-For example, you can build XBlocks to represent individual problems or pieces
-of text or HTML content. Furthermore, like Legos, XBlocks are composable; you
-can build XBlocks to represent larger structures such as lessons, sections, and
-entire courses.
+From edX's perspective, an XBlock developer 
+does not need to download and run the entire edx-platform developer stack 
+or to know anything about the technolgies that edX uses provide the XBlock 
+runtime. Instead, XBlock developers writing with edX in mind can work from the 
+xblock-sdk and deploy their work on any platform that is compatible with XBlocks. 
 
-A primary advantage to XBlocks is that they are deployable. The code you write
-can be deployed in any instance of the edX Platform or other XBlock runtime
-application, then used by any course team using that system.
-
-By combining XBlocks from a wide variety of sources, from text and video, to
-multiple choice and numerical questions, to sophisticated collaborative and
-interactive learning laboratories, course teams can create rich and engaging
-courseware.
+In educational applications, XBlocks can be used to represent individual 
+problems, web-formatted text and videos, interactive simulations and labs, or 
+collaborative learning experiences. Furthermore, XBlocks are composable, 
+allowing an XBlock developer to control the display of other XBlocks to compose
+lessons, sections, and entire courses.
 
 *****************************
-XBlock API and Runtimes
+XBlock Specification and Runtimes
 *****************************
 
-XBlock is an API than can be used by different applications, referred to as
-XBlock :ref:`runtimes<XBlock Runtimes>`.
-
-As described below, the edX Platform uses the XBlock API, and is the most
-common XBlock runtime.
-
-If you are planning to use your XBlock in a different rutime, check the
-documentation to understand the runtime's requirements.
+A web-app can turn itself into an :ref:`XBlock runtime<XBlock Runtimes>` by 
+implementing the XBlock specification. XBlock runtimes can compose web 
+pages out of XBlocks that were developped by programmers who do not need 
+to know anything about the other components a web page might be using or 
+displaying. 
 
 *****************************
 XBlocks and the edX Platform
 *****************************
 
-The edX Platform uses many built-in XBlocks that are available to course
-developers. For example, HTML content, videos, and interactive problems are all
-XBlocks. The edX Platform also includes many specialized XBlocks such as
+The edX Platform is an XBlock runtime and edX currently provides 
+most of the support for the development of the XBlock library and 
+specification. Programmers using the 
+edx-platform devstack instead of the xblock-sdk to develop an XBlock should 
+be sure that their XBlock is fully compliant with the XBlock specification 
+before deploying to other XBlock runtimes. More specifically, XBlocks should 
+package any services provided by edx-platform that a different XBlock compliant 
+runtime might not provide. 
+
+The edX Platform currently has a large suite of XBlocks built into its primary repository that are available to course
+developers. Those XBlocks include HTML content, videos, and interactive problems. 
+The edX Platform also includes many specialized XBlocks such as
 :ref:`opencoursestaff:Google Drive Files Tool` and :ref:`opencoursestaff:Open
 Response Assessments 2`. For more information, see :ref:`XBlocks and the
 edX Platform`.
-
-EdX recognizes the ever expanding need to provide new and innovative types
-of content. The XBlock API and XBlock SDK are available for developers to
-create new types of XBlocks for course teams to use.
 
 ***********************
 XBlocks for Developers
 ***********************
 
-Developers can extend the types of content available in the edX Platform by
-creating and deploying XBlocks. EdX provides the `XBlock SDK`_ to support the
-creation of new XBlocks.
+XBlocks are like miniature web applications: they maintain state in a storage
+layer, render themselves through views, and process user actions through
+handlers. XBlocks differ from web applications in that they render only a small piece of
+a complete web page. Like HTML ``<div>`` tags, XBlocks can represent components as small as a
+paragraph of text, a video, or a multiple choice input field, or as large as a
+section, a chapter, or an entire course.
 
 ===================
 Prerequisites
@@ -89,13 +94,14 @@ This tutorial is meant to guide developers through the process of creating an
 XBlock, and to explain the :ref:`concepts<XBlock Concepts>` and
 :ref:`anatomy<Anatomy of an XBlock>` of XBlocks.
 
+EdX provides the `XBlock SDK`_ to support the creation of new XBlocks. 
 Developers should also see the :ref:`xblockapi:EdX XBlock API Guide`.
 
 =========================================
 XBlock Independence and Interoperability
 =========================================
 
-You must design your XBlock to meet two goals.
+You must design your XBlock to meet two criteria.
 
 * The XBlock must be independent of other XBlocks. Course teams must be able to
   use the XBlock without using other XBlocks.
@@ -103,19 +109,5 @@ You must design your XBlock to meet two goals.
 * The XBlock must work together with other XBlocks. Course teams must be
   able to combine different XBlocks in flexible ways.
 
-=========================================
-XBlocks Compared to Web Applications
-=========================================
-
-XBlocks are like miniature web applications: they maintain state in a storage
-layer, render themselves through views, and process user actions through
-handlers.
-
-XBlocks differ from web applications in that they render only a small piece of
-a complete web page.
-	
-Like HTML ``<div>`` tags, XBlocks can represent components as small as a
-paragraph of text, a video, or a multiple choice input field, or as large as a
-section, a chapter, or an entire course.
 
 .. include:: ../../../links/links.rst


### PR DESCRIPTION
A significant rewrite of the overview of the XBlock tutorial, in order to clarify the difference between developing XBlocks and developing for edx-platform. 
