### PR TITLE
Fixing a potentially confusing typo.

### DIFF
--- a/en_us/shared/students/SFD_mathformatting.rst
+++ b/en_us/shared/students/SFD_mathformatting.rst
@@ -154,7 +154,7 @@ positive and negative exponents.
 For example, to indicate ``0.012``, you can enter either of the following
 expressions:
 
-* ``1.2^-2``
+* ``1.2*10^-2``
 * ``1.2e-2``
 
 To indicate ``-440,000``, you can enter either of the following expressions:


### PR DESCRIPTION
In the current version it says that 1.2^-2 is one way to enter .012, but 1.2*10^-2 was obviously meant. 1.2^-2 is just 1/1.2 squared or approximately .694.
