### PR TITLE
Add teams content to open edx student guide

### DIFF
--- a/en_us/open_edx_students/source/SFD_teams.rst
+++ b/en_us/open_edx_students/source/SFD_teams.rst
@@ -1,0 +1,1 @@
+.. include:: ../../shared/students/SFD_teams.rst

--- a/en_us/open_edx_students/source/index.rst
+++ b/en_us/open_edx_students/source/index.rst
@@ -19,6 +19,7 @@ Open edX Learner's Guide
    SFD_notes
    SFD_google_docs
    SFD_certificates
+   SFD_teams
    SFD_mobile
    SFD_prerequisites
    completing_assignments/index


### PR DESCRIPTION
Add the same teams content that is in the edX Learner's Guide to the Open edX Learner's Guide.
@srpearce can you please do a quick sanity check and give the required thumbs if OK? Thanks.
