### PR TITLE
Added a shell script that builds Read the Docs projects

### DIFF
--- a/utilities/build-rtd-documents.sh
+++ b/utilities/build-rtd-documents.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script invokes the REST API that builds edX Read the Docs projects
+# for publicly visible documents.
+# The script requires the curl HTTP client (installed by default in most
+# Linux and Mac OSes) and a connection to the internet. Verify that you
+# have curl installed by invoking the "curl --version" command in a
+# terminal.
+
+# To run this script, navigate to its directory and make sure the file is executable:
+
+# C1MQH7NLG944:~ peterdesjardins$ chmod a+x build-rtd-documents.sh 
+# C1MQH7NLG944:~ peterdesjardins$ ls -l build-rtd-documents.sh
+# -rwxr-xr-x  1 peterdesjardins  staff  758 Feb  2 14:12 build-rtd-documents.sh
+
+# Invoke the script from the command line:
+
+# C1MQH7NLG944:~ peterdesjardins$ ./build-rtd-documents.sh
+
+
+DOC_IDS="edx \
+         edx-partner-course-staff \
+         edx-insights \
+         devdata \
+         edx-guide-for-students \
+         edx-installing-configuring-and-running \
+         open-edx-building-and-running-a-course \
+         open-edx-learner-guide \
+         edx-developer-guide \
+         edx-open-learning-xml \
+         xblock-tutorial \
+         edx-release-notes
+         "
+         
+# xblock - Removed this project because it is failing local builds
+# edx-platform-api - Removed from list because of its separate repo
+# edx-data-analytics-api - Removed from list because of its separate repo
+
+for DOC_ID in ${DOC_IDS}
+do
+
+  # Report the document ID
+  echo "Building ${DOC_ID}"
+  # Invoke the build API for the document ID using curl
+  curl -X POST https://readthedocs.org/build/${DOC_ID}
+  
+done


### PR DESCRIPTION
## [DOC-2651](https://openedx.atlassian.net/browse/DOC-2651)

I am adding a shell script that will invoke the REST APIs that build the Read the Docs projects for our publicly visible documents. I chose to add it in a new top-level directory because it doesn't belong with the content in en_us and the shared directory is a specialized Python module. I would be happy to put this somewhere else, if that is preferred.
### Reviewers
- [ ] Doc team review (sanity check): @lamagnifica @catong @srpearce 
### Testing
- [x] I have run this script myself several times. It prompts builds on RTD in the same way that clicking the build button from a project dashboard does.
### Post-review
- [ ] Squash commits
