### PR TITLE
Add instructions for customizing Open edX registration page

### DIFF
--- a/en_us/install_operations/source/configuration/customize_registration_page.rst
+++ b/en_us/install_operations/source/configuration/customize_registration_page.rst
@@ -1,0 +1,67 @@
+.. _Customize Registration Page:
+
+#############################################
+Adding Custom Fields to the Registration Page
+#############################################
+
+This topic describes how to add custom fields to the registration page for your
+instance of Open edX.
+
+.. contents::
+   :local:
+   :depth: 1
+
+*********
+Overview
+*********
+
+By default, the registration page for each instance of Open edX has fields that
+ask for information such as a user's name, country, and highest level of
+education completed. You can add custom fields to the registration page for
+your own Open edX instance. These fields can be different types, including
+text entry fields and drop-down lists.
+
+*********************************************
+Add Custom Fields to the Registration Page
+*********************************************
+
+Before you add a custom field to the registration page, you must make sure that
+the combined sign-in and registration form is enabled for your Open edX
+instance. To do this, open the ``lms.env.json`` and ``cms.env.json`` files, and
+set the ``ENABLE_COMBINED_LOGIN_REGISTRATION`` feature flag to True. These
+files are located one level above the ``edx- platform`` directory.
+
+To add custom fields to the registration page, follow these steps.
+
+#. Start the LMS and sign in to your instance of Open edX.
+
+#. Use Python to create a Django form that contains the fields that you want to
+   add to the page, and then create a Django model to store the information
+   from the form.
+
+   For more information about how to create Django forms, see `Django Forms`_
+   on the `Django website`_.
+
+#. In the ``lms.env.json`` file, add the app for your model to the
+   ``ADDL_INSTALLED_APPS`` array.
+
+#. In the ``lms.env.json`` file, set the ``REGISTRATION_EXTENSION_FORM``
+   setting to the path of the Django form that you just created, as a dot-
+   separated Python string.
+
+   For example, if your form is named "ExampleExtensionForm" and is located at
+   "path/to/the_form.py", the value of the setting is
+   ``path.to.the_form.ExampleExtensionForm``.
+
+#. Run database migrations.
+
+#. Restart the LMS and verify that the new fields appear on your registration
+   form.
+
+.. note::
+
+  For an example app for custom forms, see the OpenCraft `custom_form_app`_
+  page in `GitHub`_.
+
+
+.. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/index.rst
+++ b/en_us/install_operations/source/configuration/index.rst
@@ -11,6 +11,7 @@ configuration options.
    :maxdepth: 2
 
    updating_platform
+   customize_registration_page
    enable_prerequisites
    enable_entrance_exams
    enable_licensing

--- a/en_us/install_operations/source/front_matter/change_log.rst
+++ b/en_us/install_operations/source/front_matter/change_log.rst
@@ -8,6 +8,8 @@ Change Log
 
    * - Date
      - Change
+   * - 12 January 2016
+     - Added the :ref:`Customize Registration Page` topic.
    * - 16 December 2015
      - Updated the default value for the ``ENABLE_INSTRUCTOR_LEGACY_DASHBOARD``
        feature flag in the :ref:`Feature Flag Index`.

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -55,6 +55,10 @@
 
 .. GitHub Links
 
+.. _GitHub: http://github.com
+
+.. _custom_form_app: https://github.com/open-craft/custom-form-app
+
 .. _EdX Search: https://github.com/edx/edx-search/
 
 .. _GitHub Flow: https://github.com/blog/1557-github-flow-in-the-browser
@@ -346,6 +350,8 @@
 .. _1.8.7: https://docs.djangoproject.com/en/1.8/releases/1.8.7/
 
 .. _Django website: https://www.djangoproject.com
+
+.. _Django Forms: https://docs.djangoproject.com/en/1.8/ref/forms/
 
 .. _Database Transactions: https://docs.djangoproject.com/en/1.8/topics/db/transactions
 


### PR DESCRIPTION
## [DOC-2559](https://openedx.atlassian.net/browse/DOC-2559)

This PR adds documentation for a new feature that allows Open edX users to add custom fields to the registration page for their instance of Open edX. 
### Date Needed

This feature is scheduled to go live with the release on 1/12/16. 
### Reviewers
- [x] Subject matter expert: @peter-fogg  
- [x] Doc team review (dev edit): @catong @pdesjardins @lamagnifica  
- [ ] Product review: @explorerleslie 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Update change log
- [x] Squash commits
