### PR TITLE
Added theming docs to change log

### DIFF
--- a/en_us/install_operations/source/front_matter/change_log.rst
+++ b/en_us/install_operations/source/front_matter/change_log.rst
@@ -8,6 +8,8 @@ Change Log
 
    * - Date
      - Change
+   * - 8 December 2018
+     - Added the :ref`Changing the Way Open edX Looks` section.
    * - 1 December 2015
      - Added the :ref:`Configuring ORA2 to Prohibit Submission of File Types`
        section.


### PR DESCRIPTION
@lamagnifica: you asked me to add a reference to the Comprehensive Theming documentation to the change log in https://github.com/edx/edx-documentation/pull/565#issuecomment-159678074, and I misinterpreted what you were asking and added it to the release notes in #720. Is this what you intended?
