### PR TITLE
Clarified that Partner Manager should be capitalized - DOC-2453

### DIFF
--- a/en_us/course_authors/source/course_features/lti/index.rst
+++ b/en_us/course_authors/source/course_features/lti/index.rst
@@ -12,11 +12,11 @@ content, including advanced problem types and videos, in an on campus or in
 house learning management system. Examples currently include courses running on
 Canvas and Blackboard.
 
-.. note:: Support for this feature is currently provisional. EdX is working 
+.. note:: Support for this feature is currently provisional. EdX is working
  with a set of early adopter partners to support further testing of this
  feature with additional learning management systems.
 
-.. This note ^ can be removed after we get a better sense of how we'll do testing with new consumers, and regression testing for code changes. We'll also need to provide some direction on how they would line up this work (probably though Partner Manager) - Alison 16 Sept 15
+.. This note ^ can be removed after we get a better sense of how we'll do testing with new consumers, and regression testing for code changes. We'll also need to provide some direction on how they would line up this work (probably though partner manager) - Alison 16 Sept 15
 
 You use the topics in this section to prepare a course for reuse in another
 context.

--- a/en_us/course_authors/source/front_matter/change_log.rst
+++ b/en_us/course_authors/source/front_matter/change_log.rst
@@ -117,7 +117,7 @@ September 2015
        :ref:`Drag and Drop` and :ref:`Custom JavaScript`.
    * - 15 September 2015
      - Updated the :ref:`Rerun a Course` section to make it clear that only
-       edX Partner Managers can rerun a course.
+       edX partner managers can rerun a course.
    * - 9 September 2015
      - Added the :ref:`View the Course Structure API for the Usage ID` topic.
    * -

--- a/en_us/course_authors/source/video/video_course.rst
+++ b/en_us/course_authors/source/video/video_course.rst
@@ -124,7 +124,7 @@ Create or Obtain a Transcript
 To create or obtain a transcript in .srt format, you can work with a company
 that provides captioning services. To ensure quality and accuracy of
 transcripts, edX works with `3Play Media`_. To request a 3Play account at
-edX's discounted rate, contact your edX Partner Manager.
+edX's discounted rate, contact your edX partner manager.
 
 ===================================
 Associate a Transcript with a Video

--- a/en_us/course_authors/source/video/video_uploads.rst
+++ b/en_us/course_authors/source/video/video_uploads.rst
@@ -227,7 +227,7 @@ The encoding and hosting process assigns these statuses to video files.
   media@edx.org.
 
 Statuses of **Invalid Token** or **Unknown** indicate a configuration
-problem. Inform your edX Partner Manager if these statuses appear.
+problem. Inform your edX partner manager if these statuses appear.
 
 For more information, see :ref:`Video Encoding and Hosting Overview`.
 

--- a/en_us/data/source/internal_data_formats/credentials.rst
+++ b/en_us/data/source/internal_data_formats/credentials.rst
@@ -41,7 +41,7 @@ GNU Privacy Guard (GnuPG or GPG). Essentially, you install a cryptographic
 application on your local computer and then supply your email address and a
 secret passphrase (a password).
 
-.. important:: 
+.. important::
 
  * The email address that you supply when you create your keys must be your
    official email address at your edX partner institution.
@@ -55,7 +55,7 @@ secret passphrase (a password).
 The result is the public key that you send to edX to use in encrypting data
 files for your institution, and the private key which you keep secret and use
 to decrypt the encrypted files that you receive. Creating these keys is a one-
-time process that you coordinate with your edX Partner Manager. Instructions
+time process that you coordinate with your edX partner manager. Instructions
 for creating the keys on Windows or Macintosh follow.
 
 For more information about GPG encryption and creating key pairs, see the
@@ -69,9 +69,9 @@ Create Keys: Windows
 #. Go to the Gpg4win_ website and download the most recent version of Gpg4win.
 
 #. Install Gpg4win and then open the Kleopatra Gpg4win application. A wizard
-   presents a series of dialog boxes to collect information from you and 
+   presents a series of dialog boxes to collect information from you and
    generate your public key (called a certificate in Kleopatra).
-    
+
    a. When you are prompted to specify the type of key pair you want, click
       **Create personal OpenPGP key pair**.
 
@@ -87,12 +87,12 @@ Create Keys: Windows
 
 3. When Kleopatra presents the **Key Pair Successfully Created** dialog box,
    click **Send Certificate by EMail** to send the public key (and only the
-   public key) to your edX Partner Manager.
+   public key) to your edX partner manager.
 
 #. Optionally, click **Make a Backup Copy of Your Key Pair** to store both of
    the keys on a removable data storage device.
 
-.. important:: Do not reveal your passphrase, or share your private key, with 
+.. important:: Do not reveal your passphrase, or share your private key, with
  anyone else. If you need another person to be able to transfer and decrypt
  files, work with edX to set her or him up as an additional data czar. Data
  czars must create and use their own passphrases.
@@ -121,19 +121,19 @@ Create Keys: Macintosh
    remember, or use a secure method of retaining it for reuse in the future:
    you use this passphrase when you decrypt your data packages.
 
-#. To send only your public key to your edX Partner Manager, click the key and
+#. To send only your public key to your edX partner manager, click the key and
    then click **Export**. A dialog box opens.
 
-  a. Specify a file name and location to save the file. 
-     
+  a. Specify a file name and location to save the file.
+
   b. Make sure that **Format** is set to ASCII.
-  
+
   c. Make sure that **Allow secret key export** is cleared.
-  
+
   When you click **Save**, only the public key is saved in the resulting .asc
   file. Do not share your private key with edX or any third party.
 
-7. Compose an e-mail message to your edX Partner Manager. Attach the .asc
+7. Compose an e-mail message to your edX partner manager. Attach the .asc
    file that you saved in the previous step to the message, then send the
    message.
 
@@ -148,7 +148,7 @@ each data czar. The credentials for accessing this account are called an Access
 Key and a Secret Key.
 
 After the edX Analytics team creates these access credentials for you, they use
-the public encryption key that you sent your Partner Manager to encrypt the
+the public encryption key that you sent your partner manager to encrypt the
 credentials into a **credentials.csv.gpg** file. The edX Analytics team then
 sends the file to you as an email attachment.
 
@@ -173,12 +173,12 @@ To work with an encrypted .gpg file, you use the same GNU Privacy Guard program
 that you used to create your public/private key pair. You use your private key
 to decrypt the Amazon S3 credentials file and the files in your data packages.
 
-#. Save the encrypted file in an accessible location. 
+#. Save the encrypted file in an accessible location.
 
 #. On a Windows computer, open Windows Explorer. On a Macintosh, open Finder.
 
-#. Navigate to the file and right-click it. 
-   
+#. Navigate to the file and right-click it.
+
 #. On a Windows computer, select **Decrypt and verify**, and then click
    **Decrypt/Verify**. Do not change any other setting.
 
@@ -186,13 +186,13 @@ to decrypt the Amazon S3 credentials file and the files in your data packages.
    File**.
 
 #. Enter your passphrase. The GNU Privacy Guard program decrypts the file.
-   
+
 For example, when you decrypt the credentials.csv.gpg file the result is a
 credentials.csv file. Open the decrypted credentials.csv file to see that it
 contains your email address, your Access Key, and your Secret Key.
 
  .. image:: ../Images/AWS_Credentials.png
-  :alt: A csv file, open in Notepad, with the Access Key value and the Secret 
+  :alt: A csv file, open in Notepad, with the Access Key value and the Secret
         Key value underlined
 
 .. _Access Amazon S3:
@@ -213,7 +213,7 @@ Browser. Alternatively, you can use the `AWS Command Line Interface`_.
 #. Open your decrypted ``credentials.csv`` file. This file contains your AWS
    Access Key and your AWS Secret Key.
 
-#. Open the third-party tool. 
+#. Open the third-party tool.
 
 #. Enter information to connect to the S3 account.
 
@@ -222,13 +222,13 @@ Browser. Alternatively, you can use the `AWS Command Line Interface`_.
    Key, and your Secret Key. For more information, see the documentation
    provided for the tool that you selected.
 
-5. To access the database data files, specify or select ``s3://course-data``. 
-   
+5. To access the database data files, specify or select ``s3://course-data``.
+
    To access the event data files, specify or select ``s3://edx-course-
    data/{org}/``. You must include the identifier for your organization after
    the name of the bucket.
 
-   .. note:: If you are using a third-party tool to connect to Amazon S3, you 
+   .. note:: If you are using a third-party tool to connect to Amazon S3, you
     might not be able to navigate directly between ``s3://course-data`` and
     ``s3://edx-course-data/{org}/``. You might need to disconnect from Amazon
     S3 and then reconnect to specify the other destination.

--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -127,7 +127,7 @@ The following tables store data gathered about the teams in a course.
 * :ref:`teams_courseteammembership`
 
 .. note:: The Teams feature is in limited release. For more information,
-   contact your edX Partner Manager. For Open edX sites, contact your system
+   contact your edX partner manager. For Open edX sites, contact your system
    administrator.
 
 .. _auth_user:
@@ -251,7 +251,7 @@ is_staff
   It does not indicate that the person is a member of the course team for any
   given course.
 
-  Generally, users with this flag set to 1 are either edX Partner Managers
+  Generally, users with this flag set to 1 are either edX partner managers
   responsible for course delivery, or edX developers who need access for
   testing and debugging purposes. Users who have ``is_staff`` = 1 have
   Admin privileges on all courses and can see additional debug
@@ -989,7 +989,7 @@ Columns in the teams_courseteam Table
 This table stores information about the teams in a course.
 
 .. note:: The Teams feature is in limited release. For more information,
-   contact your edX Partner Manager. For Open edX sites, contact your system
+   contact your edX partner manager. For Open edX sites, contact your system
    administrator.
 
 **History**: Added September 15 2015
@@ -1156,7 +1156,7 @@ Columns in the teams_courseteammembership Table
 This table stores information about learners who are members of a team.
 
 .. note:: The Teams feature is in limited release. For more information,
-   contact your edX Partner Manager. For Open edX sites, contact your system
+   contact your edX partner manager. For Open edX sites, contact your system
    administrator.
 
 **History**: Added September 15 2015.

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -4017,7 +4017,7 @@ first event produced when teams are included in a course is the
 ``edx.team.created`` event.
 
 .. note:: The Teams feature is in limited release. For more information,
-   contact your edX Partner Manager. For Open edX sites, contact your system
+   contact your edX partner manager. For Open edX sites, contact your system
    administrator.
 
 .. contents::

--- a/en_us/edx_style_guide/source/wordlist.rst
+++ b/en_us/edx_style_guide/source/wordlist.rst
@@ -39,8 +39,9 @@ Word List
        deliver content to learners. In Studio, course teams can rename default
        pages and add pages. In the LMS, learners select {name of page} and work
        with the content on that page.
-   * - Partner Manager
-     - Use to refer to partners' main edX contact, not Program Manager.
+   * - partner manager
+     - Use to refer to partners' main edX contact, not program manager.
+       Do not capitalize either word.
    * - plug-in
      - Use instead of plugin.
    * - privilege

--- a/en_us/edx_style_guide/source/wordlist.rst
+++ b/en_us/edx_style_guide/source/wordlist.rst
@@ -39,9 +39,9 @@ Word List
        deliver content to learners. In Studio, course teams can rename default
        pages and add pages. In the LMS, learners select {name of page} and work
        with the content on that page.
-   * - Partner Manager
-     - Use to refer to partners' main edX contact, not Program Manager.
-       Capitalize both words.
+   * - partner manager
+     - Use to refer to partners' main edX contact, not program manager.
+       Do not capitalize either word.
    * - plug-in
      - Use instead of plugin.
    * - privilege

--- a/en_us/edx_style_guide/source/wordlist.rst
+++ b/en_us/edx_style_guide/source/wordlist.rst
@@ -41,6 +41,7 @@ Word List
        with the content on that page.
    * - Partner Manager
      - Use to refer to partners' main edX contact, not Program Manager.
+       Capitalize both words.
    * - plug-in
      - Use instead of plugin.
    * - privilege

--- a/en_us/install_operations/source/configuration/tpa/enable_tpa_edge.rst
+++ b/en_us/install_operations/source/configuration/tpa/enable_tpa_edge.rst
@@ -74,7 +74,7 @@ Configure User Attributes
 You work with edX to ensure that your identity provider will assert the user
 information that you want learners to see during initial sign in on edX Edge.
 When you :ref:`send your Shibboleth configuration data<Send Shibboleth
-Configuration Data to edX>` to your institution's edX Partner Manager, you
+Configuration Data to edX>` to your institution's edX partner manager, you
 include any customizations to the attributes that will be asserted.
 
 Selecting User Attributes to Assert
@@ -122,7 +122,7 @@ Send Shibboleth Configuration Data to edX
 ======================================================
 
 To complete the integration between your Shibboleth system and Edge, send
-the following information to your institution's edX Partner Manager.
+the following information to your institution's edX partner manager.
 
 * Metadata: The URL for your Shibboleth IdP metadata XML file.
 
@@ -135,7 +135,7 @@ the following information to your institution's edX Partner Manager.
   For more information about how you can work with edX to configure user
   attributes effectively, see :ref:`Configure User Attributes`.
 
-Your edX Partner Manager notifies you when integration with your IdP is
+Your edX partner manager notifies you when integration with your IdP is
 complete.
 
 ========================

--- a/en_us/release_notes/source/2014/10-23-2013.rst
+++ b/en_us/release_notes/source/2014/10-23-2013.rst
@@ -33,12 +33,12 @@ New Features
 
   * When you cancel a drop, the course element returns to its original position.
 
-  * You can no longer drag a course element below the New Unit button, which was causing confusion. 
+  * You can no longer drag a course element below the New Unit button, which was causing confusion.
 
 * **Text customization capability**
 
   You can now customize some of the UI text that your students see. You do this through the text_customization key in the Advanced
-  Settings for the course. (However, edX recommends that you contact your Partner Manager before you modify the text_customization key.) 
+  Settings for the course. (However, edX recommends that you contact your partner manager before you modify the text_customization key.)
 
 * **JavaScript loading performance**
 
@@ -51,35 +51,35 @@ New Features
 Changes and Updates
 ==========================
 
-The following changes are included in this release: 
+The following changes are included in this release:
 
 * In a course outline, you can no longer drag and drop a unit below the New Unit button. (STUD-152)
- 
+
 * Course update content outside of HTML tags is no longer erroneously removed.(STUD-590)
- 
+
 * In a course outline, dragging a unit over the Units label no longer causes the unit to be removed. (STUD-755)
- 
+
 * Support text in the Assignment Types section of the Grading page is updated to clarify that you enter an integer, not a percent, in the W
   eight of Total Grade field. (STUD-771)
- 
+
 * Certain component errors no longer prevent the course from saving correctly. (STUD-786)
- 
-* When you delete a Discussion component, the discussion is completely removed from the course. (STUD-811, STUD-817) 
+
+* When you delete a Discussion component, the discussion is completely removed from the course. (STUD-811, STUD-817)
 
 * When you are editing a course update, the update no longer disappears if you click outside of the Edit window. (STUD-822)
- 
+
 * When you enter the integer 7 in the Total Weight of Grade field, the value is no longer changed to a decimal. (STUD-826)
 
 
 ***************************************
-edX Learning Management System 
+edX Learning Management System
 ***************************************
 
 =============
 New Features
 =============
 
-The following changes are included in this release: 
+The following changes are included in this release:
 
 * **Fixed views in Internet Explorer 9.x**
 
@@ -88,7 +88,7 @@ The following changes are included in this release:
 * **Disabled downloading data for large courses**
 
   For courses with over 200 students, downloading large data sets could fail. The Download Data button on the Instructor Dashboard is now
-  temporarily disabled to avoid this problem. 
+  temporarily disabled to avoid this problem.
 
 * **Improved Beta Instructor Dashboard**
 
@@ -97,12 +97,12 @@ The following changes are included in this release:
 
 * **Improved video and transcript experience** (BLD-420)
 
-  When you are playing a video with the transcript hidden, you can display the transcript by hovering the mouse pointer over the CC button. 
+  When you are playing a video with the transcript hidden, you can display the transcript by hovering the mouse pointer over the CC button.
   You can then click a paragraph in the displayed transcript to move to that point in the video. When you move the pointer off the CC button,
   the transcript is hidden.
 
 * **Improved Learning Tools Interoperability (LTI)** (BLD-330, BLD-347)
-  
+
   You can now use multiple LTI tools per page. You can also have an LTI module load external content in a new window.
 
 
@@ -111,27 +111,27 @@ Changes and Updates
 ==========================
 
 * The link to open and close the calculator has additional aria attributes for accessibility. (BLD-164)
- 
+
 * The Hints panel for the calculator is now accessible to screen readers. (BLD-165)
- 
+
 * Students can now download video subtitles. (BLD-245)
- 
+
 * Multi-speed video playback now works in Firefox browsers as expected. (BLD-287)
- 
+
 * Window resizing no longer cuts off videos. (BLD-289)
- 
+
 * Video HD control is now handicap accessible. (BLD-387)
- 
+
 * You can now export courses that have LTI modules. (BLD-389)
- 
+
 * A malformed custom parameter in an LTI component no longer permanently breaks the unit. (BLD-390)
- 
+
 * The styles and text for the download links for videos and transcripts are updated for clarity and accessibility. (BLD-403)
- 
+
 * The CC button in the video player now includes explanatory text that is accessible with a screen reader. (BLD-404)
- 
+
 * LTI with the Piazza platform now works as expected. (BLD-405)
- 
+
 * The **Close** button on dialog boxes is now defined as an HTML button and is accessible to screen readers. (LMS-582)
 
 
@@ -139,10 +139,10 @@ Changes and Updates
 Discussion Forums
 ******************
 
-The following changes are included in this release: 
+The following changes are included in this release:
 
 * The color contrast of the Report Misuse link is updated for accessibility. (FOR-200)
- 
+
 * The Report Misuse link now includes a tooltip that is accessible to screen readers. (FOR-201)
- 
+
 * The Report Misuse link is now included in the page tab order, for keyboard accessibility. (FOR-209)

--- a/en_us/shared/course_assets/course_files.rst
+++ b/en_us/shared/course_assets/course_files.rst
@@ -28,7 +28,7 @@ The maximum size for an uploaded file is 50 MB.
 
 We recommend that you use standard compression tools to reduce PDF and image
 file sizes before you add the files to your course. If you have to use files
-that are larger than 50 MB after compression, contact your edX Partner Manager.
+that are larger than 50 MB after compression, contact your edX partner manager.
 
 If you have video or audio files or large data sets to share with your
 students, use YouTube or another hosting service to host these files. Do not

--- a/en_us/shared/course_components/create_html_component.rst
+++ b/en_us/shared/course_components/create_html_component.rst
@@ -483,7 +483,7 @@ example, if you want to create "beautiful math" such as the following.
 .. warning::
  The LaTeX processor that Studio uses to convert LaTeX code to XML is a third-
  party tool. We recommend that you use this feature with caution. If you do use
- it, make sure to work with your Partner Manager.
+ it, make sure to work with your partner manager.
 
 Enable the LaTeX Processor
 **************************

--- a/en_us/shared/course_features/lti/lti_prepare_content.rst
+++ b/en_us/shared/course_features/lti/lti_prepare_content.rst
@@ -16,11 +16,11 @@ Preparing to Reuse Course Content
 .. only:: Open_edX
 
   Before you begin work to reuse the content in an Open edX course, check with
-  your development operations (DevOps) team for information about the 
+  your development operations (DevOps) team for information about the
   website to use. At some sites, a completely separate Open edX instance, with
   a different Studio website, is set up to be the LTI tool provider.
 
-.. contents:: 
+.. contents::
    :local:
    :depth: 1
 
@@ -32,7 +32,7 @@ Planning for Content Reuse
 
 When you create links to edX course content in your external LMS, you can link
 to components individually, to all of the content in a unit, or to all of the
-content in a subsection. 
+content in a subsection.
 
 As you plan which parts of the course you want to reuse, note the following
 considerations.
@@ -72,7 +72,7 @@ Create the Duplicate Course
 .. only:: Partners
 
   Before you create a duplicate course, be sure to check with your DevOps team
-  or your edX Partner Manager to determine the website that hosts your
+  or your edX partner manager to determine the website that hosts your
   organization's courses for LTI use.
 
 .. only:: Open_edX
@@ -84,11 +84,11 @@ To create the duplicate course, follow these steps.
 
 #. In Studio, export the original course. For more information, see
    :ref:`Export a Course`.
-   
+
 #. In Studio on your organization's host site for LTI courses, create a course.
    This is the duplicate course.
-   
-   .. note:: If your organization uses the same site as the host for both the 
+
+   .. note:: If your organization uses the same site as the host for both the
     original course and for LTI courses, be sure to give the duplicate course a
     different name or run.
 
@@ -159,7 +159,7 @@ Verify Content Status
 
 Only edX course content that is published appears in an external LMS.
 
-.. note:: The **Hide from students** setting for sections, subsections, 
+.. note:: The **Hide from students** setting for sections, subsections,
  and units does not affect the visibility of content in an external LMS. Only
  the publication status of a unit can prevent content from being included.
 

--- a/en_us/shared/exercises_tools/external_graders.rst
+++ b/en_us/shared/exercises_tools/external_graders.rst
@@ -107,7 +107,7 @@ problems in Studio.
 EdX partners who are using external graders should use the base URL
 ``https://xqueue.edx.org`` as the XQueue name.
 
-If you are an edX partner, contact your edX Partner Manager for more
+If you are an edX partner, contact your edX partner manager for more
 information. Because edX hosts many XQueues for different courses, you must use
 the exact XQueue name in your problems, as described in  :ref:`Create a Code
 Response Problem`.
@@ -234,7 +234,7 @@ edX operations, when the grader fails. In collaboration with edX, you must
 develop a procedure to quickly identify the cause of failure, which can be your
 grader or edX's XQueue.
 
-Contact your edX Partner Manager for more information.
+Contact your edX partner manager for more information.
 
 If you know the grader will be unavailable at a certain time for maintenance,
 you should :ref:`add a course update <Add a Course Update>`.
@@ -287,7 +287,7 @@ external grader::
 Note the following details about the XML definition.
 
 * **queuename**: The value of the queuename attribute of the ``<coderesponse>``
-  element maps to an XQueue. Partners should contact their edX Partner Manager
+  element maps to an XQueue. Partners should contact their edX partner manager
   for more information. You must use this exact name in order for the problem
   to communicate with the correct XQueue.
 

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -4,9 +4,9 @@
 Glossary
 ############
 
-:ref:`A` - :ref:`C` - :ref:`D` - :ref:`E` - :ref:`F` 
-- :ref:`G` - :ref:`H` - :ref:`I` - :ref:`K` - :ref:`L` 
-- :ref:`M` - :ref:`N` - :ref:`O` - :ref:`P` - :ref:`R` 
+:ref:`A` - :ref:`C` - :ref:`D` - :ref:`E` - :ref:`F`
+- :ref:`G` - :ref:`H` - :ref:`I` - :ref:`K` - :ref:`L`
+- :ref:`M` - :ref:`N` - :ref:`O` - :ref:`P` - :ref:`R`
 - :ref:`S` - :ref:`T` - :ref:`V` - :ref:`W` - :ref:`XYZ<X>`
 
 .. _A:
@@ -38,7 +38,7 @@ A
   For more information, see `Creating Exercises and Tools`_.
 
 .. _Advanced Editor_g:
- 
+
 **Advanced Editor**
 
   An XML-only editor in a problem component that allows you to can create and
@@ -46,7 +46,7 @@ A
 
 
 .. _Assignment Type:
- 
+
 **Assignment Type**
 
   The category of graded student work, such as homework, exams, and exercises.
@@ -70,7 +70,7 @@ C
   XBlocks. An open response assessment is an example of a non-capa problem type.
 
 .. _Certificate:
- 
+
 **Certificate**
 
   A document issued to an enrolled student who successfully completes a course.
@@ -82,7 +82,7 @@ C
   See :ref:`Section<S>`.
 
 .. _Checkbox_g:
- 
+
 **Checkbox Problem**
 
   A problem that prompts the student to select one or more options from a list
@@ -90,7 +90,7 @@ C
 
 
 .. _Chemical Equation_g:
- 
+
 **Chemical Equation Response Problem**
 
   A problem that allows the student to enter chemical equations as answers.
@@ -98,7 +98,7 @@ C
 
 
 .. _Circuit Schematic_g:
- 
+
 **Circuit Schematic Builder Problem**
 
   A problem that allows the student to construct a schematic answer (such as
@@ -111,7 +111,7 @@ C
   See :ref:`Transcript<T>`.
 
 .. _Cohort:
- 
+
 **Cohort**
 
   A group of students who participate in a class together. Students who are in
@@ -123,7 +123,7 @@ C
   assign students to them, see `Using Cohorts in Your Courses`_.
 
 .. _Component_g:
- 
+
 **Component**
 
   The part of a unit that contains your actual course content. A unit can
@@ -149,9 +149,9 @@ C
 **Content-Specific Discussion Topic**
 
   A category within the course discussion that appears at a defined point in
-  the course to encourage questions and conversations. To add a 
-  content-specific discussion topic to your course, you add a discussion 
-  component to a unit. Students cannot contribute to a content-specific 
+  the course to encourage questions and conversations. To add a
+  content-specific discussion topic to your course, you add a discussion
+  component to a unit. Students cannot contribute to a content-specific
   discussion topic until the release date of the section that contains it.
 
   For more information, see `Working with Discussion Components`_ and
@@ -159,7 +159,7 @@ C
 
 
 .. _Course Catalog:
- 
+
 **Course Catalog**
 
   The page that lists all courses offered in the edX learning management
@@ -168,7 +168,7 @@ C
 
 
 .. _Course Handouts:
- 
+
 **Course Handouts**
 
   Course handouts are files you make available to students in the Course Info
@@ -178,7 +178,7 @@ C
 
 
 .. _Course Info Page:
- 
+
 **Course Info Page**
 
   The page that opens first every time students access your course. You can
@@ -187,7 +187,7 @@ C
 
 
 .. _Run:
- 
+
 **Course Run**
 
   The term or time frame in which a specific offering of your course takes
@@ -195,7 +195,7 @@ C
   information, see `Create a New Course`_.
 
 .. _Courseware:
- 
+
 
 **Courseware**
 
@@ -213,7 +213,7 @@ C
   For more information, see `Creating Discussion Topics for Your Course`_.
 
 .. _Custom Response Problem:
- 
+
 **Custom Response Problem**
 
   A custom response problem evaluates text responses from students using an
@@ -247,7 +247,7 @@ D
 
 
 .. _Discussion Component:
- 
+
 **Discussion Component**
 
   Discussion topics that course teams add directly to units. For example, a
@@ -259,7 +259,7 @@ D
   For more information, see `Working with Discussion Components`_.
 
 .. _Dropdown_g:
- 
+
 **Dropdown Problem**
 
   A problem that asks students to choose from a collection of answer options,
@@ -273,14 +273,14 @@ E
 ****
 
 .. _edX101_g:
- 
+
 **edX101**
 
   An online course about how to create online courses. The intended audience
-  for `edX101`_ is faculty and university administrators. 
+  for `edX101`_ is faculty and university administrators.
 
 .. _edX Edge:
- 
+
 **edX Edge**
 
   `Edge`_ is a less restricted site than edX.org. While only edX employees and
@@ -290,16 +290,16 @@ E
   at edge.edx.org.
 
 .. _edX Studio:
- 
+
 **edX Studio**
 
-  The edX tool that you use to build your courses. 
+  The edX tool that you use to build your courses.
 
   For more information, see `What is Studio?`_.
 
 
 .. _Exercises:
- 
+
 **Exercises**
 
   Practice or practical problems interspersed in edX course content to keep
@@ -308,7 +308,7 @@ E
 
 
 .. _Export:
- 
+
 **Export**
 
   A tool in edX Studio that you use to export your course or library for
@@ -334,7 +334,7 @@ G
 ****
 
 .. _grade:
- 
+
 **Grade Range**
 
   Thresholds that specify how numerical scores are associated with grades, and
@@ -342,9 +342,9 @@ G
 
   For more information, see `Set the Grade Range`_.
 
- 
+
 **Grading Rubric**
- 
+
   See :ref:`Rubric<R>`.
 
 
@@ -355,7 +355,7 @@ H
 ****
 
 .. _HTML Component:
- 
+
 **HTML Component**
 
   A type of component that you can use to add and format text for your course.
@@ -373,7 +373,7 @@ I
 
 
 .. _Image Mapped_g:
- 
+
 **Image Mapped Input Problem**
 
   A problem that presents an image and accepts clicks on the image as an
@@ -383,7 +383,7 @@ I
 
 
 .. _Import:
- 
+
 **Import**
 
   A tool in edX Studio that you use to load a course or library in XML format
@@ -394,7 +394,7 @@ I
   For more information, see `Import a Course`_ or `Import a Library`_.
 
 
- 
+
 .. _K:
 
 ****
@@ -404,7 +404,7 @@ K
 **Keyword**
 
   A variable in a bulk email message. When you send the message, a value that
-  is specific to the each recipient is substituted for the keyword. 
+  is specific to the each recipient is substituted for the keyword.
 
 .. _L:
 
@@ -417,7 +417,7 @@ L
   See :ref:`Accessible Label<A>`.
 
 .. _LaTeX:
- 
+
 **LaTeX**
 
   A document markup language and document preparation system for the TeX
@@ -430,7 +430,7 @@ L
 
 
 .. _Learning Management System:
- 
+
 **Learning Management System (LMS)**
 
   The platform that students use to view courses, and that course team members
@@ -443,7 +443,7 @@ L
   page in the LMS. The learning sequence contains an icon for each unit in the
   selected subsection. When a learner moves the cursor over one of these
   icons, the names of each component in that unit appear.
- 
+
 **Left Pane**
 
   The navigation frame that appears at the left side of the **Courseware**
@@ -465,7 +465,7 @@ L
 
 
 .. _Live Mode:
- 
+
 **Live Mode**
 
   A view that allows the course team to review all published units as students
@@ -490,7 +490,7 @@ M
 ****
 
 .. _Math Expression_g:
- 
+
 **Math Expression Input Problem**
 
   A problem that requires students to enter a mathematical expression as text,
@@ -500,7 +500,7 @@ M
 
 
 .. _MathJax:
- 
+
 **MathJax**
 
   A LaTeX-like language that you use to write equations. Studio uses MathJax
@@ -524,7 +524,7 @@ M
 
 
 .. _Multiple Choice_g:
- 
+
 **Multiple Choice Problem**
 
   A problem that asks students to select one answer from a list of options.
@@ -539,7 +539,7 @@ N
 ****
 
 .. _Numerical Input_g:
- 
+
 **Numerical Input Problem**
 
   A problem that asks students to enter numbers or specific and relatively
@@ -571,7 +571,7 @@ P
 ****
 
 .. _Pages_g:
- 
+
 **Pages**
 
   Pages organize course materials into categories that students select in the
@@ -583,20 +583,20 @@ P
 
 **Partner Manager**
 
-  Each EdX partner institution has an edX Partner Manager. The Partner Manager
+  Each EdX partner institution has an edX partner manager. The partner manager
   is the primary contact for the institution's course teams.
 
 
 **Pre-Roll Video**
 
   A short video file that plays before the video component selected by the learner.
-  Pre-roll videos play automatically, on an infrequent schedule. 
+  Pre-roll videos play automatically, on an infrequent schedule.
 
   For more information, see `Adding a Pre-Roll Video`_.
 
 
 .. _Preview Mode:
- 
+
 **Preview Mode**
 
   A view that allows you to see all the units of your course as students see
@@ -608,7 +608,7 @@ P
 
 
 .. _Problem Component:
- 
+
 **Problem Component**
 
   A component that allows you to add interactive, automatically graded
@@ -620,7 +620,7 @@ P
 
 
 .. _Progress Page:
- 
+
 **Progress Page**
 
   The page in the learning management system that shows students their scores
@@ -629,7 +629,7 @@ P
 
 
 .. _Public Unit:
- 
+
 .. **Public Unit**
 
 ..  A unit whose **Visibility** option is set to Public so that the unit is
@@ -651,7 +651,7 @@ Q
   other students can resolve.
 
   For more information, see `Managing Course Discussions`_.
-  
+
 .. _R:
 
 ****
@@ -659,7 +659,7 @@ R
 ****
 
 .. _Rubric_g:
- 
+
 **Rubric**
 
   A list of the items that a student's response should cover in an open
@@ -679,7 +679,7 @@ S
 
 
 .. _Section_g:
- 
+
 **Section**
 
   The topmost category in your course outline. A section can represent a time
@@ -695,7 +695,7 @@ S
 
 
 .. _Short Course Description:
- 
+
 **Short Course Description**
 
   The description of your course that appears on the edX `Course List
@@ -705,7 +705,7 @@ S
 
 
 .. _Simple Editor_g:
- 
+
 **Simple Editor**
 
   The graphical user interface in a problem component that contains formatting
@@ -720,7 +720,7 @@ S
 
 
 .. _Subsection:
- 
+
 **Subsection**
 
   A division in the course outline that represents a topic in your course,
@@ -737,7 +737,7 @@ T
 ****
 
 .. _Text Input_g:
- 
+
 **Text Input Problem**
 
   A problem that asks the student to enter a line of text, which is then
@@ -747,7 +747,7 @@ T
 
 
 .. _Transcript:
- 
+
 **Transcript**
 
   A text version of the content of a video. You can make video transcripts
@@ -780,10 +780,10 @@ V
   See :ref:`Unit<U>`.
 
 .. _Video Component:
- 
+
 **Video Component**
 
-  A component that you can use to add recorded videos to your course. 
+  A component that you can use to add recorded videos to your course.
 
   For more information, see `Working with Video Components`_.
 
@@ -795,12 +795,12 @@ W
 ****
 
 .. _Wiki:
- 
+
 **Wiki**
 
   The page in each edX course that allows both students and members of the
   course team to add, modify, or delete content.
- 
+
   Students can use the wiki to share links, notes, and other helpful
   information with each other.
 
@@ -814,7 +814,7 @@ XYZ
 ****
 
 .. _XBlock:
- 
+
 **XBlock**
 
   EdX's component architecture for writing courseware components: XBlocks are
@@ -851,7 +851,7 @@ XYZ
 .. _Dropdown Problem: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/dropdown.html
 .. _edX101: https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VOYi8rDF-n0
 .. _Edge: http://edge.edx.org
-.. _What is Studio?: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/getting_started/get_started.html#what-is-studio.. _: 
+.. _What is Studio?: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/getting_started/get_started.html#what-is-studio.. _:
 .. _Export a Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/export_import_course.html#export-a-course
 .. _Export a Library: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/libraries.html#export-a-library
 .. _Set the Grade Range: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/establish_grading_policy.html#set-the-grade-range
@@ -866,11 +866,11 @@ XYZ
 .. _View Your Live Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/developing_course/testing_courseware.html#view-your-live-course
 .. _Entering Mathematical and Scientific Expressions: http://edx-guide-for-students.readthedocs.org/en/latest/SFD_mathformatting.html
 .. _A Brief Introduction to MathJax in Studio: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/mathjax.html
-.. _Multiple Choice Problem: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/multiple_choice.html 
+.. _Multiple Choice Problem: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/multiple_choice.html
 .. _Numerical Input Problem: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/exercises_tools/numerical_input.html
 .. _Adding Pages to a Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/pages.html
 .. _Preview Course Content: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/developing_course/testing_courseware.html#preview-course-content
-.. _Working with Problem Components: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/create_problem.html 
+.. _Working with Problem Components: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/create_problem.html
 .. _Developing Course Sections: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/developing_course/course_sections.html
 .. _Describe Your Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/building_course/setting_up_student_view.html#describe-your-course
 .. _The Studio View of a Problem: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/create_problem.html#problem-studio-view

--- a/en_us/shared/set_up_course/creating_course_certificates.rst
+++ b/en_us/shared/set_up_course/creating_course_certificates.rst
@@ -55,7 +55,7 @@ Certificate Design
 .. only:: Partners
 
   The design of certificates for your course, including your institution's
-  logo, are configured by edX. Contact your Partner Manager for
+  logo, are configured by edX. Contact your partner manager for
   more information.
 
 
@@ -141,7 +141,7 @@ You can edit a certificate before it is activated.
 
 .. only:: Partners
 
-  Contact your edX Partner Manager if you need to edit an activated
+  Contact your edX partner manager if you need to edit an activated
   certificate.
 
 .. caution::
@@ -253,7 +253,7 @@ Activate a Certificate
 
 .. only:: Partners
 
-  When you have verified your certificates, contact your edX Partner Manager to
+  When you have verified your certificates, contact your edX partner manager to
   activate your certificates.
 
 .. only:: Open_edX
@@ -292,7 +292,7 @@ it is possible that certificates have already been issued to learners.
 
 .. only:: Partners
 
-  Contact your edX Partner Manager if you need to modify an activated
+  Contact your edX partner manager if you need to modify an activated
   certificate.
 
 .. only:: Open_edX

--- a/en_us/shared/set_up_course/lti/lti_prepare_content.rst
+++ b/en_us/shared/set_up_course/lti/lti_prepare_content.rst
@@ -16,11 +16,11 @@ Preparing to Reuse Course Content
 .. only:: Open_edX
 
   Before you begin work to reuse the content in an Open edX course, check with
-  your development operations (DevOps) team for information about the 
+  your development operations (DevOps) team for information about the
   website to use. At some sites, a completely separate Open edX instance, with
   a different Studio website, is set up to be the LTI tool provider.
 
-.. contents:: 
+.. contents::
    :local:
    :depth: 1
 
@@ -32,7 +32,7 @@ Planning for Content Reuse
 
 When you create links to edX course content in your external LMS, you can link
 to components individually, to all of the content in a unit, or to all of the
-content in a subsection. 
+content in a subsection.
 
 As you plan which parts of the course you want to reuse, note the following
 considerations.
@@ -72,7 +72,7 @@ Create the Duplicate Course
 .. only:: Partners
 
   Before you create a duplicate course, be sure to check with your DevOps team
-  or your edX Partner Manager to determine the website that hosts your
+  or your edX partner manager to determine the website that hosts your
   organization's courses for LTI use.
 
 .. only:: Open_edX
@@ -84,11 +84,11 @@ To create the duplicate course, follow these steps.
 
 #. In Studio, export the original course. For more information, see
    :ref:`Export a Course`.
-   
+
 #. In Studio on your organization's host site for LTI courses, create a course.
    This is the duplicate course.
-   
-   .. note:: If your organization uses the same site as the host for both the 
+
+   .. note:: If your organization uses the same site as the host for both the
     original course and for LTI courses, be sure to give the duplicate course a
     different name or run.
 
@@ -159,7 +159,7 @@ Verify Content Status
 
 Only edX course content that is published appears in an external LMS.
 
-.. note:: The **Hide from students** setting for sections, subsections, 
+.. note:: The **Hide from students** setting for sections, subsections,
  and units does not affect the visibility of content in an external LMS. Only
  the publication status of a unit can prevent content from being included.
 

--- a/en_us/shared/set_up_course/scheduling_course.rst
+++ b/en_us/shared/set_up_course/scheduling_course.rst
@@ -64,7 +64,7 @@ start the course.
 
   .. note::
     For courses on edX.org, you must communicate the course start and end dates
-    and times to your edX Partner Manager to ensure the information is accurate
+    and times to your edX partner manager to ensure the information is accurate
     on the course About page.
 
 ============================
@@ -135,7 +135,7 @@ the course end date.
   For partner courses on edx.org, when the enrollment end date passes,
   the course is no longer listed in the course catalog. EdX encourages you to
   keep enrollment open as long as possible. For more information, contact your
-  edX Partner Manager.
+  edX partner manager.
 
 .. _Set Start and End Dates:
 

--- a/en_us/shared/set_up_course/setting_up_student_view.rst
+++ b/en_us/shared/set_up_course/setting_up_student_view.rst
@@ -72,7 +72,7 @@ page.
  :width: 600
 
 .. note:: For courses on edX.org, you must communicate the course description
- to your edX Partner Manager, to ensure the content is accurate on the course
+ to your edX partner manager, to ensure the content is accurate on the course
  About page.
 
 #. From the **Settings** menu, select **Schedule & Details**.
@@ -128,7 +128,7 @@ in the dashboard.
 .. note::
   On edX.org, the course image you add in Studio is used on the learner
   dashboard, but does not automatically appear on the course About page. Work
-  directly with your edX Partner Manager to set up the About page assets and
+  directly with your edX partner manager to set up the About page assets and
   course image for the course summary page.
 
 .. _Add a Course Video:
@@ -183,7 +183,7 @@ Specifications` and :ref:`Video Formats` guidelines as course content videos.
 #. View your course About page to test how the video will appear to learners.
 
 .. note::
-  On edX.org, you work directly with your Partner Manager to set up the course
+  On edX.org, you work directly with your partner manager to set up the course
   video in the summary page.
 
 .. _Set Course Effort Expectations:

--- a/en_us/shared/student_progress/checking_student_progress.rst
+++ b/en_us/shared/student_progress/checking_student_progress.rst
@@ -84,7 +84,7 @@ communication with your learners.
 .. only:: Partners
 
    Course teams should also discuss additional self-paced settings with their
-   edX Partner Manager during the course announcement process.
+   edX partner manager during the course announcement process.
 
 ==============================================================
 Allow Learners to Download Certificates when they Qualify


### PR DESCRIPTION
## [DOC-2453](https://openedx.atlassian.net/browse/DOC-2453)

Clarified that Partner Manager should be capitalized in edX documentation.
### Reviewers
- [ ] Doc team review (sanity check/copy edit/dev edit): @srpearce @lamagnifica @catong 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
