### PR TITLE
Pdesjardins/doc 2471 - Update LTI doc with new modal window display option

### DIFF
--- a/en_us/shared/course_features/content_experiments/content_experiments_configure.rst
+++ b/en_us/shared/course_features/content_experiments/content_experiments_configure.rst
@@ -39,7 +39,7 @@ To enable content experiments in your course, you add ``split_test`` to the
    .. code-block:: json
 
      [
-       "lti",
+       "lti_consumer",
        "word_cloud",
        "split_test"
      ]

--- a/en_us/shared/exercises_tools/lti_component.rst
+++ b/en_us/shared/exercises_tools/lti_component.rst
@@ -31,7 +31,7 @@ Overview
 
 You can use an LTI component in several ways.
 
-* You can add remote LTI content that displays to learners only, and that does
+* You can add remote LTI tools that display content only, and that do
   not require a learner response. An example is a digital copy of a textbook in
   a format other than PDF.
 
@@ -52,7 +52,7 @@ When you add an LTI component to your course, the edX Learning Management
 System (LMS) is the LTI tool consumer, and the external tool or content is the
 LTI tool provider.
 
-Be sure to review all supplemental materials to assure that they are accessible
+Be sure to review all supplemental materials to ensure that they are accessible
 before making them available through your course. For more information, see
 :ref:`Accessibility Best Practices for Course Content Development`.
 
@@ -73,129 +73,157 @@ system such as Canvas or Blackboard.
 
 .. _LTI Information:
 
-************************
-Obtain LTI Information
-************************
+******************************
+LTI Authentication Information
+******************************
 
-Before you create an LTI component to integrate content from a remote tool
-provider into a unit of your course, you need the following information.
+Some LTI tools require users to provide authentication credentials. If the LTI
+tool you are including in your course requires authentication, you must add an
+LTI passport for that tool to your course configuration.
 
--  If the LTI component requires a learner response that will be graded, the
-   **launch URL** is required. You obtain the launch URL from the LTI tool
-   provider. The launch URL is the URL that Studio sends to the remote LTI tool
-   provider so that the tool provider can send back learners' grades.
+An LTI passport is a string of text that contains the authentication key and
+shared secret for one LTI tool. A passport also contains the LTI ID for the
+tool. When you add an LTI component to your course, assign it a matching LTI ID
+so that it can use the LTI passport that it requires.
 
-- The **LTI Passports** policy key. This policy key has three parts: an LTI ID,
-  a client key, and a client secret.
-
-  -  The **LTI ID** is a value that you create to refer to the remote LTI
-     tool provider. You should create an LTI ID that you can remember easily.
-
-     The LTI ID can contain uppercase and lowercase alphanumeric characters, as
-     well as underscore characters (_). It can be any length. For example, you
-     can create an LTI ID that is as simple as ``test_lti_id``, or your LTI ID
-     can be a string of numbers and letters such as  ``id_21441`` or
-     ``book_lti_provider_from_new_york``.
-
-  -  The **client key** is a sequence of characters that you obtain from the
-     LTI tool provider. The client key is used for authentication and can
-     contain any number of characters. For example, your client key might be
-     ``b289378-f88d-2929-ctools.school.edu``.
-
-  -  The **client secret** is a sequence of characters that you obtain from the
-     LTI tool provider. The client secret is used for authentication and can
-     contain any number of characters. For example, your client secret can be
-     something as simple as ``secret``, or it might be a string of numbers and
-     letters such as ``23746387264`` or ``yt4984yr8``.
-
-  To create the **LTI Passports** policy key, combine the LTI ID, client key,
-  and client secret in the following format (be sure to include the colons).
-
-  ``{your_lti_id}:{client_key}:{client_secret}``
-
-  An **LTI Passports** policy key can resemble any of the following examples.
-
-  ``test_lti_id:b289378-f88d-2929-ctools.school.edu:secret``
-
-  ``id_21441:b289378-f88d-2929-ctools.school.edu:23746387264``
-
-  ``book_lti_provider_from_new_york:b289378-f88d-2929-ctools.company.com:yt4984yr8``
-
-************************
-Create an LTI Component
-************************
-
-To add an LTI component to your course, you complete all of these steps.
+For more information about creating and registering LTI passports, see the
+following sections.
 
 .. contents::
    :local:
    :depth: 1
 
-============================================
-Enable LTI Components
-============================================
+=========================================
+Creating an LTI Passport String
+=========================================
 
-Before you can add LTI components to your course, you must enable the
-LTI tool in Studio.
+Each LTI passport includes three component text strings that are separated by
+colon characters. The component strings are: the LTI ID, the client key, and
+the client secret.
 
-To enable the LTI tool in Studio, you add the ``"lti"`` key to the **Advanced
-Module List** on the **Advanced Settings** page. For more information, see
-:ref:`Enable Additional Exercises and Tools`.
+-  The **LTI ID** is a value that you create to refer to the remote LTI tool
+   provider. You should create an LTI ID that you can remember easily.
 
-==========================================
-Register the External LTI Provider
-==========================================
+   The LTI ID can contain uppercase and lowercase alphanumeric characters, as
+   well as underscore characters (_). It can be any length. For example, you
+   can create an LTI ID that is as simple as ``test_lti_id``, or your LTI ID
+   can be a string of numbers and letters such as  ``id_21441`` or
+   ``book_lti_provider_from_new_york``.
 
-To register the remote LTI tool provider, you add the **LTI Passports** policy
-key to the course's advanced settings.
+-  The **client key** is a sequence of characters that you obtain from the LTI
+   tool provider. The client key is used for authentication and can contain any
+   number of characters. For example, your client key might be
+   ``b289378-f88d-2929-ctools.school.edu``.
+
+-  The **client secret** is a sequence of characters that you obtain from the
+   LTI tool provider. The client secret is used for authentication and can
+   contain any number of characters. For example, your client secret can be
+   something as simple as ``secret``, or it might be a string of numbers and
+   letters such as ``23746387264`` or ``yt4984yr8``.
+
+To create an LTI passport, combine the LTI ID, client key,
+and client secret in the following format (be sure to include the colons).
+
+``{your_lti_id}:{client_key}:{client_secret}``
+
+The following example LTI passports show the format of the
+passport string.
+
+``test_lti_id:b289378-f88d-2929-ctools.school.edu:secret``
+
+``id_21441:b289378-f88d-2929-ctools.school.edu:23746387264``
+
+``book_lti_provider_from_new_york:b289378-f88d-2929-ctools.company.com:yt4984yr
+8``
+
+.. _adding_an_lti_passport:
+
+==================================================
+Adding an LTI Passport to the Course Configuration
+==================================================
+
+To add an LTI passport for an LTI tool to the configuration for your course, follow these steps.
 
 #. From the Studio **Settings** menu, select **Advanced Settings**.
 
 #. In the **LTI Passports** field, place your cursor between the
    brackets.
 
-#. Enter your **LTI Passports** policy key surrounded by quotation marks.
+#. Enter the LTI passport string surrounded by quotation marks.
 
-   For example, the text in the **LTI Passports** field can resemble the
-   following.
+   The following example shows an LTI passport string.
 
    ``"test_lti_id:b289378-f88d-2929-ctools.umich.edu:secret"``
 
    For more information about creating your key, see :ref:`LTI Information`.
 
-#. To integrate tools from more than one LTI provider into your
-   course, separate the policy key for each **LTI Passports** policy key with a
-   comma. Make sure to surround each entry with quotation marks.
+#. If you use more than one LTI provider in your course, separate each LTI
+   passport string with commas. Make sure to surround each entry with quotation
+   marks. The following example shows multiple LTI passports in the **LTI
+   Passports** field.
 
-   .. code-block:: xml
+   .. code-block:: json
 
       [
-          "test_lti_id:b289378-f88d-2929-ctools.umich.edu:secret",
-          "id_21441:b289378-f88d-2929-ctools.school.edu:23746387264",
-          "book_lti_provider_from_new_york:b289378-f88d-2929-ctools.company.com:yt4984yr8"
+        "test_lti_id:b289378-f88d-2929-ctools.umich.edu:secret",
+        "id_21441:b289378-f88d-2929-ctools.school.edu:23746387264",
+        "book_lti_provider_from_new_york:b289378-f88d-2929-ctools.company.com:yt4984yr8"
       ]
 
-#. At the bottom of the page, select **Save Changes**.
+#. Select **Save Changes**.
 
-The page refreshes automatically and reformats your entry in the **LTI
-Passports** field. At the top of the page, you see a notification that your
-changes have been saved.
+The page refreshes automatically, reformats your entry in the **LTI Passports**
+field, and displays a notification that your changes have been saved.
 
-==========================================
-Add the LTI Component to a Unit
-==========================================
+.. _enable_lti_components:
 
-#. In the unit where you want to add the remote learning tool, from the **Add
-   New Component** section select **Advanced**, and then select **LTI**.
+******************************************
+Enabling LTI Components for a Course
+******************************************
 
-#. In the component that appears, select **Edit**.
+Before you can add LTI components to your course, you must enable the LTI tool
+in Studio.
 
-#. In the component editor, specify the settings that you want. For more
-   information about each setting, see :ref:`LTI Component settings`.
+To enable the LTI tool in Studio, add the ``"lti_consumer"`` module to the
+**Advanced Module List** on the **Advanced Settings** page. For more
+information, see
+:ref:`Enable Additional Exercises and Tools`.
+
+.. note::
+  The ``lti_consumer`` module replaces a previous version of the LTI component.
+  The name of the module for the previous LTI component is ``lti`` and it may
+  appear in the **Advanced Module List** for older courses.
+
+  The ``lti_consumer`` module includes all of the functionality of the previous
+  LTI component and it should be used for all new courses. Courses that include
+  the previous LTI component will continue to work correctly, even if the
+  ``lti`` module is no longer present in the **Advanced Module List**.
+
+******************************************
+Adding an LTI Component to a Course Unit
+******************************************
+
+To add an LTI component to a course unit, follow these steps.
+
+#. If the LTI tool requires authentication, register the key and shared secret
+   for the LTI tool in the configuration for your course. For more information
+   about registering authentication credentials, see :ref:`LTI Information`.
+
+#. Edit the unit in which you want to add the remote LTI tool and select
+   **Advanced** from the **Add New Component** section. Select **LTI
+   Consumer**.
+
+   If the **Advanced** component type is not available, make sure you have
+   enabled LTI components. To do this, see :ref:`enable_lti_components`.
+
+#. Select **Edit** in the component that appears.
+
+#. Configure the LTI component in the component editor. For more information
+   about each setting, see :ref:`LTI Component settings`.
 
 #. Select **Save**.
 
-To test an LTI component, you use the Preview feature or view the live version
+To test an LTI component, use the **Preview** feature or view the live version
 in the LMS. For more information, see :ref:`Testing Your Course Content`.
 
 .. _LTI Component settings:
@@ -210,76 +238,122 @@ LTI Component Settings
 
    * - Setting
      - Description
-   * - Accept grades past deadline
-     - Specifies whether third party systems are allowed to post grades past
-       the deadline. By default, this value is set to True.
-   * - Button Text
-     - Enter a custom label for the button that launches the external LTI
-       application.
-   * - Custom Parameters
-     - Enables you to add one or more custom parameters. For example, if you
-       add an e-book, you can set a custom parameter that opens the e-book to
-       a specific page. You could also use a custom parameter to set the
-       background color of the LTI component.
-
-       Every custom parameter has a key and a value. You must add the key and
-       value in the following format.
-
-       {key}={value}
-
-       An example custom parameter follows.
-
-       ::
-
-          bgcolor=red
-          page=144
-
-       To add a custom parameter, select **Add**.
 
    * - Display Name
      - Specifies the name of the component. This name appears as a heading
        above the problem and as a tooltip in the learning sequence at the top
        of the **Courseware** page. Unique, descriptive display names help you
        identify problems quickly and accurately for analysis.
-   * - Hide External Tool
-     - Indicates whether you want to launch a remote tool or use this component
-       as a placeholder for synchronizing with a remote grading system.
-
-       If you set the value to True, Studio hides the **Launch** button and any
-       IFrames for this component. By default, this value is set to False.
 
    * - LTI Application Information
-     - The description of the external application. If the application requires
-       a username or email address, use this field to inform learners that
-       their information will be forwarded to the external application.
+     - The description of the remote LTI application. If the application
+       requires a username or email address, use this field to inform learners
+       that their information will be forwarded to the external application.
+
    * - LTI ID
      - Specifies the LTI ID for the remote LTI tool provider. This value must
-       be the same LTI ID that you entered as part of the **LTI Passports**
-       policy key on the **Advanced Settings** page.
+       match the LTI ID that you entered as part of the LTI passport string for
+       the LTI tool. For more information about LTI passports, see :ref:`LTI
+       Information`.
+
    * - LTI URL
-     - Specifies the URL of the remote tool that this component launches. This
-       setting is applicable when **Hide External Tool** is set to False.
-   * - Open in New Page
-     - Specifies whether the component opens in a new page. If you set this
-       value to True, when the learner selects this component the LTI content
-       opens in a new window. If you set this value to False, the LTI content
-       opens in an IFrame in the current page. This setting is applicable when
-       **Hide External Tool** is set to False.
-   * - Request user's email
-     - If **Open in New Page** is set to True, you can also request user
-       information. Set this value to True to request the learner's email
-       address.
-   * - Request user's username
-     - If **Open in New Page** is set to True, you can also request user
-       information. Set this value to True to request the learner's username.
+     - Specifies the URL of the remote LTI tool that this component launches.
+
+   * - Custom Parameters
+     - Sends additional parameters that are required by the remote LTI tool.
+       The parameters that you send depend on the specific LTI tool you are
+       using.
+
+       Supply a key and value for each custom parameter. The key is an
+       identifier for the parameter. Use the following format.
+
+       ``{key}={value}``
+
+       For example, an LTI tool that displays an e-book might accept a ``page``
+       parameter to control which page the e-book opens to by default. The
+       following example sends a ``page`` parameter to an LTI tool.
+
+       ::
+
+          ["page=144"]
+
+   * - LTI Launch Target
+     - Controls the way that the course page will open and display the remote
+       LTI tool.
+
+       Options are:
+
+       * **Inline** - the LTI tool will appear directly in the course page.
+
+       * **Modal** - the LTI tool will appear in a separate display window in
+         front of the course page. The modal display window prevents learners
+         from interacting with the course page until they dismiss the LTI tool.
+
+       * **New Window** - the LTI tool will appear in a new web browser window.
+         Depending on the configuration of the web browser, it may appear in a
+         new tab or in a separate browser window. Learners can interact with
+         both the course page and the LTI tool.
+
+   * - Button Text
+     - Enter a custom label for the button that opens the external LTI tool.
+
+   * - Inline Height
+     - Specifies the on-screen height of the LTI tool in pixels.
+
+       This setting is only applied if the **LTI Launch Target** is set to
+       **Inline**.
+
+   * - Modal Height
+     - Specifies the on-screen height of the LTI content window in pixels.
+
+       This setting is only applied if the **LTI Launch Target** control is set
+       to **Modal**.
+
+   * - Modal Width
+     - Specifies the on-screen width of the LTI content window in pixels.
+
+       This setting is only applied if the **LTI Launch Target** control is set
+       to **Modal**.
+
    * - Scored
      - Indicates whether the LTI component receives a numerical score from the
-       remote LTI tool provider. By default, this value is set to False.
+       remote LTI tool provider. By default, this value is set to **False**.
+
    * - Weight
-     - Specifies the number of points possible for a problem. By default, if
-       a remote LTI tool provider grades the problem, the problem is worth 1
-       point, and a learner's score can be any value between 0 and 1. This
-       setting is applicable when **Scored** is set to True.
+     - Specifies the number of points possible for a problem. By default, if a
+       remote LTI tool provider grades the problem, the problem is worth one
+       point, and a learner's score can be any value between zero and one.
+
+       This setting is only applied if **Scored** is set to **True**.
 
        For more information about problem weights and computing point scores,
        see :ref:`Problem Weight`.
+
+   * - Hide External Tool
+     - Controls whether the LTI component will display the remote LTI tool on
+       the course page.
+
+       Set the value to **True** to prevent the course page from displaying the
+       remote LTI tool. For example, you might use an LTI component to
+       synchronize with a remote grading system. In that situation, the LTI
+       component should not appear on the course page.
+
+       Set the value to **False** to display the remote LTI tool and allow
+       learners to interact with it.
+
+   * - Accept grades past deadline
+     - Specifies whether third party systems are allowed to post grades after
+       the deadline. By default, this value is set to **True**.
+
+   * - Request user's email
+     - Sends the learner's email address to the remote LTI tool.
+
+       An LTI component will only send learners' email addresses if the **LTI
+       Launch Target** control is set to **New Window**.
+
+   * - Request user's username
+     - Sends the learner's username to the remote LTI tool. This is the
+       username that the learner used to register for the course.
+
+       An LTI component will only send learners' usernames if the **LTI Launch
+       Target** control is set to **New Window**.


### PR DESCRIPTION
## [DOC-2471](https://openedx.atlassian.net/browse/DOC-2471)

Updated the documentation that explains how to configure LTI components based on development work described in https://openedx.atlassian.net/browse/PHX-200. LTI components can now be configured to open in a modal window. Several of the LTI component configuration options have changed.

I also revised the LTI component section while updating it. I consolidated the information about LTI authentication credentials, reordered the configuration parameter table, and gerund-ized headings. 
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @douglashall 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @srpearce @catong 
- [x] Product review: @explorerleslie 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version
- [x] http://draft-lti-2015-12-04.readthedocs.org/en/latest/exercises_tools/lti_component.html
### Post-review
- [x] Add description to release notes task as a comment
- [x] Squash commits
