### PR TITLE
Adds two fields that I missed in the original PR

### DIFF
--- a/en_us/data/source/front_matter/change_log.rst
+++ b/en_us/data/source/front_matter/change_log.rst
@@ -14,6 +14,9 @@ October-December 2015
 
    * - Date
      - Change
+   * - 14 Dec 2015
+     - Corrected the events for :ref:`discussion forum<forum_events>` voting to
+       include the ``category_id`` and ``category_name`` event member fields.
    * - 1 Dec 2015
      - Added new events for :ref:`discussion forum<forum_events>` voting to the
        Events in the Tracking Logs section.

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -3047,6 +3047,8 @@ fields as :ref:`edx.forum.thread.voted` events. The following member fields
 serve the same purpose for votes on a response as they do for votes on a
 thread.
 
+* ``category_id``
+* ``category_name``
 * ``commentable_id``
 * ``id``
 * ``target_username``
@@ -3168,16 +3170,18 @@ complete, the server emits an ``edx.forum.thread.created`` event.
      - Identifier for the specific discussion component or top-level,
        course-wide discussion.
 
-       Also present for ``edx.forum.response.created`` and
-       ``edx.forum.comment.created`` events.
+       Also present for ``edx.forum.response.created``,
+       ``edx.forum.comment.created``, ``edx.forum.response.voted``, and
+       ``edx.forum.thread.voted``  events.
 
    * - ``category_name``
      - string
      - The display name for the specific discussion component or top-level,
        course-wide discussion.
 
-       Also present for ``edx.forum.response.created`` and
-       ``edx.forum.comment.created`` events.
+       Also present for ``edx.forum.response.created``,
+       ``edx.forum.comment.created``, ``edx.forum.response.voted``, and
+       ``edx.forum.thread.voted``  events.
 
    * - ``commentable_id``
      - string
@@ -3282,6 +3286,8 @@ member fields that are described for :ref:`forum_thread` events. The following
 member fields serve the same purpose for votes on a thread as they do for
 thread creation.
 
+* ``category_id``
+* ``category_name``
 * ``commentable_id``
 * ``id``
 * ``team_id``


### PR DESCRIPTION
## [DOC-2499](https://openedx.atlassian.net/browse/DOC-2499)

I missed the category_id and category_name fields for these new events. 
### Date Needed

Already released
### Reviewers
- [x] Subject matter expert: @stroilova 
- [x] Doc team review (sanity check): @pdesjardins 

FYI @explorerleslie 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Update change log
- [x] Squash commits
