### PR TITLE
DOC-2446 Events doc for ORA Staff Grading

### DIFF
--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -243,11 +243,15 @@ M, N, O
      - :ref:`ora2`
    * - ``openassessmentblock.get_peer_submission``
      - :ref:`ora2`
+   * - ``openassessmentblock.get_submission_for_staff_grading``
+     - :ref:`ora2`
    * - ``openassessmentblock.peer_assess``
      - :ref:`ora2`
    * - ``openassessmentblock.save_submission``
      - :ref:`ora2`
    * - ``openassessmentblock.self_assess``
+     - :ref:`ora2`
+   * - ``openassessmentblock.staff_assess``
      - :ref:`ora2`
    * - ``openassessmentblock.submit_feedback_on_assessments``
      - :ref:`ora2`


### PR DESCRIPTION
This PR updates Research Guide documentation for ORA events. Adds 2 new events; also updates terminology within the ORA section so that "students" -> "learners".
Tracked in DOC-2446

Draft documentation for easier reading is here: 
http://draft-events-ora-staff-grading.readthedocs.org/en/latest/internal_data_formats/tracking_logs.html#ora2
### Reviewers
- [x] Subject matter expert: @stroilova 
- [x] Subject matter expert: @dianakhuang
- [x] Product owner: @explorerleslie 
- [x] Doc team review: @lamagnifica 
### Testing
- [ ] Run ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
