### PR TITLE
replace IRC with Slack

### DIFF
--- a/en_us/developers/source/process/contributor.rst
+++ b/en_us/developers/source/process/contributor.rst
@@ -2,143 +2,141 @@
 Contributor
 ***********
 
-Before you make a pull request, it’s a good idea to reach out to the edX
+Before you make a pull request, it's a good idea to reach out to the edX
 developers and the rest of the Open edX community to discuss your ideas. There
 might well be someone else already working on the same change you want to make,
-and it’s much better to collaborate than to submit incompatible pull requests.
-You can `send an email to the mailing list`_, `chat on the IRC channel`_, or
-`open an issue in our JIRA issue tracker`_. The earlier you start the
-conversation, the easier it will be to make sure that everyone’s on the right
+and it's much better to collaborate than to submit incompatible pull requests.
+The `Community Discussions`_ page on the open.edx.org website lists different
+ways you can ask, and answer, questions. The earlier you start the
+conversation, the easier it will be to make sure that everyone's on the right
 track -- before you spend a lot of time and effort making a pull request.
 
-.. _send an email to the mailing list: https://groups.google.com/forum/#!forum/edx-code
-.. _chat on the IRC channel: http://webchat.freenode.net?channels=edx-code
-.. _open an issue in our JIRA issue tracker: https://openedx.atlassian.net
+.. _Community Discussions: https://open.edx.org/resources/community-discussions
 
-If you've got an idea for a new feature or new functionality for an existing feature,
-and wish to contribute your code upstream, please `start a discussion on JIRA`_
-(you may first need to `create a free JIRA account`_).
-Do this by visiting the JIRA website and clicking the "Create" button at the top.
-Choose the project "Open Source Pull Requests" and the issue type "Feature Proposal";
-in the description give us as much detail as you can for the feature or functionality
-you are thinking about implementing. We encourage you to do this before
-you begin implementing your feature, in order to get valuable feedback from the edX
-product team early on in your journey and increase the likelihood of a successful
-pull request.
+If you've got an idea for a new feature or new functionality for an existing
+feature, and wish to contribute your code upstream, please `start a discussion
+on JIRA`_ (you may first need to `create a free JIRA account`_). Do this by
+visiting the JIRA website and clicking the "Create" button at the top. Choose
+the project "Open Source Pull Requests" and the issue type "Feature Proposal";
+in the description give us as much detail as you can for the feature or
+functionality you are thinking about implementing. We encourage you to do this
+before you begin implementing your feature, in order to get valuable feedback
+from the edX product team early on in your journey and increase the likelihood
+of a successful pull request.
 
 .. _start a discussion on JIRA: https://openedx.atlassian.net/secure/Dashboard.jspa
 .. _create a free JIRA account: https://openedx.atlassian.net/admin/users/sign-up
 
-It’s also sometimes useful to submit a pull request even before the code is
+It's also sometimes useful to submit a pull request even before the code is
 working properly, to make it easier to collect early feedback. To indicate to
 others that your pull request is not yet in a functional state, just prefix the
 pull request title with "(WIP)" (which stands for Work In Progress). Please do
 include a link to a WIP pull request in your JIRA ticket, if you have one.
 
-Once you’re ready to submit your changes in a pull request, check the following
+Once you're ready to submit your changes in a pull request, check the following
 list of requirements to be sure that your pull request is ready to be reviewed:
 
-#. Prepare a :doc:`pull request cover letter <cover-letter>`. When you open
-   up your pull request, put your cover letter into the "Description" field on GitHub.
+#. Prepare a :doc:`pull request cover letter <cover-letter>`. When you open up
+   your pull request, put your cover letter into the "Description" field on
+   GitHub.
 
-#. The code should be clear and understandable.
-   Comments in code, detailed docstrings, and good variable naming conventions
-   are expected. The `edx-platform GitHub wiki`_ contains many great links to
-   style guides for Python, Javascript, and internationalization (i18n) conventions.
+#. The code should be clear and understandable. Comments in code, detailed
+   docstrings, and good variable naming conventions are expected. The
+   `edx-platform GitHub wiki`_ contains many great links to style guides for
+   Python, Javascript, and internationalization (i18n) conventions.
 
-#. The pull request should be as small as possible.
-   Each pull request should encompass only one idea: one bugfix, one feature,
-   etc. Multiple features (or multiple bugfixes) should not be bundled into
-   one pull request. A handful of small pull requests is much better than
-   one large pull request.
+#. The pull request should be as small as possible. Each pull request should
+   encompass only one idea: one bugfix, one feature, etc. Multiple features (or
+   multiple bugfixes) should not be bundled into one pull request. A handful of
+   small pull requests is much better than one large pull request.
 
-#. Structure your pull request into logical commits.
-   "Fixup" commits should be squashed together. The best pull requests contain
-   only a single, logical change -- which means only a single, logical commit.
+#. Structure your pull request into logical commits. "Fixup" commits should be
+   squashed together. The best pull requests contain only a single, logical
+   change -- which means only a single, logical commit.
 
 #. All code in the pull request must be compatible with edX's AGPL license.
    This means that the author of the pull request must sign a `contributor's
-   agreement with edX`_, and all libraries included or referenced in
-   the pull request must have `compatible licenses`_.
+   agreement with edX`_, and all libraries included or referenced in the pull
+   request must have `compatible licenses`_.
 
-#. All of the tests must pass.
-   If a pull request contains a new feature, it should also contain
-   new tests for that feature. If the pull request fixes a bug, it should
-   also contain a test for that bug to be sure that it stays fixed.
-   (edX’s continuous integration server will verify this for your pull request,
-   and point out any failing tests.)
+#. All of the tests must pass. If a pull request contains a new feature, it
+   should also contain new tests for that feature. If the pull request fixes a
+   bug, it should also contain a test for that bug to be sure that it stays
+   fixed. (edX's continuous integration server will verify this for your pull
+   request, and point out any failing tests.)
 
-#. The author of the pull request should provide a test plan for manually verifying
-   the change in this pull request. The test plan should include details
-   of what should be checked, how to check it, and what the correct behavior
-   should be. When it makes sense to do so, a good test plan includes a tarball
-   of a small edX test course that has a unit which triggers the bug or illustrates
-   the new feature.
+#. The author of the pull request should provide a test plan for manually
+   verifying the change in this pull request. The test plan should include
+   details of what should be checked, how to check it, and what the correct
+   behavior should be. When it makes sense to do so, a good test plan includes
+   a tarball of a small edX test course that has a unit which triggers the bug
+   or illustrates the new feature.
 
-#. For pull requests that make changes to the user interface,
-   please include screenshots of what you changed. GitHub will allow
-   you to upload images directly from your computer.
-   In the future, the core committers will produce a style guide that
-   contains more requirements around how pages should appear and how
-   front-end code should be structured.
+#. For pull requests that make changes to the user interface, please include
+   screenshots of what you changed. GitHub will allow you to upload images
+   directly from your computer. In the future, the core committers will produce
+   a style guide that contains more requirements around how pages should appear
+   and how front-end code should be structured.
 
-#. The pull request should contain some documentation for the feature or bugfix,
-   either in a README file or in a comment on the pull request.
-   A well-written description for the pull request may be sufficient.
+#. The pull request should contain some documentation for the feature or
+   bugfix, either in a README file or in a comment on the pull request. A well-
+   written description for the pull request may be sufficient.
 
-#. The pull request should integrate with existing infrastructure as much
-   as possible, rather than reinventing the wheel.  In a project as large as
-   Open edX, there are many foundational components that might be hard to find,
-   but it is important not to duplicate functionality, even if small,
-   that already exists.
+#. The pull request should integrate with existing infrastructure as much as
+   possible, rather than reinventing the wheel.  In a project as large as Open
+   edX, there are many foundational components that might be hard to find, but
+   it is important not to duplicate functionality, even if small, that already
+   exists.
 
 #. The author of the pull request should be receptive to feedback and
-   constructive criticism.
-   The pull request will not be accepted until all feedback from reviewers
-   is addressed. Once a core committer has reviewed a pull request from a
-   contributor, no further review is required from the core committer until
-   the contributor has addressed all of the core committer’s feedback:
-   either making changes to the pull request, or adding another comment
-   explaining why the contributor has chosen not make any change
-   based on that feedback.
+   constructive criticism. The pull request will not be accepted until all
+   feedback from reviewers is addressed. Once a core committer has reviewed a
+   pull request from a contributor, no further review is required from the core
+   committer until the contributor has addressed all of the core committer's
+   feedback: either making changes to the pull request, or adding another
+   comment explaining why the contributor has chosen not make any change based
+   on that feedback.
 
-It’s also important to realize that you and the core committers may have
+It's also important to realize that you and the core committers may have
 different ideas of what is important in the codebase. The power and freedom of
-open source software comes from the fact that you can fork our software and make
-any modifications that you like, without permission from us; however, the core
-committers are similarly empowered and free to decide what modifications to pull
-in from other contributors, and what not to pull in. While your code might work
-great for you on a small installation, it might not work as well on a large
-installation, have problems with performance or security, not be compatible with
-internationalization or accessibility guidelines, and so on. There are many,
-many reasons why the core committers may decide not to accept your pull request,
-even for reasons that are unrelated to the quality of your code change. However,
-if we do reject your pull request, we will explain why we aren’t taking it, and
-try to suggest other ways that you can accomplish the same result in a way that
-we will accept.
+open source software comes from the fact that you can fork our software and
+make any modifications that you like, without permission from us; however, the
+core committers are similarly empowered and free to decide what modifications
+to pull in from other contributors, and what not to pull in. While your code
+might work great for you on a small installation, it might not work as well on
+a large installation, have problems with performance or security, not be
+compatible with internationalization or accessibility guidelines, and so on.
+There are many, many reasons why the core committers may decide not to accept
+your pull request, even for reasons that are unrelated to the quality of your
+code change. However, if we do reject your pull request, we will explain why we
+aren't taking it, and try to suggest other ways that you can accomplish the
+same result in a way that we will accept.
 
 Once A PR is Open
 -----------------
 
-Once a pull request is open, our faithful robot "Botbro" will open up a JIRA ticket
-in our system to track review of your pull request. The JIRA ticket is a way for
-non-engineers (particularly, product owners) to understand your change and prioritize
-your pull request for team review.
+Once a pull request is open, our faithful robot "Botbro" will open up a JIRA
+ticket in our system to track review of your pull request. The JIRA ticket is a
+way for non-engineers (particularly, product owners) to understand your change
+and prioritize your pull request for team review.
 
 If you open up your pull request with a solid description, following the
-:doc:`pull request cover letter <cover-letter>` guidelines, the product owners will be able
-to quickly understand your change and prioritize it for review. However, they may have
-some questions about your intention, need, and/or approach that they will ask about
-on the JIRA ticket. A community manager will ping you on GitHub to clarify these questions if
-they arise; you are not required to monitor the JIRA discussion.
+:doc:`pull request cover letter <cover-letter>` guidelines, the product owners
+will be able to quickly understand your change and prioritize it for
+review. However, they may have some questions about your intention, need,
+and/or approach that they will ask about on the JIRA ticket. A community
+manager will ping you on GitHub to clarify these questions if they arise;
+you are not required to monitor the JIRA discussion.
 
-Once the product team has sent your pull request to the engineering teams for review, all
-technical discussion regarding your change will occur on GitHub, inline with your code.
+Once the product team has sent your pull request to the engineering teams for
+review, all technical discussion regarding your change will occur on GitHub,
+inline with your code.
 
 Further Information
 -------------------
-For futher information on the pull request requirements, please see the following
-links:
+
+For futher information on the pull request requirements, please see the
+following links:
 
 * :doc:`code-considerations`
 * :doc:`../testing/jenkins`

--- a/en_us/developers/source/process/core-committer.rst
+++ b/en_us/developers/source/process/core-committer.rst
@@ -2,80 +2,85 @@
 Core Committer
 **************
 
-Core committers (or simply, committers) are responsible for reviewing pull requests from
-contributors. This happens once the pull request has passed through a community manager and
-been prioritized by a product owner. As much as possible, the code review
-process for community contributors should be identical to the process of reviewing a pull request
-from another committer: we’re all part of the same community. However,
-there are a few ways that the process is different:
+Core committers (or simply, committers) are responsible for reviewing pull
+requests from contributors. This happens once the pull request has passed
+through a community manager and been prioritized by a product owner. As much as
+possible, the code review process for community contributors should be
+identical to the process of reviewing a pull request from another committer:
+we're all part of the same community. However, there are a few ways that the
+process is different:
 
-* The contributor cannot see when conflicts occur in the branch.
-  These conflicts prevent the pull request from being merged,
-  so you should ask the contributor to rebase their pull request,
-  and point them to `the documentation for doing so`_.
+* The contributor cannot see when conflicts occur in the branch. These
+  conflicts prevent the pull request from being merged, so you should ask the
+  contributor to rebase their pull request, and point them to `the
+  documentation for doing so`_.
 
-* Jenkins may not run on the contributor’s pull request automatically.
-  Be sure to start new Jenkins jobs for the PR as necessary -- do not approve
-  a pull request unless Jenkins has run, and passed, on the last commit
-  in the pull request. If this contributor has already contributed a few
-  good pull requests, that contributor can be added to the Jenkins whitelist,
-  so that jobs are run automatically.
+* Jenkins may not run on the contributor's pull request automatically. Be sure
+  to start new Jenkins jobs for the PR as necessary -- do not approve a pull
+  request unless Jenkins has run, and passed, on the last commit in the pull
+  request. If this contributor has already contributed a few good pull
+  requests, that contributor can be added to the Jenkins whitelist, so that
+  jobs are run automatically.
 
-* The contributor may not respond to comments in a timely manner.
-  This is not your concern: you can move on to other things while waiting.
-  If there is no response after a few days, a community manager will warn the
-  contributor that if the comments are not addressed, the pull request will
-  be closed. (You can also warn the contributor yourself, if you wish.)
-  Do not close the pull request merely because the contributor hasn’t responded
-  -- if you think the pull request should be closed, inform the
-  community managers, and they will handle it.
+* The contributor may not respond to comments in a timely manner. This is not
+  your concern: you can move on to other things while waiting. If there is no
+  response after a few days, a community manager will warn the contributor that
+  if the comments are not addressed, the pull request will be closed. (You can
+  also warn the contributor yourself, if you wish.) Do not close the pull
+  request merely because the contributor hasn't responded. If you think the
+  pull request should be closed, inform the community managers, and they will
+  handle it.
 
 .. _the documentation for doing so: https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request
 
 Each Scrum team should decide for themselves how to estimate stories related to
 reviewing external pull requests, and how to claim points for those stories,
 keeping in mind that an unresponsive contributor may block the story in ways
-that the team can’t control. When deciding how many contributor pull request
-reviews to commit to in the upcoming iteration, teams should plan to spend about
-two hours per week per developer on the team -- larger teams can plan to spend
-more time than smaller teams. For example, a team with two developers should plan
-to spend about four hours per week on pull request review, while a team with
-four developers should plan to spend about eight hours per week on pull request
-review -- these hours can be spread out among multiple developers, or one
-developer can do all the review for the whole team in that iteration.
-However, this is just a guideline: the teams can decide for themselves how
-many contributor pull request reviews they want to commit to.
+that the team can't control. When deciding how many contributor pull request
+reviews to commit to in the upcoming iteration, teams should plan to spend
+about two hours per week per developer on the team -- larger teams can plan to
+spend more time than smaller teams. For example, a team with two developers
+should plan to spend about four hours per week on pull request review, while a
+team with four developers should plan to spend about eight hours per week on
+pull request review -- these hours can be spread out among multiple developers,
+or one developer can do all the review for the whole team in that iteration.
+However, this is just a guideline: the teams can decide for themselves how many
+contributor pull request reviews they want to commit to.
 
 Once a pull request from a contributor passes all required code reviews, a core
 committer will need to merge the pull request into the project. The core
 committer who merges the pull request will be responsible for verifying those
-changes on the staging server prior to release, using the manual test plan provided
-by the author of the pull request.
+changes on the staging server prior to release, using the manual test plan
+provided by the author of the pull request.
 
 In addition to reviewing contributor requests as part of sprint work, core
 committers should expect to spend about one hour per week doing other tasks
-related to the open source community: reading/responding to questions on the
-mailing list and/or IRC channel, disseminating information about what edX is
-working on, and so on.
+related to the open source community: reading/responding to questions in the
+`Community Discussions`_ , disseminating information about what edX is working
+on, and so on.
+
+.. _Community Discussions: https://open.edx.org/resources/community-discussions
 
 Review Comments Terminology
 ---------------------------
-In order to expedite the review process and to have a clear and mutual understanding
-between reviewers and contributors, the following terminology should be used
-when submitting comments on a PR:
 
-* **Must** - A comment of type "Must" indicates the reviewer feels strongly about
-  their requested change to the code and feels the PR should not be merged unless
-  their concern is satisfactorily addressed.
+In order to expedite the review process and to have a clear and mutual
+understanding between reviewers and contributors, the following terminology
+should be used when submitting comments on a PR:
+
+* **Must** - A comment of type "Must" indicates the reviewer feels strongly
+  about their requested change to the code and feels the PR should not be
+  merged unless their concern is satisfactorily addressed.
 
 * **Opt(ional)** - A comment of type "Optional" indicates the reviewer strongly
-  favors their suggestion, but may be agreeable to the current behavior, especially
-  with a persuasive response.
+  favors their suggestion, but may be agreeable to the current behavior,
+  especially with a persuasive response.
 
-* **Nit(pick)** - A comment of type "Nitpick" indicates the reviewer has a minor
-  criticism that *may* not be critical to address, but considers important to share
-  in the given context. Contributors should still seriously consider and weigh these
-  nits and address them in the spirit of maintaining high quality code.
+* **Nit(pick)** - A comment of type "Nitpick" indicates the reviewer has a
+  minor criticism that *might* not be critical to address, but considers
+  important to share in the given context. Contributors should still seriously
+  consider and weigh these nits and address them in the spirit of maintaining
+  high quality code.
 
 * **FYI** - A comment of type "FYI" is a related side comment that is
   informative, but with the intention of having no required immediate action.
@@ -85,6 +90,6 @@ As an example, the following PR comment is clearly categorized as Optional:
 ``"Optional: Consider reducing the high degree of connascense in this code by using
 keyword arguments."``
 
-**Note:** It is possible that after further discussion and review, the reviewer
-chooses to amend their comment, thereby changing its severity to be higher or
-lower than what was originally set.
+.. note:: It is possible that after further discussion and review, the reviewer
+  chooses to amend their comment, thereby changing its severity to be higher or
+  lower than what was originally set.

--- a/en_us/developers/source/process/cover-letter.rst
+++ b/en_us/developers/source/process/cover-letter.rst
@@ -11,38 +11,41 @@ the "Description" field on GitHub. A good cover letter concisely answers as
 many of the following questions as possible. Not all pull requests will have
 answers to every one of these questions, which is okay!
 
-* What JIRA ticket does this address (if any)? Please provide a link to the JIRA ticket
-  representing the bug you are fixing or the feature discussion you've already
-  had with the edX product owners.
+* What JIRA ticket does this address (if any)? Please provide a link to the
+  JIRA ticket representing the bug you are fixing or the feature discussion
+  you've already had with the edX product owners.
 
-* Who have you talked to at edX about this work? Design, architecture, previous PRs,
-  course project manager, IRC, mailing list, etc. Please include links to relevant
-  discussions.
+* Who have you talked to at edX about this work? Design, architecture, previous
+  PRs, course project manager, community discussions, etc. Please include links
+  to relevant discussions.
 
-* Why do you need this change? It's important for us to understand what problem your
-  change is trying to solve, so please describe fully why you feel this change is needed.
+* Why do you need this change? It's important for us to understand what problem
+  your change is trying to solve, so please describe fully why you feel this
+  change is needed.
 
-* What components are affected? (LMS, Studio, a specific app in the system, etc)
+* What components are affected? (LMS, Studio, a specific app in the system,
+  etc.).
 
-* What users are affected?  For example, is this a new component intended for use
-  in just one course, or is this a system wide change affecting all edX students?
+* What users are affected?  For example, is this a new component intended for
+  use in just one course, or is this a system wide change affecting all edX
+  students?
 
-* Test instructions for manual testing. When it makes sense to do so, a good test
-  plan includes a tarball of a small test course that has a unit which triggers
-  the bug or illustrates the new feature. Another option would be to provide
-  explicit, numbered steps (ideally with screenshots!) to walk the reviewer
-  through your feature or fix.
+* Test instructions for manual testing. When it makes sense to do so, a good
+  test plan includes a tarball of a small test course that has a unit which
+  triggers the bug or illustrates the new feature. Another option would be to
+  provide explicit, numbered steps (ideally with screenshots!) to walk the
+  reviewer through your feature or fix.
 
 * Please provide screenshots for all user-facing changes.
 
 * Indicate the urgency of your request. If this is a pull request for a course
-  running or about to run on edx.org, we need to understand your time constraints.
-  Good pieces of information to provide are the course(s) that need this feature
-  and the date that the feature needed by.
+  running or about to run on edx.org, we need to understand your time
+  constraints. Good pieces of information to provide are the course(s) that
+  need this feature and the date that the feature needed by.
 
-* What are your concerns (the author’s) about the PR? Is there a corner case you
-  don't know how to address or some tests you aren't sure how to add? Please bring
-  these concerns up in your cover letter so we can help!
+* What are your concerns (the author's) about the PR? Is there a corner case
+  you don't know how to address or some tests you aren't sure how to add?
+  Please bring these concerns up in your cover letter so we can help!
 
 Example Of A Good PR Cover Letter
 ---------------------------------
@@ -54,8 +57,8 @@ issue, and provides clear manual testing instructions.
 
 `Pull Request 4983`_ is another great example. This pull request's cover letter
 includes before and after screenshots, so the UX team can quickly understand
-what changes were made and make suggestions. Further, the pull request indicates
-how to manually test the feature and what date it is needed by.
+what changes were made and make suggestions. Further, the pull request
+indicates how to manually test the feature and what date it is needed by.
 
 .. _Pull Request 4675: https://github.com/edx/edx-platform/pull/4675
 .. _Pull Request 4983: https://github.com/edx/edx-platform/pull/4983

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -3,11 +3,11 @@ Process for Contributing Code
 *****************************
 
 Open edX is a massive project, and we would love you to help us build
-the best online education system in the world -- we can’t do it alone!
+the best online education system in the world -- we can't do it alone!
 However, the core committers on the project are also developing features
 and creating pull requests, so we need to balance reviewing time with
 development time. To help manage our time and keep everyone as happy as
-possible, we’ve developed this document that explains what core committers
+possible, we've developed this document that explains what core committers
 and other contributors can expect from each other. The goals are:
 
 * Keep pull requests unblocked and flowing as much as possible,
@@ -24,24 +24,25 @@ feature. This will help you so much, we promise: we'll help guide your work so
 you don't have to rearchitect it late in your development cycle. We'll help you
 understand the analytics, performance, test, accessibility, and other various
 requirements up front. We'll also be able to let you know if work you're
-planning duplicates work edX or others are doing. Finally, we'll let you know if
-your work requires `architecture council review`_.
+planning duplicates work edX or others are doing. Finally, we'll let you know
+if your work requires `architecture council review`_.
 
-You can get in touch with us using JIRA, IRC, or mailing lists. `The
-instructions here`_ explain how to use each tool; use whichever you prefer.
+You can get in touch with us using our `Community Discussions`_.
+
+.. _Community Discussions: https://open.edx.org/resources/community-discussions
 
 You should get in touch with us regarding any work you intend to contribute
-upstream, including but not limited to:
+upstream, including but not limited to these types of contributions.
 
-* Core platform changes (changes to the edx-platform repo)
-* Changes to any associated repos (edx-analytics, configuration, XBlock, etc)
-* A new XBlock you're writing that you intend to have run on edx.org
+* Core platform changes (changes to the edx-platform repo).
+* Changes to any associated repos (edx-analytics, configuration, XBlock, etc.).
+* A new XBlock you're writing that you intend to have run on edx.org.
 
-We do not need to review your code if you are writing:
+We do not need to review your code if you are writing a tool or customization for your own installation.
 
-* An XBlock to be run on your own server, not intended to run on edx.org
-* LTI tools that are running on an external server
-* Code you are writing for your own installation, that won't be run on edx.org
+* An XBlock to be run on your own server, not intended to run on edx.org.
+* LTI tools that are running on an external server.
+* Code you are writing for your own installation, that won't be run on edx.org.
 
 Make sure you've signed a `contribution agreement`_ before you submit code
 upstream to any edX owned repo. Please be sure you've at least skimmed the
@@ -79,9 +80,8 @@ questions or concerns.
 * `Analytics Guidelines`_
 * `Eventing Design and Review Process`_
 
-For XBlocks you intend to install on edx.org, please also read
-
-* `XBlock Review Guidelines`_
+For XBlocks you intend to install on edx.org, please also read the `XBlock
+Review Guidelines`_.
 
 .. _Internationalization Coding Guidelines: https://openedx.atlassian.net/wiki/edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
 .. _RTL UI Best Practices: https://github.com/edx/edx-platform/wiki/RTL-UI-Best-Practices
@@ -94,7 +94,7 @@ Roles
 -----
 
 People play different roles in the pull-request review process.  Each role has
-different jobs and responsibilities:
+different jobs and responsibilities.
 
 :doc:`core-committer`
     Can commit changes to an Open edX repository.  Core committers are
@@ -111,27 +111,28 @@ different jobs and responsibilities:
     Submits pull requests for eventual committing to an Open edX repository.
 
 
-If you are a :doc:`contributor <contributor>` submitting a pull request, expect that it will
-take a few weeks before it can be merged. The earlier you can start talking
-with the rest of the Open edX community about the changes you want to make,
-before you even start changing code, the better the whole process
+If you are a :doc:`contributor <contributor>` submitting a pull request, expect
+that it will take a few weeks before it can be merged. The earlier you can
+start talking with the rest of the Open edX community about the changes you
+want to make, before you even start changing code, the better the whole process
 will go.
 
-Follow the guidelines in this document for a high-quality pull request: include a detailed
-description of your pull request when you open it on GitHub (we recommend using a
-:doc:`pull request cover letter <cover-letter>` to guide your description),
-keep the code clear and readable, make sure the tests pass, be responsive to code review comments.
-Small pull requests are easier to review than large pull requests, so
-split up your changes into several small pull requests when possible --
-it will make everything go faster.  See the full :doc:`contributor guidelines <contributor>`
-for details of what to do and what to expect.
+Follow the guidelines in this document for a high-quality pull request: include
+a detailed description of your pull request when you open it on GitHub (we
+recommend using a :doc:`pull request cover letter <cover-letter>` to guide your
+description), keep the code clear and readable, make sure the tests pass, be
+responsive to code review comments. Small pull requests are easier to review
+than large pull requests, so split up your changes into several small pull
+requests when possible -- it will make everything go faster.  See the full
+:doc:`contributor guidelines <contributor>` for details of what to do and what
+to expect.
 
-If you are a :doc:`product owner <product-owner>`, treat pull requests
-from contributors like feature requests from a customer.
-Keep the lines of communication open -- if there are delays or unexpected
-problems, add a comment to the pull request informing the author of the
-pull request of what’s going on. No one likes to feel like they’re being ignored!
-More details are in the :doc:`product owner guidelines <product-owner>`.
+If you are a :doc:`product owner <product-owner>`, treat pull requests from
+contributors like feature requests from a customer. Keep the lines of
+communication open -- if there are delays or unexpected problems, add a comment
+to the pull request informing the author of the pull request of what's going
+on. No one likes to feel like they're being ignored! More details are in the
+:doc:`product owner guidelines <product-owner>`.
 
 If you are a :doc:`core committer <core-committer>`, allocate some time
 in your normal work schedule to review pull requests from other contributors.
@@ -139,7 +140,7 @@ The community managers will make sure that these pull requests meet a
 basic standard for quality before asking you to spend time reviewing them.
 More details are in the :doc:`core committer guidelines <core-committer>`.
 
-Feel free to read the other documentation specific to each individual role in the
-process, but you don’t need to read everything to get started! If you're not
-sure where to start, check out the :doc:`contributor <contributor>` documentation. Thanks
-for helping us grow the project smoothly! :)
+Feel free to read the other documentation specific to each individual role in
+the process, but you don't need to read everything to get started! If you're
+not sure where to start, check out the :doc:`contributor <contributor>`
+documentation. Thanks for helping us grow the project smoothly! :)

--- a/en_us/shared/preface.rst
+++ b/en_us/shared/preface.rst
@@ -307,28 +307,14 @@ Additional repositories are used for other projects. Our contributor agreement,
 contributor guidelines and coding conventions, and other resources are
 available in these repositories.
 
-===============
-Email and Slack
-===============
+======================
+Community Discussions
+======================
 
-To receive and share information by email, developers can join these Google
-groups to ask questions and participate in discussions with peers and edX
-staffers.
+The `Community Discussions`_ page in the Open edX Portal lists different
+ways that you can ask, and answer, questions.
 
-* For conversations about the code in Open edX, join `edx-code`_.
-* For conversations about running Open edX, join `openedx-ops`_.
-* For conversations about globalization and translation,
-  join `openedx-translation`_.
-
-Additional Google groups are occasionally formed for individual projects.
-
-.. note::
- Please do not report security issues in public. If you have a concern,
- please email security@edx.org.
-
-For real-time conversation about Open edX, the edX open source community
-managers run a Slack team. To join the team, get an `invitation to
-Slack`_ and follow the instructions.
+.. _Community Discussions: https://open.edx.org/resources/community-discussions
 
 ====================
 Wikis and Web Sites
@@ -479,7 +465,6 @@ edX Global Community meetup_ group.
 .. _edX Status: http://status.edx.org/
 .. _edx-tools: https://github.com/edx/edx-tools/wiki
 .. _frequently asked questions: http://www.edx.org/student-faq
-.. _invitation to Slack: https://openedx-slack-invite.herokuapp.com/
 .. _Installing, Configuring, and Running the edX Platform: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/
 .. _meetup: http://www.meetup.com/edX-Global-Community/
 .. _openedx-analytics: http://groups.google.com/forum/#!forum/openedx-analytics


### PR DESCRIPTION
Follow on to DOC-2455. Several references to IRC remained in the Developer’s guide. Replaced with Slack. line wrapping and curly quotes also fixed.

@jbarciauskas @pdesjardins 
