### PR TITLE
Add JavaScript redirect from http://edx.readthedocs.org to http://docs.edx.org/

### DIFF
--- a/en_us/landing_page/source/_static/edx_js.js
+++ b/en_us/landing_page/source/_static/edx_js.js
@@ -1,0 +1,1 @@
+window.location = "http://docs.edx.org/"; 

--- a/en_us/landing_page/source/conf.py
+++ b/en_us/landing_page/source/conf.py
@@ -12,3 +12,7 @@ html_theme_path = ['../../_themes']
 html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'EdX Documentation Resources'
+
+def setup(app): app.add_javascript('edx_js.js')
+
+html_static_path = ['_static/edx_js.js']


### PR DESCRIPTION
## [DOC-2571](https://openedx.atlassian.net/browse/DOC-2571)

This change adds custom JavaScript to the HTML pages for the landing_page document in the edx-documentation repository. The custom JavaScript redirects visitors to docs.edx.org with this line of code:

  window.location = "http://docs.edx.org/";

The landing_page document was added a few weeks ago to help guide users from search results to the main documentation page at docs.edx.org or to a specific document. This change does not alter or remove that landing page.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @wesmason 
- [x] Doc team review (sanity check): @lamagnifica @catong @srpearce  
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version
- [x] http://draft-redirect.readthedocs.org/
  NOTE: following this link will invoke the redirect, so you will end up at docs.edx.org. If you want to see the page that contains the redirect, you will need to disable JavaScript and follow the link or build locally.
### Post-review
- [ ] Squash commits
