### PR TITLE
Removes IE10, streamlines the browsers.rst

### DIFF
--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -389,3 +389,8 @@
 .. _Safari: https://www.apple.com/safari
 
 .. _Firefox: https://mozilla.org/firefox
+
+.. _Microsoft Edge: https://www.microsoft.com/microsoft-edge
+
+.. _Microsoft Internet Explorer: http://windows.microsoft.com/internet-explorer/download-ie
+

--- a/en_us/olx/source/about/overview.rst
+++ b/en_us/olx/source/about/overview.rst
@@ -78,8 +78,8 @@ Replace the placeholders in the following template with your information.
       <h2>Frequently Asked Questions</h2>
       <article class="response">
         <h3>What web browser should I use?</h3>
-        <p>The Open edX platform works best with current versions of Chrome, Firefox or Safari, or with Internet Explorer version 9 and above.</p>
-        <p>See our <a href="http://edx.readthedocs.org/en/latest/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
+        <p>The Open edX platform works best with the current versions of Chrome, Firefox, Safari, and Microsoft Edge.</p>
+        <p>See our <a href="http://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
       </article>
       <article class="response">
         <h3>Question 2?</h3>

--- a/en_us/shared/browsers.rst
+++ b/en_us/shared/browsers.rst
@@ -6,122 +6,18 @@
 edX Browser Support
 ####################
 
-The edX Platform runs on the following browsers.
+The edX platform runs on the following browsers.
 
-* `Chrome <https://www.google.com/chrome>`_
-* `Safari <https://www.apple.com/safari>`_
-* `Firefox <https://mozilla.org/firefox>`_
-* `Internet Explorer <https://microsoft.com/ie>`_
+* `Chrome`_
+* `Safari`_
+* `Firefox`_
+* `Microsoft Edge`_ and `Microsoft Internet Explorer`_ 11
 
-.. note:: If you use the Safari browser, be aware that it does not support the 
- search feature for the `edX documentation`_. This is a known limitation.
+The edX platform is routinely tested and verified on the current version and
+the previous version of each of these browsers. We generally encourage the use
+of, and fully support only, the latest version.
 
-The edX Platform is routinely tested and verified on the current
-and previous version of each of these browsers. We generally encourage the
-use of and fully support only the latest version.
+.. note:: If you use the Safari browser, be aware that it does not support the
+ search feature for the guides on `docs.edx.org`_. This is a known limitation.
 
-This information is updated as new major operating system and browser versions
-are released. All point releases are supported unless noted; occasional
-exceptions are based on specific bug fixes or feature updates.
-
-***********************************
-edX Learning Management System
-***********************************
-
-The following table shows operating system and browser support for the edX
-learning management system (LMS), which learners and course teams use to
-interact with course content. 
-
-.. list-table::
-   :widths: 20 10 10 10 10 10
-   :header-rows: 1
-
-   * -
-     - Chrome
-     - Safari
-     - Firefox
-     - IE 11
-     - IE 10
-   * - Windows 8
-     - Yes
-     - N/A
-     - Yes
-     - Yes
-     - Yes
-   * - Mac OSX Mavericks or Yosemite
-     - Yes
-     - Yes
-     - Yes
-     - N/A
-     - N/A
-
-For more information about the LMS, see `Building and Running an edX Course`_. 
-
-***********************************
-edX Studio
-***********************************
-
-The following table shows operating system and browser support for edX Studio,
-which course teams use to build a course.
-
-.. list-table::
-   :widths: 20 10 10 10 10 10
-   :header-rows: 1
-
-   * -
-     - Chrome
-     - Safari
-     - Firefox
-     - IE 11
-     - IE 10
-   * - Windows 8
-     - Yes
-     - N/A
-     - Yes
-     - Provisional
-     - Provisional
-   * - Mac OSX Mavericks or Yosemite
-     - Yes
-     - Yes
-     - Yes
-     - N/A
-     - N/A
-
-For more information about Studio, see `Building and Running an edX Course`_. 
-
-***********************************
-edX Insights
-***********************************
-
-The following table shows operating system and browser support for edX
-Insights, which course teams use to review and download data about their
-courses and learners.
-
-.. list-table::
-   :widths: 20 10 10 10 10 10
-   :header-rows: 1
-
-   * -
-     - Chrome
-     - Safari
-     - Firefox
-     - IE 11
-     - IE 10
-   * - Windows 8
-     - Yes
-     - N/A
-     - Yes
-     - Provisional
-     - Provisional
-   * - Mac OSX Mavericks or Yosemite
-     - Yes
-     - Yes
-     - Yes
-     - N/A
-     - N/A
-
-For more information about edX Insights, see `Using edX Insights`_.
-
-.. _edX documentation: http://docs.edx.org
-.. _Building and Running an edX Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/
-.. _Using edX Insights: http://edx-insights.readthedocs.org/en/latest/
+.. include:: ../../../links/links.rst

--- a/en_us/shared/course_components/create_video.rst
+++ b/en_us/shared/course_components/create_video.rst
@@ -258,9 +258,9 @@ course video, it might be the result of one of these browser-related problems.
   video elements`_.
 
 * Verify that file metadata, particularly the MIME type, is correctly set on
-  the host site. Internet Explorer 10 browsers do not play videos if the MIME
-  type is not set. For example, make sure that the HTTP header ``Content-Type``
-  is set to video/mp4 for an .mp4 file.
+  the host site. For example, when edX offered support for Internet Explorer 10
+  browsers, it was found that videos did not play if the MIME type was not set.
+  The HTTP header ``Content-Type`` had to be set to video/mp4 for an .mp4 file.
 
   As an example of how you might set metadata on a video backup site, the
   *Console User Guide* for the Amazon Simple Storage Service provides this

--- a/en_us/shared/students/SFD_notes.rst
+++ b/en_us/shared/students/SFD_notes.rst
@@ -219,13 +219,18 @@ You can use keyboard shortcuts to create, edit, and delete your notes.
  However, you can only use these keyboard shortcuts on browsers that support
  caret browsing.
 
-  * Internet Explorer and Firefox support caret browsing by default. To enable
-    caret browsing in Firefox, press F7.
+.. * Microsoft Edge, Internet Explorer 11, and (add back with DOC-2629)
+
+  * Firefox supports caret browsing by
+    default. To enable or disable caret browsing, press F7.
 
   * Safari supports caret browsing when VoiceOver is turned on. For more
     information about VoiceOver, see the `VoiceOver for OS X`_ website.
 
   * Chrome does not support caret browsing.
+
+..    However, Google does offer a `Caret
+    Browsing extension`_ that you can install and enable with F7. (add back with DOC-2628)
 
 Before you use the following keyboard shortcuts, you must make sure that notes
 are visible. To show or hide notes, press Ctrl + Shift + left bracket (``[``).


### PR DESCRIPTION
## [DOC-2587](https://openedx.atlassian.net/browse/DOC-2587)

IE 10 is no longer supported. Per discussion with @benpatterson, providing separate matrices for the browsers and operating systems seemed unnecessarily detailed. so I removed them. 

There is a companion PR for the edx-analytics-dashboard repo, https://github.com/edx/edx-analytics-dashboard/pull/405. 
### Date Needed

ASAP
### Reviewers
- [x] Subject matter expert: @benpatterson 
- [ ] Subject matter expert: @cptvitamin or @clrux
- [x] Doc team review (sanity check): @catong @srpearce @pdesjardins 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Squash commits
