### PR TITLE
Removed a note not being able to set course start date until web certificates are activated

### DIFF
--- a/en_us/shared/set_up_course/scheduling_course.rst
+++ b/en_us/shared/set_up_course/scheduling_course.rst
@@ -77,11 +77,6 @@ course content. By default, the course start date and time are set to
 before you intend it to. You must change this setting to the correct date and
 time for your course.
 
-.. note::
-  If your course is configured to issue certificates, you cannot start the
-  course until the required certificates are activated. For more information,
-  see :ref:`Activate a Certificate`.
-
 EdX recommends that you set the start time of your course early in the day,
 generally 00:00 UTC or earlier. Learners often expect the course to be
 available on the start date in their own time zones and try to access course


### PR DESCRIPTION
## [DOC-2479](https://openedx.atlassian.net/browse/DOC-2479)

Removed a note that described a restriction that has been removed. Previously, course teams could not set the start date for a course until web certificates were activated. Addresses https://openedx.atlassian.net/browse/DOC-2479.
### Reviewers
- [ ] Subject matter expert: @asadiqbal08 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica
- [ ] Product review: @griffresch 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
