### PR TITLE
Make handling of CERTIFICATES_HTML_VIEW precise

### DIFF
--- a/en_us/install_operations/source/configuration/enable_certificates.rst
+++ b/en_us/install_operations/source/configuration/enable_certificates.rst
@@ -36,12 +36,15 @@ To enable certificates, you modify the ``lms.env.json`` and ``cms.env.json``
 files, which are located one level above the ``edx-platform`` directory.
 
 #. In the ``lms.env.json`` and ``cms.env.json`` files, set the value of
-   ``CERTIFICATES_HTML_VIEW``  to ``True``.
+   ``CERTIFICATES_HTML_VIEW`` within the ``FEATURES`` object  to ``true``.
 
    .. code-block:: bash
 
-     # Certificates Web/HTML Views
-     'CERTIFICATES_HTML_VIEW': True,
+     "FEATURES": {
+         ...
+         'CERTIFICATES_HTML_VIEW': true,
+         ...
+     }
 
 #. Save the ``lms.env.json`` and ``cms.env.json`` files.
 


### PR DESCRIPTION
The instructions here had an example that was in the format of an environment python file rather than a JSON object, and they did not indicate that this variable has to be set within the `FEATURES` object, which cost me a bit of time to figure out :)

@catong could you take a look at this?
