### PR TITLE
Add info about audit_notpassing and audit_passing statuses to data guide

### DIFF
--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -1798,12 +1798,18 @@ status
 
        * - Value
          - Description
+       * - audit_notpassing
+         - The learner enrolled in the audit track and did not earn a passing
+           grade. **History**: Added 26 January 2016.
+       * - audit_passing
+         - The learner enrolled in the audit track and received a passing
+           grade. **History**: Added 26 January 2016.
        * - deleted
          - The certificate has been deleted.
        * - deleting
          - A request has been made to delete a certificate.
        * - downloadable
-         - The student passed the course and a certificate is available for
+         - The learner passed the course and a certificate is available for
            download.
        * - error
          - An error ocurred during certificate generation.
@@ -1811,7 +1817,8 @@ status
          - A request has been made to generate a certificate but it has not
            yet been generated.
        * - notpassing
-         - The student's grade is not a passing grade.
+         - The learner enrolled in a certificate track, but did not earn a
+           passing grade.
        * - regenerating
          - A request has been made to regenerate a certificate but it has not
            yet been generated.
@@ -1823,9 +1830,11 @@ status
          - No entry, typically because the student has not yet been graded for
            certificate generation.
 
-  After a course has been graded and certificates have been issued, status is
-  one of these values.
+  After a course has been graded and certificates have been issued, the status
+  is one of these values.
 
+  * audit_notpassing
+  * audit_passing
   * downloadable
   * notpassing
 


### PR DESCRIPTION
Add `audit_notpassing` and `audit_passing` statuses to the `certificates_generatedcertificate` table  per the following:
- [Grading and certificate changes to support honor -> audit transition](https://openedx.atlassian.net/wiki/display/ECOM/Grading+and+certificate+changes+to+support+honor+-%3E+audit+transition)
- [PR 11296](https://github.com/edx/edx-platform/pull/11296)
### Date needed: 1/26/16

The changes to the table will go out in the edX release the week of 1/25-29.
### Reviewers

Reviewers, please check the box next to your name after you have reviewed and given :+1:.
- [x] Subject matter expert: @peter-fogg  
- [ ] Subject matter expert: @stroilova 
- [ ] Doc team review: @lamagnifica @catong @pdesjardins  
