### PR TITLE
Add supplemental information about audit_passing and audit_notpassing

### DIFF
--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -1792,6 +1792,12 @@ status
 --------
   The status can be one of these states.
 
+  .. note::
+   The ``audit_notpassing`` and ``audit_passing`` statuses identify audit
+   learners who were graded after 26 January 2016. These audit learners are not
+   eligible to receive a certificate. Audit learners who were graded before 26
+   January 2016 have a status of ``downloadable`` or ``notpassing``.
+
   .. list-table::
        :widths: 15 80
        :header-rows: 1
@@ -1800,10 +1806,10 @@ status
          - Description
        * - audit_notpassing
          - The learner enrolled in the audit track and did not earn a passing
-           grade. **History**: Added 26 January 2016.
+           grade. **History**: Added 26 January 2016. See the note above.
        * - audit_passing
          - The learner enrolled in the audit track and received a passing
-           grade. **History**: Added 26 January 2016.
+           grade. **History**: Added 26 January 2016. See the note above.
        * - deleted
          - The certificate has been deleted.
        * - deleting


### PR DESCRIPTION
## Overview

This PR adds supplemental information about two new statuses in the Certificates table. These statuses are documented in [PR-803](https://github.com/edx/edx-documentation/pull/803).
### Date Needed

today (so that @stroilova can send an e-mail to course teams)
### Reviewers
- [ ] Doc team review (copy edit): @lamagnifica  
- [ ] Product review: @stroilova 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
