### PR TITLE
DOC-2405 Remove ORA submission and delete student state

### DIFF
--- a/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
+++ b/en_us/shared/subsections/open_response_assessments/Access_ORA_Info.rst
@@ -133,12 +133,13 @@ inappropriate response, it is counted as one of the submissions they have
 graded.
 
 .. note:: After you remove an inappropriate response from peer assessment, you
-   decide whether the learner who submitted that response is allowed to submit a
-   replacement response. If you do not want to allow the learner to submit a
+   decide whether the learner who submitted that response is allowed to submit
+   a replacement response. If you do not want to allow the learner to submit a
    replacement response, you do not need to take any additional action. The
    learner receives a grade of zero for the entire submission. To allow the
-   learner to resubmit a response for a cancelled submission, :ref:`reset the
-   learner's attempts for the problem<reset_attempts>`.
+   learner to resubmit a response for a cancelled submission, you must delete
+   the learner's state for the problem. For information, see
+   :ref:`delete_state`.
 
 Remove a submission from peer assessment by completing these steps.
 

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -268,7 +268,7 @@ To add and score learner training responses, follow these steps.
 #. Under **Response Score**, for each criterion, select the option that you
    want.
 
-For more information, see :ref:`PA Learner Training Assessments`.
+For more information, see :ref:`PA Learner Training Step`.
 
 
 ============================


### PR DESCRIPTION
This PR updates a note in documentation to clarify that after course staff remove an ORA submission, if they want to allow a learner to resubmit a response, they must delete the learner's state from the problem. https://openedx.atlassian.net/browse/DOC-2405
### Reviewers
- [x] Subject matter expert: @awaisdar001 
- [x] Product manager: @explorerleslie 
- [x] Doc team review:  @lamagnifica or @srpearce 
### Post-review
- [x] Squash commits
