### PR TITLE
Add second_review_required to the proctored exam results documentation

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
@@ -669,8 +669,9 @@ learners' proctoring sessions contains the following fields.
    * - status
      - The status of the proctoring session review. Possible values are
        ``created``, ``ready to start``, ``started``, ``timed out``,
-       ``completed``, ``submitted``, ``verified``, ``rejected``, and
-       ``error``. For an explanation of each status, see the table below.
+       ``completed``, ``submitted``, ``second review required``, ``verified``,
+       ``rejected``, and ``error``. For an explanation of each status, see the
+       table below.
 
 
 The following table describes the possible values in the Status column.
@@ -696,6 +697,10 @@ The following table describes the possible values in the Status column.
    * - Submitted
      - The learner has completed the proctored exam and results have been
        submitted for review.
+   * - Second Review Required
+     - The exam attempt has been reviewed and the review team has
+       determined that it requires additional evaluation. The review team will
+       perform the second review. Course teams do not need to take any action.
    * - Satisfactory
      - The proctoring session review has been completed, and has passed.
    * - Unsatisfactory


### PR DESCRIPTION
## [DOC-2561](https://openedx.atlassian.net/browse/DOC-2561)

Add the new second_review_required status for proctored exam attempts to the documentation for proctored exam results. This is a very small update to the tables that explain exam attempt states.
### Reviewers

PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @douglashall 
- [x] Doc team review (sanity check/copy edit): @srpearce @lamagnifica @catong 
- [ ] PM review: @jhendersonedx
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version
- [x] http://draft-proctored-exam-review-status.readthedocs.org/en/latest/course_features/credit_courses/proctored_exams.html#understanding-the-proctored-session-results-file
### Post-review
- [x] Squash commits
