### PR TITLE
Adds video use case for Office Mix

### DIFF
--- a/en_us/shared/course_components/create_video.rst
+++ b/en_us/shared/course_components/create_video.rst
@@ -21,7 +21,7 @@ material, showing experiments, and reducing cognitive load for complex
 content.
 
 =====================
-When to use a Video
+When to Use a Video
 =====================
 
 Before creating video content, figure out whether video is the best medium by

--- a/en_us/shared/exercises_tools/office_mix.rst
+++ b/en_us/shared/exercises_tools/office_mix.rst
@@ -8,9 +8,12 @@ Office Mix Tool
 
 .. note:: EdX offers full support for this tool.
 
-`Office Mix`_ is a third-party tool that you can use to turn PowerPoint
-presentations into interactive online lessons that are called mixes. This topic
-describes how to embed mixes in your course.
+`Office Mix`_ is a third-party tool that you can use to turn Microsoft®
+PowerPoint® presentations into interactive online lessons that are called
+mixes.
+
+This topic describes how to embed PowerPoint (.ppt) format mixes in your
+course.
 
 .. contents::
   :local:
@@ -26,15 +29,39 @@ Overview
 *********
 
 Office Mix is an extension to PowerPoint. With Office Mix, you can create
-lessons by integrating narration, screen recordings, quizzes, polls, website
-links, and more into your PowerPoint presentations. The `Office Mix gallery`_
-provides examples and links to more information.
+lessons by integrating quizzes, polls, website links, narration, screen
+recordings, and more into your PowerPoint presentations. The `Office Mix
+gallery`_ provides examples and links to more information.
+
+When you design a lesson that uses PowerPoint with Office Mix, consider that
+you can save the result in either PowerPoint (.ppt) format or export the file
+to video (.mp4 format).
+
+* Lessons that include interactive elements should be saved in PowerPoint
+  format as mixes.
+
+* Lessons that do not include interactive elements, but that do include audio
+  narration or video tablet capture, can be exported as videos in .mp4 format.
+
+.. note:: Because Office Mix is a third-party tool, its features are subject
+ to change without notice. Be sure to consult the `Office Mix Knowledge Base`_
+ for up to date information about this tool's features.
+
+=============================================
+Creating Interactive Mixes with Office Mix
+=============================================
+
+To embed mixes that have interactive elements, including quizzes, web pages,
+and apps, in a course, you save the file in .ppt format. These files can
+include any of the other Office Mix features as well, including audio and
+video.
 
 .. note:: While you can include questions in your mixes, these questions cannot
   be graded. EdX recommends that you add Office Mix components only to ungraded
   subsections in a course.
 
-The following example shows a mix as learners see it in the edX LMS.
+This topic describes how to embed PowerPoint (.ppt) format mixes in your
+course. The following example shows a mix as learners see it in the edX LMS.
 
 .. image:: ../../../shared/images/office_mix.png
   :alt: An Office mix in courseware.
@@ -43,13 +70,45 @@ The following example shows a mix as learners see it in the edX LMS.
 For information about how to create mixes, see the `Office Mix Knowledge
 Base`_.
 
+======================================
+Creating Video Files with Office Mix
+======================================
+
+You can use Office Mix to add audio, video, or both to a PowerPoint
+presentation. These annotations can be recorded (or rerecorded) for the entire
+presentation or for individual slides within the presentation. To embed mixes
+that include audio and video only, you have the option to export the
+presentation to a video file in .mp4 format.
+
+You then use a video component to add the resulting .mp4 file to your course,
+instead of the .ppt file. For more information about including .mp4 format
+video files in your course, see :ref:`Working with Video Components`.
+
+.. note:: Interactive features, such as hyperlinks, do not function in an .mp4
+  video file. The quality of the output that is rendered by the Microsoft
+  PowerPoint web client for mixes in .ppt format can be higher than the quality
+  of a video file exported for the same presentation.
+
+.. only:: Partners
+
+  The video files that you create with Office Mix go through the same media
+  encoding and hosting process that applies to any other video in your course.
+  This process helps assure that high quality video experiences are delivered
+  to as many learners as possible.
+
+  For more information about video processing for courses that run on the
+  edx.org site, see :ref:`partnercoursestaff:Video Processing Overview`.
+
 ******************************
 Add an Office Mix to a Course
 ******************************
 
-To add mixes to your course, you create a mix at an external site, and then
-enable and use the Office Mix tool in Studio to add the mix into a component in
-your course.
+To add .ppt format mixes to your course, you create a mix, host it at an
+external site, and then enable and use the Office Mix tool in Studio to add the
+mix into a component in your course.
+
+For information about how to create mixes, see the `Office Mix Knowledge
+Base`_.
 
 =================================
 Create or Identify an Office Mix
@@ -57,6 +116,8 @@ Create or Identify an Office Mix
 
 #. On an external website, create or identify the mix that you want to add to
    your course. For examples of mixes, see the `Office Mix gallery`_.
+
+#. Save the mix in .ppt format.
 
 #. Make a note of the URL for the mix.
 


### PR DESCRIPTION
## [DOC-2498](https://openedx.atlassian.net/browse/DOC-2498)

Anant requested that we add another use case for teams that use Office Mix: saving the output in mp4 format and adding the resulting file in a video component INSTEAD OF using the new Office Mix Block. The main features available are the per-slide recording capability (superior to Camtasia) and for partners with edx.org courses, access to the video processing workflow performed with our media team
### Date Needed

15 Jan if possible
### Reviewers
- [x] Subject matter expert: Anant
- [x] Subject matter expert: @kurtb
- [x] Doc team review (copy edit):  @catong @srpearce @pdesjardins 
- [x] Product review: @explorerleslie 

FYI: @jbarciauskas @mollydb 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Squash commits
