### PR TITLE
DOC-2119: Modify sentence in course farewell template

### DIFF
--- a/en_us/shared/building_and_running_chapters/running_course/bulk_email.rst
+++ b/en_us/shared/building_and_running_chapters/running_course/bulk_email.rst
@@ -671,8 +671,8 @@ about future access to course materials. Be sure to replace values enclosed by
     to generate all of the course certificates.
 
   * As an enrolled student, you will have access to the lecture videos even
-    after the course ends. The problem sets and exams will be removed from the
-    course when it is archived.
+    after the course ends. Assessments will remain, but you will no longer be
+    able to submit answers to any problem sets or exams with due dates.
 
   * The {course number} discussions close on {date} at {time} UTC. You will not
     be able to add to the discussions after that time, but you will be able to


### PR DESCRIPTION
This PR modifies a sentence in the bulk email template for course farewell, clarifying that although assessments remain, learners can no longer submit answers to problems and exams.
https://openedx.atlassian.net/browse/DOC-2119
### Reviewers
- [ ] Subject matter expert: @mrrudnick
- [x] Product manager: @explorerleslie 
- [x] Doc team review:  @lamagnifica or @srpearce 
