### PR TITLE
DOC-2445 SFD for ORA Staff Grading

### DIFF
--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -20,23 +20,54 @@ might not have simple or definitive answers. For some open response
 assessments, you can submit an image or other file to accompany a written
 response.
 
-Open response assessments can include a peer assessment, a self assessment, or
-both.
+.. contents::
+  :local:
+  :depth: 1
 
-* In the peer assessment, you assess, or grade, responses that several of your
-  peers have submitted, and several of your peers assess your responses.
+==========================================
+The Steps in an Open Response Assessment
+==========================================
 
-* In the self assessment, you assess your own responses.
+In addition to :ref:`your own responses<Submit Your Response>` to the
+questions in the assignment, open response assessments have several steps that
+can include assessment training steps, peer assessments, self assessments, and
+staff assessments.
 
-To assess a response, you compare the response to a rubric that the course team
-provides. A rubric is a list of expectations that the responses in an open
-response assessment should meet. Rubrics are made of criteria and options.
+* In training steps, you perform assessments of sample responses provided by
+  the course team. The goal is to give the sample response the same grade that
+  a member of the course team would have given. For more information, see
+  :ref:`Learn to Assess Responses`.
+
+* In peer assessments, you perform assessments of responses that other
+  learners in the course have submitted, and other learners in the course also
+  assess your responses. The number of peer assessments that you have to
+  perform is decided for each assignment by your course team. For more
+  information, see :ref:`Assess Peer Responses`.
+
+* In self assessments, you assess your own responses. For more information,
+  see :ref:`Assess Your Response`.
+
+* In staff assessments, members of the course team assess your responses. For
+  more information, see :ref:`Staff Grade`.
+
+==========================================
+The Rubric, Criteria, and Options
+==========================================
+
+Every open response assessment has a rubric provided by the course team, to be
+used as guidance for grading. The rubric is a list of expectations that the
+responses should meet. Grading for all the types of assessments in an open
+response assessment is done by comparing each response against the same rubric.
+
+Rubrics consist of criteria and options.
 
 * Criteria describe characteristics that each response should have, such as
-  topics the response should cover.
+  concepts that a response should cover, or the amount of supporting
+  information that is included for a response.
 
-* The options for each of the criteria describe how well each response
-  satisfies the criteria.
+* Each criterion has options, which describe how well each response satisfies
+  the criterion. These are usually a range of ratings, for example, "Fair",
+  "Good", or "Excellent".
 
 The following image shows a rubric with two criteria. Each of the criteria has
 several options.
@@ -45,53 +76,57 @@ several options.
    :alt: Rubric showing criteria and options.
    :width: 500
 
-When you assess a response, you select the option that best describes the
-response for each of the criteria.
+When you assess a response, you select the option that best describes how well
+the response met each of the criteria.
 
 Some open response assessments provide a **Top Responses** section that shows
-the top-scoring responses for the assignment and the scores that these
-responses received. If provided, this section appears below your score after
-you complete each step of the assignment.
+the top scoring responses for the assignment and the scores that these
+responses received. If it is provided, this section appears below your score
+after you complete each step of the assignment.
 
-****************************
-Instructions for Learners
-****************************
+**************************************
+Completing an Open Response Assessment
+**************************************
 
 When you come to an open response assessment in the course, you see the
-questions and a response field for each question. After you submit your
-responses, you assess some of your peers' responses, your own responses, or
-both, depending on the assignment. You can see the steps that your assignment
-includes below each response field.
+questions you must answer, with a response field for each question in the
+assignment. After you enter and submit your responses, you assess some of your
+peers' responses, your own responses, or both, depending on the assignment.
+Below the final response field in the **Your Response** step, you can see the
+steps that your assignment includes.
 
 .. image:: ../../shared/students/Images/PA_S_AsmtWithResponse.png
    :alt: Open response assessment example with question, response field, and
        assessment types and status labeled.
    :width: 550
 
-This section describes how you complete an open response assessment that
-includes a learner training step, a peer assessment, and a self assessment.
+The following topics describe how you complete an open response assessment
+that includes a learner training step, a peer assessment step, a self
+assessment step, and a staff grade step.
 
 .. contents::
  :local:
  :depth: 1
 
-At any time during an assessment, you can see your progress at the bottom of
-the page under **Your Grade**. A message tells you the steps that you still
-have to perform before you can receive your grade. For example, you might see
-the following message.
+At any time during an assessment, you can see your progress at the bottom of the
+page under **Your Grade**. A message indicates the steps that must still be
+completed before you can receive your final grade for the assignment. For
+example, you might see the following message.
 
 .. code-block:: xml
 
   Not Completed
 
-  You have not completed the peer assessment step and self
-  assessment step of this problem.
+  You have not completed the peer assessment step and self assessment step of
+  this problem.
+
+.. _Submit Your Response:
 
 =====================
 Submit Your Response
 =====================
 
-Read each question carefully. Some course teams include important information
+#. Read each question carefully. Some course teams include important information
 in the question, such as how long a response must be, or specific topics your
 response must cover.
 
@@ -99,11 +134,13 @@ response must cover.
  be more than 10,000 words (approximately the equivalent of 20 pages of 8.5x11
  inch paper, with text single-spaced).
 
-For each question, type your response into the field under **Your Response**.
-When you have completed responses for all the questions, select **Submit your
-response and move to the next step**. If you need more time, you can select
-**Save Your Progress** to save a draft of your responses, and then come back
-and submit them later.
+#. For each question, enter your response into the field under **Your Response**.
+
+#. When you have completed responses for all the questions, select **Submit
+   your response and move to the next step**.
+
+   If you need more time, you can select **Save Your Progress** to save a
+   draft of your responses, and then come back and submit them later.
 
 After you submit your responses, if other learners have already submitted
 responses, the peer assessment step starts immediately. However, you do not
@@ -118,10 +155,10 @@ message.
 
   Waiting for Peer Responses
 
-  All submitted peer responses have been assessed.
-  Check back later to see if more learners have submitted responses. You'll
-  receive your grade after you complete the peer assessment and self assessment
-  steps, and after your peers have assessed your response.
+  All submitted peer responses have been assessed. Check back later to see if
+  more learners have submitted responses. You will receive your grade after you
+  complete the peer assessment and self assessment steps, and after your peers
+  have assessed your response.
 
 Note that you can view your own responses at any time after you submit them. To
 do this, for the response you want to view, select the **Your Response**
@@ -142,9 +179,10 @@ For some assignments, you might be asked to submit a file along with your text
 response. Those assignments include **Choose File** and **Upload your file**
 options below the response field. Note the following requirements.
 
-* A text response is required.
+* A text response is always required. You cannot submit a response that
+  contains only an uploaded file.
 
-* You can only upload one file to submit with your response.
+* You can upload only one file to submit with your response.
 
 * The file that you upload must be smaller than 5 MB in size.
 
@@ -161,12 +199,12 @@ To upload your file, follow these steps.
 The name of the file that you selected and uploaded appears below the response
 field.
 
+You can replace the file that you uploaded with a different one until you
+submit your response. To do so, follow steps 1-3 again.
+
 .. image:: ../../shared/students/Images/PA_Upload_WithImage.png
    :alt: Example response with an image of Paris.
    :width: 500
-
-You can replace the file that you uploaded with a different one until you
-submit your response. To do so, follow steps 1-3 again.
 
 .. _Learn to Assess Responses:
 
@@ -220,7 +258,7 @@ In the following example, the learner chose one correct option and one
 incorrect option.
 
 .. image:: ../../shared/students/Images/PA_TrainingAssessment_Scored.png
-   :alt: Sample training response, scored.
+   :alt: Sample training response, with one correct and one incorrect option.
    :width: 500
 
 You continue to assess the sample response until the options you select for all
@@ -228,6 +266,8 @@ criteria match the options defined by the course team.
 
 When you have successfully assessed all of the sample responses, you move to
 the next step in the assignment.
+
+.. _Assess Peer Responses:
 
 =====================
 Assess Peer Responses
@@ -242,12 +282,13 @@ already assessed.
    :alt: An in-progress peer assessment.
    :width: 500
 
-You assess other learners' responses by selecting options in the rubric, in the
-same way you assessed the sample responses in the :ref:`learn to assess
-responses<Learn to Assess Responses>` step. Additionally, this step has a field below the rubric where you can
-provide comments about the learner's responses.
+You assess other learners' responses by selecting options in the rubric, in
+the same way you assessed the sample responses in the :ref:`learn to assess
+responses<Learn to Assess Responses>` step. Additionally, this step has a
+field below the rubric where you can provide comments about the learner's
+responses.
 
-.. note:: Some assessments have an additional **Comments** field for one or
+.. note:: Some assessments might have a **Comments** field for one or
   more of the assessment's individual criteria. You can enter up to 300
   characters in these fields. In the following image, both criteria have a
   **Comments** field. There is also a field for overall comments on the
@@ -269,24 +310,28 @@ will repeat these steps until you have assessed the required number of
 responses. The number in the upper right corner of the step is updated as you
 assess each set of responses.
 
-Assess Additional Peer Responses
-********************************
+=================================================
+Assess Additional Peer Responses (optional)
+=================================================
 
-You can assess more peer responses if you want to. After you assess the
-required number of responses, the step "collapses" so that only the **Assess
-Peers** heading is visible.
+If you have assessed the required number of peer responses, the peer
+assessment step "collapses" so that only the **Assess Peers** heading is
+visible.
 
 .. image:: ../../shared/students/Images/PA_PAHeadingCollapsed.png
    :width: 500
    :alt: The peer assessment step with just the heading visible.
 
-To assess more responses, select the **Assess Peers** heading to expand the
-step, and then select **Continue Assessing Peers**.
+If you want to, you can assess more peer responses than required. To assess
+more responses, select the **Assess Peers** heading to expand the step, and
+then select **Continue Assessing Peers**.
 
 .. image:: ../../shared/students/Images/PA_ContinueGrading.png
    :width: 500
    :alt: The peer assessment step expanded so that "Continue Assessing Peers"
        is visible.
+
+.. _Assess Your Response:
 
 =====================
 Assess Your Response
@@ -296,6 +341,26 @@ When you have completed the required number of peer assessments, your self
 assessment opens. You see your responses along with the same rubric that you
 used in the peer assessment step. Assess your responses, then select **Submit
 Your Assessment**.
+
+.. _Staff Grade:
+
+=====================
+Staff Grade
+=====================
+
+In some assignments, a staff assessment step is included for a member of the
+course team to grade your responses. You do not need to take any action for
+this step. The status of the **Staff Grade** step changes to **Complete** when
+a member of the course team has completed grading your response.
+
+If a **Staff Grade** step exists in your assignment, you receive your final
+assignment grade when staff grading is complete, even if you have not received
+the required number of peer assessments.
+
+.. note:: A **Staff Grade** section also appears as a step in the assignment
+   if a member of the course team has performed override grading on your
+   response. A staff grade that is added in this way also overrides any peer
+   assessment scores, and becomes the final grade for your assignment.
 
 ==========================================
 Receive Your Score and Provide Feedback
@@ -316,29 +381,33 @@ Response** step.
 If you see this message, keep checking back periodically until the peer
 assessments of your work are complete.
 
-When peer assessment is complete, you can see the scores you received from all
-of the peers who scored your work, as well as your self assessment. You can
-also see any additional comments that your peers have provided.
+When peer assessment is complete, and if there is no staff assessment step in
+the assignment, you can see the scores you received from all of the peers who
+scored your work, as well as your self assessment. You can also see any
+additional comments that your peers have provided.
+
+If you want to, you can provide feedback on the peer scores that you received,
+under **Provide Feedback on Peer Assessments**.
 
 .. image:: ../../shared/students/Images/PA_AllScores.png
    :alt: A learner's response with peer and self assessment scores.
    :width: 550
 
-If you want to, you can provide feedback on the scores that you received under
-**Provide Feedback on Peer Assessments**.
+If the assignment included a staff assessment step, you receive your final
+grade when a member of the course team has graded your response. If there is a
+staff assessment step, peer assessments are not taken into account in the
+grading; the staff grade is always equivalent to your final grade.
 
-=================================================
-Assess Additional Peer Responses (optional)
-=================================================
-
-If you have assessed the required number of peer responses and completed your
-self assessment, you can assess additional peer responses. To do this, select
-the **Assess Peers** heading. If any responses remain to be assessed, a new
-response opens.
 
 ***********************
 Peer Assessment Scoring
 ***********************
+
+.. note:: If a staff grade is provided in the assignment, either because a
+   staff assessment step was included or because a member of the course team
+   provided a staff grade as an override grade, peer assessments are not taken
+   into account in the grading. If a staff grade exists, it is always
+   equivalent to your final grade.
 
 Peer assessments are scored by criteria. An individual criterion's score is the
 median, not the average, of the scores that each peer assessor gave that

--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -33,16 +33,16 @@ questions in the assignment, open response assessments have several steps that
 can include assessment training steps, peer assessments, self assessments, and
 staff assessments.
 
-* In training steps, you perform assessments of sample responses provided by
-  the course team. The goal is to give the sample response the same grade that
-  a member of the course team would have given. For more information, see
+* In training steps, you perform assessments of sample responses that the
+  course team provides. The goal is to give the sample response the same grade
+  that a member of the course team would have given. For more information, see
   :ref:`Learn to Assess Responses`.
 
 * In peer assessments, you perform assessments of responses that other
   learners in the course have submitted, and other learners in the course also
-  assess your responses. The number of peer assessments that you have to
-  perform is decided for each assignment by your course team. For more
-  information, see :ref:`Assess Peer Responses`.
+  assess your responses. For each assignment, your course team decides the
+  number of peer assessments that you have to perform. For more information,
+  see :ref:`Assess Peer Responses`.
 
 * In self assessments, you assess your own responses. For more information,
   see :ref:`Assess Your Response`.
@@ -50,23 +50,31 @@ staff assessments.
 * In staff assessments, members of the course team assess your responses. For
   more information, see :ref:`Staff Grade`.
 
+  .. note:: Course staff can grade your open response assignment even if a
+     staff assessment step is not included in the assignment. This might
+     happen if, for example, you receive peer assessments of your response
+     that are inappropriate. In such cases, course staff can perform an
+     assessment of your response that overrides any peer assessment grades.
+
+
 ==========================================
 The Rubric, Criteria, and Options
 ==========================================
 
-Every open response assessment has a rubric provided by the course team, to be
-used as guidance for grading. The rubric is a list of expectations that the
+Every open response assessment has a rubric that the course team provides, to
+be used as guidance for grading. The rubric is a list of expectations that the
 responses should meet. Grading for all the types of assessments in an open
-response assessment is done by comparing each response against the same rubric.
+response assessment is done by comparing each response against the same
+rubric.
 
 Rubrics consist of criteria and options.
 
 * Criteria describe characteristics that each response should have, such as
   concepts that a response should cover, or the amount of supporting
-  information that is included for a response.
+  information that a response must include.
 
 * Each criterion has options, which describe how well each response satisfies
-  the criterion. These are usually a range of ratings, for example, "Fair",
+  the criterion. These are usually a range of ratings, for example "Fair",
   "Good", or "Excellent".
 
 The following image shows a rubric with two criteria. Each of the criteria has
@@ -125,6 +133,8 @@ example, you might see the following message.
 =====================
 Submit Your Response
 =====================
+
+To submit your response, follow these steps.
 
 #. Read each question carefully. Some course teams include important information
    in the question, such as how long a response must be, or specific topics that
@@ -272,10 +282,10 @@ already assessed.
    :alt: An in-progress peer assessment.
    :width: 500
 
-You assess other learners' responses by selecting options in the rubric, in
-the same way you assessed the sample responses in the :ref:`learn to assess
-responses<Learn to Assess Responses>` step. Additionally, this step has a
-field below the rubric where you can provide comments about the learner's
+You assess other learners' responses by selecting options in the rubric. This
+process will be familiar to you if your assignment included the :ref:`learn to
+assess responses<Learn to Assess Responses>` step. Additionally, this step has
+a field below the rubric where you can provide comments about the learner's
 responses.
 
 .. note:: Some assessments might have a **Comments** field for one or
@@ -300,9 +310,9 @@ will repeat these steps until you have assessed the required number of
 responses. The number in the upper right corner of the step is updated as you
 assess each set of responses.
 
-If there are no new submitted responses available for grading, you see a
-status message indicating that you are waiting for peer responses to assess,
-and that you should check back later.
+If there are no new submitted responses available for grading, a status
+message indicates that no peer responses are currently available for you to
+assess, and that you should check back later.
 
 
 =================================================
@@ -317,9 +327,9 @@ visible.
    :width: 500
    :alt: The peer assessment step with just the heading visible.
 
-If you want to, you can assess more peer responses than required. To assess
-more responses, select the **Assess Peers** heading to expand the step, and
-then select **Continue Assessing Peers**.
+If you want to, you can assess more peer responses than the assignment
+requires. To assess more responses, select the **Assess Peers** heading to
+expand the step, and then select **Continue Assessing Peers**.
 
 .. image:: ../../shared/students/Images/PA_ContinueGrading.png
    :width: 500
@@ -349,13 +359,16 @@ this step. The status of the **Staff Grade** step changes to **Complete** when
 a member of the course team has completed grading your response.
 
 If a **Staff Grade** step exists in your assignment, you receive your final
-assignment grade when staff grading is complete, even if you have not received
-the required number of peer assessments.
+assignment grade when staff grading is complete, even if your response has not been assessed by the required number of peer reviewers.
 
-.. note:: A **Staff Grade** section also appears as a step in the assignment
-   if a member of the course team has performed override grading on your
-   response. A staff grade that is added in this way also overrides any peer
-   assessment scores, and becomes the final grade for your assignment.
+.. note:: Course staff can grade your open response assignment even if a staff
+   assessment step is not included in the assignment. This might happen if
+   for example you receive peer assessments of your response that are
+   inappropriate. In such cases, course staff can perform an assessment of
+   your response that overrides any peer assessment grades. If a member of the
+   course staff has graded your response, a **Staff Grade** section appears in
+   the grading details for your assignment.
+
 
 ==========================================
 Receive Your Score and Provide Feedback
@@ -370,16 +383,16 @@ Response** step.
   Your Grade: Waiting for Peer Assessment
 
   Your response is still undergoing peer assessment. After your peers have
-  assessed your response, you'll see their feedback and receive your final
+  assessed your response, you will see their feedback and receive your final
   grade.
 
 If you see this message, keep checking back periodically until the peer
 assessments of your work are complete.
 
-When peer assessment is complete, and if there is no staff assessment step in
-the assignment, you can see the scores you received from all of the peers who
-scored your work, as well as your self assessment. You can also see any
-additional comments that your peers have provided.
+When peer assessment is complete, and if the assignment does not include a
+staff assessment step, you can see the scores you received from all of the
+peers who scored your work, as well as your self assessment. You can also see
+any additional comments that your peers have provided.
 
 If you want to, you can provide feedback on the peer scores that you received,
 under **Provide Feedback on Peer Assessments**.
@@ -389,9 +402,10 @@ under **Provide Feedback on Peer Assessments**.
    :width: 550
 
 If the assignment included a staff assessment step, you receive your final
-grade when a member of the course team has graded your response. If there is a
-staff assessment step, peer assessments are not taken into account in the
-grading; the staff grade is always equivalent to your final grade.
+grade when a member of the course team has graded your response. If a staff
+assessment step is included in the assignment, peer assessment grades and
+comments are included in the assignment grade details, but the staff grade
+becomes the final grade.
 
 
 ***********************
@@ -400,9 +414,9 @@ Peer Assessment Scoring
 
 .. note:: If a staff grade is provided in the assignment, either because a
    staff assessment step was included or because a member of the course team
-   provided a staff grade as an override grade, peer assessments are not taken
-   into account in the grading. If a staff grade exists, it is always
-   equivalent to your final grade.
+   graded your response to override inappropriate peer assessments, peer
+   assessments are not taken into account in the grading. If a staff grade
+   exists, it is always your final grade.
 
 Peer assessments are scored by criteria. An individual criterion's score is the
 median, not the average, of the scores that each peer assessor gave that

--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -127,12 +127,12 @@ Submit Your Response
 =====================
 
 #. Read each question carefully. Some course teams include important information
-in the question, such as how long a response must be, or specific topics that
-your response must cover.
+   in the question, such as how long a response must be, or specific topics that
+   your response must cover.
 
-.. note:: The total word count for all responses within the assessment cannot
- be more than 10,000 words (approximately the equivalent of 20 pages of 8.5x11
- inch paper, with text single-spaced).
+   .. note:: The total word count for all responses within the assessment cannot
+      be more than 10,000 words (approximately the equivalent of 20 pages of
+      8.5x11 inch paper, with text single-spaced).
 
 #. For each question, enter your response into the field under **Your Response**.
 

--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -166,8 +166,11 @@ For some assignments, you might be asked to submit a file along with your text
 response. Those assignments include **Choose File** and **Upload your file**
 options below the response field. Note the following requirements.
 
-* A text response is always required. You cannot submit a response that
-  contains only an uploaded file.
+* A text response is always required. If you upload a file in your response,
+  also include a text response that describes the file you have uploaded in such
+  a way that a reviewer who cannot access the uploaded file can still assess the
+  text content of your response using a screen reader or other text parsing
+  tool.
 
 * You can upload only one file to submit with your response.
 
@@ -290,15 +293,16 @@ After you have selected options in the rubric and provided additional comments
 about the responses, select **Submit your assessment and move to response
 #<number>**.
 
-When you submit your assessment of the first learner's responses, the next set of responses opens for you. Assess these responses in the same way that you
+When you submit your assessment of the first learner's responses, the next set
+of responses opens for you. Assess these responses in the same way that you
 assessed the first learner's responses, and then submit your assessment. You
 will repeat these steps until you have assessed the required number of
 responses. The number in the upper right corner of the step is updated as you
 assess each set of responses.
 
-If there are no new submitted responses available for grading, you see a status
-message indicating that you are waiting for peer responses and that you should
-check back later.
+If there are no new submitted responses available for grading, you see a
+status message indicating that you are waiting for peer responses to assess,
+and that you should check back later.
 
 
 =================================================

--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -127,8 +127,8 @@ Submit Your Response
 =====================
 
 #. Read each question carefully. Some course teams include important information
-in the question, such as how long a response must be, or specific topics your
-response must cover.
+in the question, such as how long a response must be, or specific topics that
+your response must cover.
 
 .. note:: The total word count for all responses within the assessment cannot
  be more than 10,000 words (approximately the equivalent of 20 pages of 8.5x11
@@ -142,29 +142,16 @@ response must cover.
    If you need more time, you can select **Save Your Progress** to save a
    draft of your responses, and then come back and submit them later.
 
-After you submit your responses, if other learners have already submitted
-responses, the peer assessment step starts immediately. However, you do not
-have to start grading right away. If you want to stop working and come back
-later, just refresh or reopen your browser when you come back. New peer
-responses will be available for you to grade.
+After you submit your responses, the next step, usually either an assessment
+training step or a peer assessment step, starts immediately. However, you do not
+have to start the next step right away. If you want to stop working and come
+back later, just refresh or reopen your browser when you come back.
 
-If no other learners have submitted responses yet, you see the following
-message.
-
-.. code-block:: xml
-
-  Waiting for Peer Responses
-
-  All submitted peer responses have been assessed. Check back later to see if
-  more learners have submitted responses. You will receive your grade after you
-  complete the peer assessment and self assessment steps, and after your peers
-  have assessed your response.
-
-Note that you can view your own responses at any time after you submit them. To
-do this, for the response you want to view, select the **Your Response**
-heading to expand the response field. Your response appears, along with the
-status of your response, and information about additional steps you have to
-complete before you receive your grade.
+.. note:: You can view your own responses at any time after you submit them. To
+   do this, for the response you want to view, select the **Your Response**
+   heading to expand the response field. Your response appears, along with the
+   status of your response, and information about additional steps you have to
+   complete before you receive your grade.
 
 .. image:: ../../shared/students/Images/PA_S_ReviewResponse.png
    :alt: Image of the Response field collapsed and then expanded.
@@ -303,12 +290,16 @@ After you have selected options in the rubric and provided additional comments
 about the responses, select **Submit your assessment and move to response
 #<number>**.
 
-When you submit your assessment of the first learner's responses, another set
-of responses opens for you. Assess these responses in the same way that you
+When you submit your assessment of the first learner's responses, the next set of responses opens for you. Assess these responses in the same way that you
 assessed the first learner's responses, and then submit your assessment. You
 will repeat these steps until you have assessed the required number of
 responses. The number in the upper right corner of the step is updated as you
 assess each set of responses.
+
+If there are no new submitted responses available for grading, you see a status
+message indicating that you are waiting for peer responses and that you should
+check back later.
+
 
 =================================================
 Assess Additional Peer Responses (optional)


### PR DESCRIPTION
This PR updates Learner's Guide documentation for ORA assignments to include staff grading (staff assessment steps and staff override grading). Did some minor work to try to make the section a bit easier for learners to read, including adding subheads in one section.
Tracked in DOC-2445
Analytics doc and CA are in separate PRs (https://github.com/edx/edx-documentation/pull/763 and https://github.com/edx/edx-documentation/pull/755)

Draft documentation for easier reading is here: 
http://draft-sfd-ora-staff-grading.readthedocs.org/en/latest/SFD_ORA.html
### Reviewers
- [x] Subject matter expert: @dianakhuang
- [x] Product owner: @explorerleslie 
- [x] Doc team review: @srpearce
### Testing
- [x] Run ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
