### PR TITLE
GitHub has a capital H

### DIFF
--- a/en_us/developers/source/process/community-manager.rst
+++ b/en_us/developers/source/process/community-manager.rst
@@ -4,7 +4,7 @@ Community Manager
 
 Community managers handle the first part of the process of responding to pull
 requests, before they are reviewed by core committers. Community managers are
-responsible for monitoring the Github project so that they are aware of incoming
+responsible for monitoring the GitHub project so that they are aware of incoming
 pull requests. For each pull request, a community manager should:
 
 #. Read the description of the pull request to understand the idea behind it

--- a/en_us/developers/source/process/contributor.rst
+++ b/en_us/developers/source/process/contributor.rst
@@ -39,11 +39,11 @@ Once you’re ready to submit your changes in a pull request, check the followin
 list of requirements to be sure that your pull request is ready to be reviewed:
 
 #. Prepare a :doc:`pull request cover letter <cover-letter>`. When you open
-   up your pull request, put your cover letter into the "Description" field on Github.
+   up your pull request, put your cover letter into the "Description" field on GitHub.
 
 #. The code should be clear and understandable.
    Comments in code, detailed docstrings, and good variable naming conventions
-   are expected. The `edx-platform Github wiki`_ contains many great links to
+   are expected. The `edx-platform GitHub wiki`_ contains many great links to
    style guides for Python, Javascript, and internationalization (i18n) conventions.
 
 #. The pull request should be as small as possible.
@@ -76,7 +76,7 @@ list of requirements to be sure that your pull request is ready to be reviewed:
    the new feature.
 
 #. For pull requests that make changes to the user interface,
-   please include screenshots of what you changed. Github will allow
+   please include screenshots of what you changed. GitHub will allow
    you to upload images directly from your computer.
    In the future, the core committers will produce a style guide that
    contains more requirements around how pages should appear and how
@@ -129,11 +129,11 @@ If you open up your pull request with a solid description, following the
 :doc:`pull request cover letter <cover-letter>` guidelines, the product owners will be able
 to quickly understand your change and prioritize it for review. However, they may have
 some questions about your intention, need, and/or approach that they will ask about
-on the JIRA ticket. A community manager will ping you on Github to clarify these questions if
+on the JIRA ticket. A community manager will ping you on GitHub to clarify these questions if
 they arise; you are not required to monitor the JIRA discussion.
 
 Once the product team has sent your pull request to the engineering teams for review, all
-technical discussion regarding your change will occur on Github, inline with your code.
+technical discussion regarding your change will occur on GitHub, inline with your code.
 
 Further Information
 -------------------
@@ -147,6 +147,6 @@ links:
 * `Python Guidelines <https://github.com/edx/edx-platform/wiki/Python-Guidelines>`_
 * `Javascript Guidelines <https://github.com/edx/edx-platform/wiki/Javascript-Guidelines>`_
 
-.. _edx-platform Github wiki: https://github.com/edx/edx-platform/wiki#development
+.. _edx-platform GitHub wiki: https://github.com/edx/edx-platform/wiki#development
 .. _contributor's agreement with edX: http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf
 .. _compatible licenses: https://github.com/edx/edx-platform/wiki/Licensing

--- a/en_us/developers/source/process/cover-letter.rst
+++ b/en_us/developers/source/process/cover-letter.rst
@@ -7,7 +7,7 @@ guidelines for :ref:`Contributing to the Documentation for your Open Source
 Feature`.
 
 When opening up a pull request, please prepare a "cover letter" to place into
-the "Description" field on Github. A good cover letter concisely answers as
+the "Description" field on GitHub. A good cover letter concisely answers as
 many of the following questions as possible. Not all pull requests will have
 answers to every one of these questions, which is okay!
 

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -118,7 +118,7 @@ before you even start changing code, the better the whole process
 will go.
 
 Follow the guidelines in this document for a high-quality pull request: include a detailed
-description of your pull request when you open it on Github (we recommend using a
+description of your pull request when you open it on GitHub (we recommend using a
 :doc:`pull request cover letter <cover-letter>` to guide your description),
 keep the code clear and readable, make sure the tests pass, be responsive to code review comments.
 Small pull requests are easier to review than large pull requests, so

--- a/en_us/developers/source/testing/index.rst
+++ b/en_us/developers/source/testing/index.rst
@@ -7,7 +7,7 @@ Testing is something that we take very seriously at edX: we even have a
 infrastructure even more awesome.
 
 This file is currently a stub: to find out more about our testing infrastructure,
-check out the `testing.md`_ file on Github.
+check out the `testing.md`_ file on GitHub.
 
 .. toctree::
     :maxdepth: 2

--- a/en_us/developers/source/testing/jenkins.rst
+++ b/en_us/developers/source/testing/jenkins.rst
@@ -13,7 +13,7 @@ Kicking Off Builds
 ==================
 
 Jenkins has the ability to automatically detect new pull requests and changed
-pull requests on Github, and it can automatically run builds in response to
+pull requests on GitHub, and it can automatically run builds in response to
 these events. We have Jenkins configured to automatically run builds for all
 pull requests from core committers; however, Jenkins will *not* automatically
 run builds for new contributors, so a community manager will need to manually

--- a/en_us/edx_style_guide/source/DocTranslationGuidelines.rst
+++ b/en_us/edx_style_guide/source/DocTranslationGuidelines.rst
@@ -19,8 +19,8 @@ The complete edX documentation translation process is described in
    Documentation Source Files`.
 
    In addition, you or another person on the translation team should
-   understand Github repositories and the Github pull request process. For
-   more information about using Github, see https://help.git.com.
+   understand GitHub repositories and the GitHub pull request process. For
+   more information about using GitHub, see https://help.github.com.
 
 When you translate edX documentation source .rst files, follow these general
 guidelines. For examples of each type of element, see :ref:`the Example .rst
@@ -43,15 +43,15 @@ In addition to obvious text, do translate the following items.
 
   For example, in
 
-  ``:ref:`Work with edX Documentation Source Files``` or  
-  ```Work with edX Documentation Source Files`_`` 
+  ``:ref:`Work with edX Documentation Source Files``` or
+  ```Work with edX Documentation Source Files`_``
 
   the text between the grave accent
   characters (`) is actual anchor text and should not be translated.
 
   However, in the example
 
-  ``:ref:`this is link text<Work with edX Documentation Source Files>``` 
+  ``:ref:`this is link text<Work with edX Documentation Source Files>```
 
   the actual anchor text is between the carets and should not be
   translated. The text string between the first grave accent character and the
@@ -64,7 +64,7 @@ In addition to obvious text, do translate the following items.
 
    .. image:: ../../../data/source/Images/DataCzar_Initialization.png
       :width: 100
-      :alt: Flowchart showing process for initializing a data czar 
+      :alt: Flowchart showing process for initializing a data czar
 
 
 
@@ -83,23 +83,23 @@ Do not translate or alter any of the following elements.
   the same Images folder location, so that image links within the
   documentation are not broken.
 
-* Words in file paths in cross-references or image references. 
+* Words in file paths in cross-references or image references.
 
 * Words that are part of .rst directives, including "note" or "warning".
   Examples are listed in :ref:`Work with edX Documentation Source Files` and
   :ref:`ExampleRSTFile<Anchor For ExampleRSTFile>`.
 
-* The text of anchors in .rst files. 
+* The text of anchors in .rst files.
 
-* Code examples that are tagged with ``.. code-block::``.  
+* Code examples that are tagged with ``.. code-block::``.
 
 * Variables, database field names, or code examples that are tagged with
-  monospace code font (placed between double grave accent characters). 
+  monospace code font (placed between double grave accent characters).
 
-  For example, in the following sentence, do not translate the event names that are between pairs of double grave accent characters.  
+  For example, in the following sentence, do not translate the event names that are between pairs of double grave accent characters.
 
   The edX mobile app for iOS now emits ````play_video````, ````pause_video````,
-  ````stop_video````, ````load_video````, and ````seek_video```` events. 
+  ````stop_video````, ````load_video````, and ````seek_video```` events.
 
 
 For information about working with edX Documentation source files, see

--- a/en_us/edx_style_guide/source/DocTranslationProcess.rst
+++ b/en_us/edx_style_guide/source/DocTranslationProcess.rst
@@ -14,12 +14,12 @@ understanding of reStructuredText and formatting in .rst files. For more
 information, see :ref:`Work with edX Documentation Source Files`.
 
 In addition, you or another person on the translation team should understand
-Github repositories and the Github pull request process. For more information
-about using Github, see https://help.github.com.
+GitHub repositories and the GitHub pull request process. For more information
+about using GitHub, see https://help.github.com.
 
 The basic process for translating edX documentation consists of these steps.
 
-#. Use Github to clone the ``edx-documentation`` repository to a location on
+#. Use GitHub to clone the ``edx-documentation`` repository to a location on
    your local file system.
 
 #. Locate the target language folder that we have set up for you. This is your
@@ -32,7 +32,7 @@ The basic process for translating edX documentation consists of these steps.
       references.
 
 #. Create a working branch or branches off master to make translation changes.
-   Follow best practices for Github use. For information, see
+   Follow best practices for GitHub use. For information, see
    https://help.github.com.
 
    * Before making new branches, check that your local version of edx-
@@ -43,13 +43,13 @@ The basic process for translating edX documentation consists of these steps.
 
 	* Save changes in the source files without renaming or moving the files.
 
-	* Commit changes back to Github. 
+	* Commit changes back to GitHub.
 
-	* Create pull requests in Github for review purposes.
+	* Create pull requests in GitHub for review purposes.
 
 4. Build draft output and verify that everything renders as it should in both
    HTML and PDF formats. For information, see the "Verify Output" topic on this
-   wiki page: 
+   wiki page:
 
    https://openedx.atlassian.net/wiki/display/DOC/Instructions+for+Updating+Documentation
 

--- a/en_us/edx_style_guide/source/WorkingWithEdXDocSource.rst
+++ b/en_us/edx_style_guide/source/WorkingWithEdXDocSource.rst
@@ -6,7 +6,7 @@ Working with edX Documentation Source Files
 
 This section provides information about the tools used to create edX
 documentation, and gives guidelines for translating or updating documentation
-in the edx-documentation Github repository.
+in the edx-documentation GitHub repository.
 
 For information, see the following topics.
 
@@ -34,7 +34,7 @@ to basic information that we provide about working with our source files, you
 can find resources online, including the `restructuredText Primer <http
 ://sphinx-doc.org/rest.html>`_ and http://docutils.sourceforge.net/rst.html#user-documentation.
 
-Our documentation source files reside in a github repository: edx-documentation. 
+Our documentation source files reside in a GitHub repository: edx-documentation.
 The folder structure within the repository is critical to our process and
 should not be modified. Each .rst file results in one page of HTML output.
 
@@ -75,7 +75,7 @@ important. Text that is on the same line as an .rst tag and text that is
 indented to the same level on following lines are interpreted as being part of
 the same block.
 
- 
+
 .. _Headings:
 
 ========
@@ -85,7 +85,7 @@ Headings
 The level of a heading is indicated by a series of characters above and below
 the heading text.
 
-* H1: pound symbols (#) 
+* H1: pound symbols (#)
 * H2: asterisk (*)
 * H3: equals symbol (=)
 
@@ -121,8 +121,8 @@ Create automatic numbered lists using the hash symbol
 followed by a period, for each item in the numbered list. For example,
 
 #. Select **Advanced Settings**.
-#. Find the **Course Advertised Start Date** policy key.   
-#. Enter the value you want to display. 
+#. Find the **Course Advertised Start Date** policy key.
+#. Enter the value you want to display.
 
 In some cases, for example if an automatic numbered list is interrupted by
 multiple paragraphs or a nested list, you need to enter a number in place of
@@ -162,7 +162,7 @@ Special Tags
 ============
 
 Special tagging for notes, warnings, tables, and code blocks is achieved using
-lines beginning with 2 periods, followed by additional syntax. 
+lines beginning with 2 periods, followed by additional syntax.
 
 ``.. note::``
 
@@ -194,7 +194,7 @@ that is useful to someone who might not be able to see the image. ::
 
 .. important:: When you translate existing content, make sure you do not
    change the filepath portion of the image reference. You should only
-   translate the alternative text. 
+   translate the alternative text.
 
    If you replace any original source images with localized images, make sure
    the replacement image files have exactly the same filenames, and replace
@@ -217,18 +217,18 @@ and the hyphens indicating each column must also align. Empty cells must be
 accounted for, so that each column in a row is always marked, even if there is
 no content in the table cell. An example of an empty cell is the second column
 in the first row of the following example. ::
- 
+
   .. list-table::
      :widths: 25 25 50
 
    * - .. image:: ../../../shared/building_and_running_chapters/Images/AnnotationExample.png
           :width: 100
           :alt: Example annotation problem
-     - 
+     -
      - Annotation problems ask students to respond to questions about a
        specific block of text. The question appears above the text when the
        student hovers the mouse over the highlighted text so that students can
-       think about the question as they read.   
+       think about the question as they read.
    * - .. image:: ../../../shared/building_and_running_chapters/Images/PollExample.png
           :width: 100
           :alt: Example poll
@@ -300,7 +300,7 @@ Cross references using specified link text
 
 For cross references that use specific link text rather than substituting the
 actual target heading text, enter your own text followed by the anchor text in
-angle brackets. For example, 
+angle brackets. For example,
 ::
 
   For more information, see :ref:`the introductory section on
@@ -345,17 +345,17 @@ the code-block tag. Here is a code block. For examples, see
                     <text>PLACEHOLDER: Text of annotation</text>
                       <comment>PLACEHOLDER: Text of question</comment>
                       <comment_prompt>PLACEHOLDER: Type your response below:</comment_prompt>
-                      <tag_prompt>PLACEHOLDER: In your response to this question, which tag below 
+                      <tag_prompt>PLACEHOLDER: In your response to this question, which tag below
                       do you choose?</tag_prompt>
                     <options>
-                      <option choice="incorrect">PLACEHOLDER: Incorrect answer (to make this 
-                      option a correct or partially correct answer, change choice="incorrect" 
+                      <option choice="incorrect">PLACEHOLDER: Incorrect answer (to make this
+                      option a correct or partially correct answer, change choice="incorrect"
                       to choice="correct" or choice="partially-correct")</option>
-                      <option choice="correct">PLACEHOLDER: Correct answer (to make this option 
-                      an incorrect or partially correct answer, change choice="correct" to 
+                      <option choice="correct">PLACEHOLDER: Correct answer (to make this option
+                      an incorrect or partially correct answer, change choice="correct" to
                       choice="incorrect" or choice="partially-correct")</option>
-                      <option choice="partially-correct">PLACEHOLDER: Partially correct answer 
-                      (to make this option a correct or partially correct answer, 
+                      <option choice="partially-correct">PLACEHOLDER: Partially correct answer
+                      (to make this option a correct or partially correct answer,
                       change choice="partially-correct" to choice="correct" or choice="incorrect")
                       </option>
                     </options>

--- a/en_us/edx_style_guide/source/wordlist.rst
+++ b/en_us/edx_style_guide/source/wordlist.rst
@@ -87,4 +87,6 @@ Word List
        result as the staff view or student view.
    * - XBlock
      - Use instead of "Xblock" or "xBlock".
+   * - GitHub
+     - The "H" is always capitalized.
 

--- a/en_us/install_operations/source/configuration/install_xblock.rst
+++ b/en_us/install_operations/source/configuration/install_xblock.rst
@@ -14,13 +14,13 @@ Open edX platform, both of the following tasks must be completed.
 
 * Course teams enable the XBlock in the specific courses that will use it.
 
-.. Future: link to an XBlock reference that would let people explore what's available and get both the Github commit string and the key. - Alison 22 Oct 2015
+.. Future: link to an XBlock reference that would let people explore what's available and get both the GitHub commit string and the key. - Alison 22 Oct 2015
 
 To install an XBlock, follow these steps.
 
-#. Obtain the Github location and commit for the XBlock.
+#. Obtain the GitHub location and commit for the XBlock.
 
-#. Run ``pip`` with a Github link to the XBlock.
+#. Run ``pip`` with a GitHub link to the XBlock.
 
    An example that installs the Oppia XBlock follows.
 

--- a/en_us/xblock-tutorial/source/edx_platform/edx.rst
+++ b/en_us/xblock-tutorial/source/edx_platform/edx.rst
@@ -12,25 +12,25 @@ Note that you are not required to submit your XBlock to edX. You and other edX s
 
 To submit your XBlock to edx.org, complete the following steps.
 
-#. Upload the XBlock to a repository on Github.
-   
-#. Create a new branch in `edx-platform`_ Github repository.
+#. Upload the XBlock to a repository on GitHub.
+
+#. Create a new branch in the `edx-platform`_ GitHub repository.
 
 #. In your branch, add a line to the `requirements/edx/github.txt`_ file that
    indicates the version of your XBlock to use.
-   
+
    .. note::
      The requirements file addition is the only change you should make in your
      branch. Do not include the code for your XBlock in the pull request.
-   
-#. Create a pull request for your branch in the edx-platform Github repository.
+
+#. Create a pull request for your branch in the edx-platform GitHub repository.
 
 #. Add a thorough description of your XBlock and its intended use to the pull
    request. You must include instructions to manually test that the XBlock is
    working properly.
 
 #. Add a link to your XBlock repository in the pull request.
- 
+
 After you submit the pull request, edX will review your XBlock to ensure that
 it is appropriate for use on edx.org. Specifically, edX will review your XBlock
 for security, scalability, accessibility, and fitness of purpose. You should be

--- a/en_us/xblock-tutorial/source/overview/examples.rst
+++ b/en_us/xblock-tutorial/source/overview/examples.rst
@@ -18,7 +18,7 @@ Google Drive and Calendar XBlock
 Course teams can use the `Google Drive and Calendar XBlock`_ to embed Google
 documents and calendars in their courseware.
 
-The Google Drive and Calendar XBlock is created and stored in a separate Github
+The Google Drive and Calendar XBlock is created and stored in a separate GitHub
 repository. You can explore the contents of this XBlock repository to learn how
 it is structured and developed.
 
@@ -43,10 +43,10 @@ Course teams or developers can also add a Google calendar using OLX.
 
 .. code-block:: xml
 
-  <google-calendar 
+  <google-calendar
     url_name="4115e717366045eaae7764b2e1f25e4c"
     calendar_id="abcdefghijklmnop1234567890@group.calendar.google.com"
-    default_view="1" 
+    default_view="1"
     display_name="Class Schedule"
   />
 


### PR DESCRIPTION
All of GitHub's own usage of their name has a capital H. It's even on their [logo usage page](https://github.com/logos). We should respect their preferences about how their name is used.
