### PR TITLE
Carol/doc/TNL 3688

### DIFF
--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -7,12 +7,12 @@ Open Response Assessments
 This topic describes how to work with open response assessments in your edX
 course.
 
-.. contents:: 
-  :local: 
+.. contents::
+  :local:
   :depth: 1
 
 *********************************************
-Overview of Embedded Files and Calendars
+Overview of Open Response Assessments
 *********************************************
 
 In an open response assessment, you provide written responses to questions that
@@ -45,9 +45,9 @@ responses for the assignment and the scores that these responses received. If
 your course team creates this section, you can see it below your score after
 you complete each step of the assignment.
 
-************************
-Student Instructions
-************************
+****************************
+Instructions for Learners
+****************************
 
 When you come to an open response assessment in the course, you will see the
 questions and a response field for each question. After you submit your
@@ -60,12 +60,12 @@ assignment includes below each response field.
    :width: 550
 
 Here, we will walk you through the process of completing an open response
-assessment that includes a student training step, a peer assessment, and a self
+assessment that includes a learner training step, a peer assessment, and a self
 assessment.
 
 #. Submit your responses to the questions.
 #. Learn to assess responses.
-#. Assess responses that other students have submitted.
+#. Assess responses that other learners have submitted.
 #. Assess your own responses to the questions.
 #. Receive your score and provide feedback on the peer assessment.
 
@@ -76,7 +76,7 @@ example, you might see the following message:
 
 .. code-block:: xml
 
-  Not Completed 
+  Not Completed
 
   You have not completed the peer assessment step and self
   assessment step of this problem.
@@ -105,12 +105,12 @@ to start grading right away. If you want to stop working and come back later,
 just refresh or reopen your browser when you come back. New peer responses will
 be available for you to grade.
 
-If no other students have submitted responses yet, you see the following
+If no other learners have submitted responses yet, you see the following
 message.
 
 .. code-block:: xml
 
-  Waiting for Peer Responses 
+  Waiting for Peer Responses
 
   All submitted peer responses have been assessed.
   Check back later to see if more students have submitted responses. You'll
@@ -140,7 +140,7 @@ any text.
 .. note:: The image file must be a .jpg or .png file, and it must be smaller
    than 5 MB in size.
 
-.. image:: ../../shared/students/Images/PA_Upload_ChooseFile.png 
+.. image:: ../../shared/students/Images/PA_Upload_ChooseFile.png
    :alt: Open response assessment example with Choose File and Upload Your
        Image buttons circled.
    :width: 500
@@ -189,7 +189,7 @@ then select **Compare your selections with the instructor's selections**.
 
 .. code-block:: xml
 
-  Learning to Assess Responses 
+  Learning to Assess Responses
 
   Your assessment differs from the instructor's
   assessment of this response. Review the response and consider why the
@@ -208,7 +208,7 @@ on whether your selections matched those defined by the course team.
   Selected Options Differ
   The option you selected is not the option that the instructor selected.
 
-In the following example, the student chose one correct option and one
+In the following example, the learner chose one correct option and one
 incorrect option.
 
 .. image:: ../../shared/students/Images/PA_TrainingAssessment_Scored.png
@@ -226,7 +226,7 @@ Assess Peer Responses
 =====================
 
 When the peer assessment step starts, you see each original question, another
-student's responses, and the rubric for the assignment. Above the responses you
+learner's responses, and the rubric for the assignment. Above the responses you
 can see how many responses you are expected to assess and how many you have
 already assessed.
 
@@ -234,12 +234,12 @@ already assessed.
    :alt: An in-progress peer assessment.
    :width: 500
 
-You assess other students' responses by selecting options in the rubric, in the
+You assess other learners' responses by selecting options in the rubric, in the
 same way you assessed the sample responses in the "learn to assess responses"
 step. Additionally, this step has a field below the rubric where you can
-provide comments about the student's responses.
+provide comments about the learner's responses.
 
-.. note:: Some assessments have an additional **Comments** field for one or 
+.. note:: Some assessments have an additional **Comments** field for one or
   more of the assessment's individual criteria. You can enter up to 300
   characters in these fields. In the following image, both criteria have a
   **Comments** field. There is also a field for overall comments on the
@@ -253,11 +253,11 @@ After you have selected options in the rubric and provided additional comments
 about the responses, select **Submit your assessment and move to response
 #<number>**.
 
-When you submit your assessment of the first student's responses, another set
+When you submit your assessment of the first learner's responses, another set
 of responses opens for you. Assess these responses in the same way that you
-assessed the first student's responses, and then submit your assessment. You
+assessed the first learner's responses, and then submit your assessment. You
 will repeat these steps until you have assessed the required number of
-responses. The number in the upper-right corner of the step is updated as you
+responses. The number in the upper right corner of the step is updated as you
 assess each set of responses.
 
 Assess Additional Peer Responses
@@ -293,7 +293,7 @@ Your Assessment**.
 Receive Your Score and Provide Feedback
 ==========================================
 
-After you submit your self assessment, if other students are still assessing
+After you submit your self assessment, if other learners are still assessing
 your responses, you see the following message under the **Assess Your
 Response** step.
 
@@ -313,7 +313,7 @@ of your peers, as well as your self assessment. You can also see any additional
 comments that your peers have provided.
 
 .. image:: ../../shared/students/Images/PA_AllScores.png
-   :alt: A student's response with peer and self assessment scores.
+   :alt: A learner's response with peer and self assessment scores.
    :width: 550
 
 If you want to, you can provide feedback on the scores that you received under
@@ -335,7 +335,7 @@ Peer Assessment Scoring
 Peer assessments are scored by criteria. An individual criterion's score is the
 *median*, not average, of the scores that each peer assessor gave that
 criterion. For example, if the Ideas criterion in a peer assessment receives a
-10 from one student, a 7 from a second student, and an 8 from a third student,
+10 from one learner, a 7 from a second learner, and an 8 from a third learner,
 the Ideas criterion's score is 8.
 
 Your final score for a peer assessment is the sum of the median scores for each

--- a/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
+++ b/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
@@ -6,18 +6,16 @@ Accessing Assignment and Learner Metrics
 
 After your open response assessment assignment has been released, you can access
 information about the number of learners in each step of the assignment or the
-performance of individual learners. This information is available in the
-**Course Staff Information** section at the end of each assignment. To access
-learner information, open the assignment in the courseware, scroll to the bottom of the
-assignment, and then select the black **Course Staff Information** banner.
+performance of individual learners. This information is available in the **Staff
+Info** and **Staff Tools** sections at the end of each assignment.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CourseStaffInfo_Collapsed.png
-   :alt: The Course Staff Information banner at the bottom of the peer assessment
+   :alt: The Staff Info banner at the bottom of the peer assessment
 
-When you access a specific learner's information for an open response
-assessment, you can view his responses and, if necessary, :ref:`cancel the
-learner's submission<Remove a learner response from peer grading>` so that it is
-not included in peer assessments.
+When you access a specific learner's information for an open response assessment
+using **Staff Tools**, you can view his responses and, if necessary,
+:ref:`cancel the learner's submission<Remove a learner response from peer
+grading>` so that it is not included in peer assessments.
 
 .. _PA View Metrics for Individual Steps:
 
@@ -32,14 +30,13 @@ working through, the following steps:
 * Completed peer assessments.
 * Waiting to assess responses or receive grades.
 * Completed self assessments.
-* Completed the entire assignment. 
+* Completed the entire assignment.
 
 To find this information, open the assignment in the courseware, scroll to the
-bottom of the assignment, and then select **Course Staff Information**.
+bottom of the assignment, and then select **Staff Info**.
 
-The **Course Staff Information** section expands, and you can see the number
-of learners who are currently working through (but have not completed) each
-step of the problem.
+The **Staff Info** section expands, and you can see the number of learners who
+are currently working through (but have not completed) each step of the problem.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/PA_CourseStaffInfo_Expanded.png
    :alt: The Course Staff Information box expanded, showing problem status
@@ -53,7 +50,7 @@ Access Information for a Specific Learner
 You can access information about an individual learner's performance on a peer
 assessment assignment, including:
 
-* The learner's response. 
+* The learner's response.
 * The peer assessments that other learners performed on the learner's
   response, including feedback on individual criteria and on the overall
   response.
@@ -90,18 +87,17 @@ Access a Specific Learner's Information
 =======================================
 
 #. In the LMS, go to the peer assessment assignment that you want to see.
-   
-#. Scroll to the bottom of the problem, and select the black **Course Staff
-   Information** banner.
-   
-#. In the **Get Student Info** box, enter the learner's username, and select
-   **Submit**.
 
-The learner's information appears below the **Get Student Info** box.
+#. Scroll to the bottom of the problem, and select **Staff Tools**.
+
+#. In **Staff Tools**, enter the learner's username or email address, then
+   select **Submit**.
+
+The learner's information appears.
 
 The following example shows:
 
-* The learner's response. 
+* The learner's response.
 * The two peer assessments for the response.
 * The two peer assessments the learner completed.
 * The learner's self assessment.
@@ -127,7 +123,7 @@ specific ORA submission>` and cancel the submission. Doing so removes the
 inappropriate response from peer assessments so that it is no longer shown to
 other learners.
 
-.. note:: Removing a learner's submission is an irreversible action. 
+.. note:: Removing a learner's submission is an irreversible action.
 
 When you cancel an inappropriate submission, the response is immediately removed
 from the pool of submissions available for peer assessment. If the inappropriate
@@ -148,26 +144,25 @@ Remove a submission from peer assessment by completing these steps.
 
 #. In the LMS, go to the peer assessment assignment that contains the submission
    you want to remove.
-   
-#. Scroll to the bottom of the problem, then select the black **Course Staff
-   Information** banner.
-   
-#. Scroll down to the **Get Student Info** box, enter the learner's username in
-   the box, and select **Submit**. 
 
-   The learner's information appears below the **Get Student Info** box.
-   
-#. Scroll down to the **Student Response** section and locate the submission you
+#. Scroll to the bottom of the problem, then select **Staff Tools**.
+
+#. In **Staff Tools**, enter the learner's username or email address, then
+   select **Submit**.
+
+   The learner's information appears.
+
+#. Scroll down to the **Learner Response** section and locate the submission you
    want to remove.
 
 .. image:: ../../../../shared/building_and_running_chapters/Images/ORA_RemoveSubmission.png
    :alt: Dialog allowing comments to be entered when removing a learner submission
-   
+
 5. Enter a comment to document or explain the removal. This comment appears to
    the learner when she views her response in the open response assessment
    problem.
-   
-#. Click **Remove submission**. 
+
+#. Click **Remove submission**.
 
    The inappropriate submission is removed from peer assessment. When you access
    this learner's information again, instead of the response, you see a note
@@ -176,9 +171,9 @@ Remove a submission from peer assessment by completing these steps.
 
    Removed submissions are also removed from the list of Top Responses if they
    were previously listed.
-   
+
 .. image:: ../../../../shared/building_and_running_chapters/Images//ORA_CancelledStudentResponse.png
-   :alt: The date, time and comment for removal of a learner response is shown instead of the original response.  
+   :alt: The date, time and comment for removal of a learner response is shown instead of the original response.
 
 
 .. _Locate a specific ORA submission:
@@ -194,7 +189,7 @@ grading>`, locate the specific submission by following these steps.
 #. Ask the person who reported the incident to send you a sample of text from
    the inappropriate post.
 
-#. Contact your edX Partner Manager to request a data download of ORA
+#. Contact your edX Program Manager to request a data download of ORA
    responses for your course.
 
    You will receive the download as a spreadsheet or in .csv file format.

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -31,7 +31,7 @@ Step 1. Create the Component
 To create the component for your open response assessment, complete these steps.
 
 #. In Studio, open the unit where you want to create the open response
-   assessment.   
+   assessment.
 #. Under **Add New Component**, select **Problem**, select the **Advanced** tab,
    and then select **Peer Assessment**.
 #. In the Problem component that appears, select **Edit**.
@@ -84,15 +84,15 @@ To allow learners to submit an image with a response, complete these steps.
 #. In the open response assessment component editor, select the **Settings** tab.
 #. For **Allow Image Responses**, select **True**.
 
-.. note:: 
- 
+.. note::
+
    * The image file must be a .jpg or .png file, and it must be smaller than 5
-     MB in size. 
+     MB in size.
    * Currently, course teams cannot see any of the images that
      learners submit. Images are not visible in the body of the assignment in
      the courseware, and they are not included in the course data package.
    * You can allow learners to upload an image, but you cannot require it.
-   * Learners can only submit one image with each response.     
+   * Learners can only submit one image with each response.
    * All responses must contain text. Learners cannot submit a response that
      contains only an image.
 
@@ -185,7 +185,7 @@ assessment feature.
   Time Zone Converter <http://www.timeanddate.com/worldclock/converter.html>`_
 
 To specify a name for the assignment as well as start and due dates for all
-student responses, complete these steps.
+learner responses, complete these steps.
 
 #. In the component editor, select the **Settings** tab.
 
@@ -204,7 +204,7 @@ student responses, complete these steps.
 Step 5. Select Assignment Steps
 ****************************************
 
-Open response assessment assignments can include learner training, peer assessment, and self assessment steps. 
+Open response assessment assignments can include learner training, peer assessment, and self assessment steps.
 
 .. note:: If you include a learner training step, you must also include a peer
    assessment step. The learner training step must come before peer or self
@@ -221,16 +221,16 @@ To add steps to the open response assignment, complete these actions.
 
 #. Locate the following headings.
 
-   * **Step: Student Training**
+   * **Step: Learner Training**
    * **Step: Peer Assessment**
    * **Step: Self Assessment**
 
-   Select the check boxes for the steps that you want the assignment to include. 
+   Select the check boxes for the steps that you want the assignment to include.
 
 #. (optional) To change the order of the steps, drag the steps into the order
    that you want.
 
-.. note:: If you include a student training step, make sure it is the first
+.. note:: If you include a learner training step, make sure it is the first
    step in the assignment.
 
 .. _PA Specify Step Settings:
@@ -246,25 +246,27 @@ steps.
    that step, the step will no longer be part of the assignment and your
    changes will not be saved.
 
-.. _PA Student Training Step:
+.. _PA Learner Training Step:
 
 ========================
-Student Training
+Learner Training
 ========================
 
-For the student training step, you enter one or more responses that you have
+For the learner training step, you enter one or more responses that you have
 created, then select an option for each criterion in your rubric.
 
 .. note:: You must enter your complete rubric on the **Rubric** tab before you
-   can select options for the student training responses. If you later change one
-   of your criteria or any of its options, you must also update the student
+   can select options for the learner training responses. If you later change
+   one of your criteria or any of its options, you must also update the learner
    training step.
 
-To add and score student training responses, follow these steps.
+To add and score learner training responses, follow these steps.
 
-#. Under **Step: Student Training**, locate the first **Scored Response** section.
+#. Under **Step: Learner Training**, locate the first **Scored Response**
+   section.
 #. In the **Response** field, enter the text of your example response.
-#. Under **Response Score**, for each criterion, select the option that you want.
+#. Under **Response Score**, for each criterion, select the option that you
+   want.
 
 For more information, see :ref:`PA Learner Training Assessments`.
 
@@ -293,7 +295,7 @@ To specify peer assessment settings, follow these steps.
 #. Next to **Due Date** and **Due Time**, enter the date and time by which all
    peer assessments must be complete.
 
-  .. note:: The times that you set, and the times that learners see, are in
+  .. note:: The times that you set, and the times that learners see, use
    Coordinated Universal Time (UTC). You might want to verify that you have
    specified the times that you intend by using a time zone converter such as
    `Time and Date Time Zone Converter
@@ -306,10 +308,10 @@ Self Assessment
 For the self assessment step, you specify when the step starts and ends.
 
 #. Locate the **Step: Self Assessment** heading.
-   
+
 #. Next to **Start Date** and **Start Time**, enter the date and time when
    learners can begin assessing their peers' responses.
-   
+
 #. Next to **Due Date** and **Due Time**, enter the date and time by which all
    peer assessments must be complete.
 
@@ -329,7 +331,7 @@ To allow learners to see the top-scoring responses for the assignment, you
 specify a number on the **Settings** tab.
 
 #. In the component editor, select the **Settings** tab.
-   
+
 #. In the **Top Responses** field, specify the number of responses that you
    want to appear in the **Top Responses** section below the learner's final
    score. If you do not want this section to appear, set the number to 0. The


### PR DESCRIPTION
This PR updates documentation with terminology and UI changes from TNL3688, in preparation for the ORA staff grading feature. Changes include updating doc strings to use "learner" rather than "student" and relabelling and updating the "Staff Info" and "Staff Tools" modals, including moving ability to remove a submission from the "Info" tab to the "Tools" tab.

Updated screenshots will not be included until later in the progress of the ORA Staff Grading updates.
### Reviewers

Keeping it light for this PR as it pretty much consists only of terminology and navigation changes. 
NB: due to a change in Sublime settings, automated changes for extra spaces, line wraps, etc. are also included in this PR. These changes add unfortunate noise to this PR but can be ignored.

@andy-armstrong and @explorerleslie, tagging you only FYI, but feel free to comment if you want to.
- [x] Doc sanity check: @srpearce OR @lamagnifica OR @mhoeber 
### Post-review
- [x] Squash commits
