### PR TITLE
Further simplification of exclude_patterns for the release notes conf.py file

### DIFF
--- a/en_us/release_notes/source/conf.py
+++ b/en_us/release_notes/source/conf.py
@@ -15,10 +15,5 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 project = u'EdX Release Notes'
 
 #remove directory when content is first added to it, and add to index
-exclude_patterns = ['links.rst', 'reusables/*', '20??/analytics/*20??.rst',
-                    '20??/discussions/*20??.rst', '20??/documentation/*20??.rst',
-                    '20??/insights/*20??.rst', '20??/lms/*20??.rst',
-                    '20??/mobile/*20??.rst', '20??/openedx/*20??.rst',
-                    '20??/ora/*20??.rst', '20??/studio/*20??.rst',
-                    '20??/website/*20??.rst', '20??/xblocks/*20??.rst']
+exclude_patterns = ['links.rst', 'reusables/*', '20??/*/*20??.rst']
 


### PR DESCRIPTION
This matches any subdirectory under a year.
