### PR TITLE
fix description of problem_show event

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -2577,7 +2577,8 @@ The browser emits ``problem_save`` events when a user saves a problem.
 
 .. no sample to check
 
-The browser emits ``problem_show`` events when a problem is shown.
+The browser emits ``problem_show`` events when the answer to a problem is shown, i.e. the "show answer" button is clicked by the user.
+Note that despite its suggestive name, this event does not indicate when a problem has been shown.  
 
 .. %%
 


### PR DESCRIPTION
problem_show is fired when the "show answer" button is clicked, not when a problem is shown.

See:  https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/js/src/capa/display.coffee#L336 and https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/js/src/capa/display.coffee#L38
