### PR TITLE
Attempts to clarify enrollment mode, timeframe, cert result

### DIFF
--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -812,8 +812,8 @@ mode
   **History**:
 
   * On 1 Dec 2015, the "audit" value was reintroduced. This value now
-    identifies learners who do choose an enrollment option that is not
-    certificate-eligible.
+    identifies learners who choose an enrollment option that is not
+    certificate eligible.
 
   * On 23 Oct 2014, the "audit" value was deprecated.
 

--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -811,12 +811,17 @@ mode
 
   **History**:
 
-  * All enrollments prior to 20 Aug 2013 are "honor", when the "audit" and
-    "verified" values were added.
+  * On 26 Jan 2016, the "audit" value was again added. This value now
+    identifies learners who do not choose a certificate-bearing enrollment
+    option.
 
-  * The "professional" value was added for courses on edx.org on 29 Sep 2014.
+  * On 23 Oct 2014, the "audit" value was deprecated.
 
-  * The "audit" value was deprecated on 23 Oct 2014.
+  * On 29 Sep 2014, the "professional" value was added for courses on edx.org.
+
+  * On 20 Aug 2013, the "audit" and "verified" values were added.
+
+  * All enrollments prior to 20 Aug 2013 were "honor".
 
   .. _user_api_usercoursetag:
 
@@ -1790,13 +1795,17 @@ distinction
 --------
 status
 --------
-  The status can be one of these states.
 
-  .. note::
-   The ``audit_notpassing`` and ``audit_passing`` statuses identify audit
-   learners who were graded after 26 January 2016. These audit learners are not
-   eligible to receive a certificate. Audit learners who were graded before 26
-   January 2016 have a status of ``downloadable`` or ``notpassing``.
+  After a course has been graded and certificates have been issued, the status
+  is one of these string values.
+
+  * audit_notpassing
+  * audit_passing
+  * downloadable
+  * notpassing
+
+  The table that follows describes these values and the other workflow states
+  that can apply during certificate generation process.
 
   .. list-table::
        :widths: 15 80
@@ -1805,44 +1814,56 @@ status
        * - Value
          - Description
        * - audit_notpassing
-         - The learner enrolled in the audit track and did not earn a passing
-           grade. **History**: Added 26 January 2016. See the note above.
+         - Applies to learners who did not earn a passing grade and who have a
+           value of "audit" in ``student_courseenrollment.mode``. No
+           certificate is generated for these learners.
+
+           **History**: Added 26 Jan 2016.
+
        * - audit_passing
-         - The learner enrolled in the audit track and received a passing
-           grade. **History**: Added 26 January 2016. See the note above.
+         - Applies to learners who earned a passing grade and who have a value
+           of "audit" in ``student_courseenrollment.mode``. These learners
+           completed the course succesfully, but no certificate is generated
+           for these learners.
+
+           **History**: Added 26 Jan 2016.
+
        * - deleted
          - The certificate has been deleted.
        * - deleting
          - A request has been made to delete a certificate.
        * - downloadable
-         - The learner passed the course and a certificate is available for
-           download.
+         - A certificate is available for download.
+
+           Applies to learners who earned a passing grade and who have a
+           certificate-bearing value in ``student_courseenrollment.mode``.
+
        * - error
          - An error ocurred during certificate generation.
        * - generating
-         - A request has been made to generate a certificate but it has not
-           yet been generated.
+         - A request has been made to generate a certificate but it has not yet
+           been generated.
        * - notpassing
-         - The learner enrolled in a certificate track, but did not earn a
-           passing grade.
+         - The learner did not earn a passing grade.
+
+           Applies to learners who have a certificate-bearing value in
+           ``student_courseenrollment.mode``. No certificate is generated for
+           these learners.
+
        * - regenerating
          - A request has been made to regenerate a certificate but it has not
            yet been generated.
        * - restricted
-         - No longer used. **History**: Specified when
-           ``userprofile.allow_certificate`` was set to false: to indicate
-           that the student was on the restricted embargo list.
+         - No longer used.
+
+           **History**: Specified when ``userprofile.allow_certificate`` was
+           set to false: to indicate that the student was on the restricted
+           embargo list.
+
        * - unavailable
          - No entry, typically because the student has not yet been graded for
            certificate generation.
 
-  After a course has been graded and certificates have been issued, the status
-  is one of these values.
-
-  * audit_notpassing
-  * audit_passing
-  * downloadable
-  * notpassing
 
 -------------
 verify_uuid
@@ -1881,7 +1902,7 @@ error_reason
 ---------------
 mode
 ---------------
-  Contains the value found in the ``enrollment.mode`` field for a student and
-  course at the time the certificate was generated: blank, audit, honor, or
-  verified. This value is not updated if the student's ``enrollment.mode``
-  changes after certificates are generated.
+  Contains the value found in the ``student_courseenrollment.mode`` field for a
+  student and course at the time the certificate was generated: audit, honor,
+  verified, or blank. This value is not updated if the value of the student's
+  ``student_courseenrollment.mode`` changes after certificates are generated.

--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -811,13 +811,14 @@ mode
 
   **History**:
 
-  * On 26 Jan 2016, the "audit" value was again added. This value now
-    identifies learners who do not choose a certificate-bearing enrollment
-    option.
+  * On 1 Dec 2015, the "audit" value was reintroduced. This value now
+    identifies learners who do choose an enrollment option that is not
+    certificate-eligible.
 
   * On 23 Oct 2014, the "audit" value was deprecated.
 
-  * On 29 Sep 2014, the "professional" value was added for courses on edx.org.
+  * On 29 Sep 2014, the "professional" and "no-id-professional" values were
+    added for courses on edx.org.
 
   * On 20 Aug 2013, the "audit" and "verified" values were added.
 
@@ -1799,10 +1800,10 @@ status
   After a course has been graded and certificates have been issued, the status
   is one of these string values.
 
-  * audit_notpassing
-  * audit_passing
   * downloadable
+  * audit_passing
   * notpassing
+  * audit_notpassing
 
   The table that follows describes these values and the other workflow states
   that can apply during certificate generation process.
@@ -1818,7 +1819,8 @@ status
            value of "audit" in ``student_courseenrollment.mode``. No
            certificate is generated for these learners.
 
-           **History**: Added 26 Jan 2016.
+           **History**: Added 26 Jan 2016 for audit enrollments created after 1
+           Dec 2015.
 
        * - audit_passing
          - Applies to learners who earned a passing grade and who have a value
@@ -1826,7 +1828,8 @@ status
            completed the course succesfully, but no certificate is generated
            for these learners.
 
-           **History**: Added 26 Jan 2016.
+           **History**: Added 26 Jan 2016 for audit enrollments created after 1
+           Dec 2015.
 
        * - deleted
          - The certificate has been deleted.
@@ -1857,7 +1860,7 @@ status
          - No longer used.
 
            **History**: Specified when ``userprofile.allow_certificate`` was
-           set to false: to indicate that the student was on the restricted
+           set to false to indicate that the learner was on the restricted
            embargo list.
 
        * - unavailable


### PR DESCRIPTION
Follow on to 
https://github.com/edx/edx-documentation/pull/811

Per discussion with Olga, attempts to clarify interaction of enrollment “mode” and the resulting certificate table statuses.
### Date Needed

1 Feb 2016
### Reviewers
- [ ] Subject matter expert:  @peter-fogg 
- [x] Subject matter expert: @stroilova
- [x] Doc team review (sanity check/FYI): @srpearce  
- [ ] Product review: @marco
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment
- [ ] Squash commits
