### PR TITLE
Change " 'about' videos" to "About videos"

### DIFF
--- a/en_us/release_notes/source/2016/studio/studio_0202_2016.rst
+++ b/en_us/release_notes/source/2016/studio/studio_0202_2016.rst
@@ -1,6 +1,6 @@
 
-For courses running on edx.org, a new procedure for uploading course "about"
+For courses running on edx.org, a new procedure for uploading course About
 videos is now ready for use. The edX media team has developed a process that
-automates hosting and encoding for your "about" videos. For more information,
+automates hosting and encoding for your About videos. For more information,
 see :ref:`partnercoursestaff:Add a Course Video` in the *Building and Running
 an edX Course* guide.


### PR DESCRIPTION
Add a missed commit to the 2 Feb 2016 Release Notes
