### PR TITLE
Fix Coffeescript i18n docs to escape html

### DIFF
--- a/en_us/developers/source/internationalization/i18n.rst
+++ b/en_us/developers/source/internationalization/i18n.rst
@@ -228,7 +228,7 @@ JavaScript::
     `// Translators: this will help the translator.`
     message = gettext('Hey there!')
     # Interpolation has to be done in JavaScript, not Coffeescript:
-    message = gettext("Error getting student progress url for '<%= student_id %>'.")
+    message = gettext("Error getting student progress url for '<%- student_id %>'.")
     full_message = _.template(message, {student_id: unique_student_identifier})
 
 But because we extract strings from the compiled .js files, there are some


### PR DESCRIPTION
The docs for i18n for Coffeescript showed an example that was not performing html escaping.  This has been fixed.
### Reviewers

PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @nedbat  
- [ ] Doc team review (sanity check/copy edit/dev edit): @catong 
### Post-review
- [ ] Add description to release notes task as a comment
- [ ] Squash commits
