### PR TITLE
Documentation - subsection prerequisites for course teams

### DIFF
--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -129,9 +129,9 @@ Overview`.
 
 .. _configuring_prerequisite_content:
 
-********************************
-Configuring Prerequisite Content
-********************************
+*******************************************
+Configuring Prerequisite Course Subsections
+*******************************************
 
 You can hide subsections of your course until learners complete other,
 prerequisite subsections. If a subsection has a prerequisite, it will not be
@@ -140,11 +140,12 @@ the prerequisite subsection.
 
 .. _enabling_subsection_gating:
 
-==========================
-Enabling Subsection Gating
-==========================
+=================================
+Enabling Subsection Prerequisites
+=================================
 
-To enable subsection gating in a course, follow these steps.
+To make it possible to configure prerequisite subsections in a course, follow
+these steps.
 
 #. From the **Settings** menu, select **Advanced Settings**.
 
@@ -164,21 +165,21 @@ earned a minimum score in a prerequisite subsection, follow these steps.
 #. Enable subsection gating for your course. For more information, see
    :ref:`enabling_subsection_gating`.
 
-#. Select the **Configure** icon for the subsection that must be completed
-   first. This is the prerequisite subsection.
+#. Select the configuration icon (an image of gear) for the subsection that
+   must be completed first. This is the prerequisite subsection.
 
    .. image:: ../../../shared/images/subsections-settings-icon.png
      :alt: The subsection settings icon circled.
 
 #. Select the **Access** tab of the subsections settings screen.
 
-#. Select **Make this subsection available as a prerequisite to other content**
-   in the **Use as a Prerequisite** section.
+#. In the **Use as a Prerequisite** section, select **Make this subsection
+   available as a prerequisite to other content**.
 
 #. Select **Save**.
 
-#. Select the **Configure** icon for the subsection that will be hidden until
-   the prerequisite is complete.
+#. Select the configuration icon (an image of gear) for the subsection that
+   will be hidden until the prerequisite is complete.
 
 #. Select the **Access** tab of the subsections settings screen.
 
@@ -192,7 +193,19 @@ earned a minimum score in a prerequisite subsection, follow these steps.
    subsection.
 
    For example, if the prerequisite subsection includes four problems and each
-   problem is worth the same number of points, set the **Minimum Score** to 75
-   in order to require at least three correct answers.
+   problem is worth the same number of points, set the **Minimum Score** to
+   ``75`` in order to require at least three correct answers.
 
 #. Select **Save**.
+
+#. The course outline will display the prerequisite for the subsection
+   underneath its name.
+
+.. note::
+    Make sure that you configure subsection prerequisites in the sequential
+    order that you intend for learners. The prerequisite configuration controls
+    will not prevent you from creating a circular chain of prerequisites that
+    will permanently hide them from learners. You can check the prerequisite
+    for each subsection in the course outline and alter the configuration of prerequisites if needed.
+
+

--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -134,8 +134,8 @@ Configuring Prerequisite Course Subsections
 *******************************************
 
 You can hide subsections of your course until learners complete other,
-prerequisite subsections. If a subsection has a prerequisite, it will not be
-visible in the course navigation until a learner has earned a minimum score in
+prerequisite subsections. If a subsection has a prerequisite, it is not
+visible in the course navigation unless a learner has earned a minimum score in
 the prerequisite subsection.
 
 .. _enabling_subsection_gating:
@@ -144,7 +144,7 @@ the prerequisite subsection.
 Enabling Subsection Prerequisites
 =================================
 
-To make it possible to configure prerequisite subsections in a course, follow
+To enable prerequisite subsections in a course, follow
 these steps.
 
 #. From the **Settings** menu, select **Advanced Settings**.
@@ -162,50 +162,49 @@ Creating a Prerequisite Subsection
 To prevent learners from seeing a subsection of your course until they have
 earned a minimum score in a prerequisite subsection, follow these steps.
 
-#. Enable subsection gating for your course. For more information, see
+#. Enable subsection prerequisites for your course. For more information, see
    :ref:`enabling_subsection_gating`.
 
-#. Select the configuration icon (an image of gear) for the subsection that
+#. Select the **Configure** icon for the subsection that
    must be completed first. This is the prerequisite subsection.
 
    .. image:: ../../../shared/images/subsections-settings-icon.png
      :alt: The subsection settings icon circled.
 
-#. Select the **Access** tab of the subsections settings screen.
+#. Select the **Access** tab.
 
-#. In the **Use as a Prerequisite** section, select **Make this subsection
+#. Select **Use as a Prerequisite** > **Make this subsection
    available as a prerequisite to other content**.
 
 #. Select **Save**.
 
-#. Select the configuration icon (an image of gear) for the subsection that
+#. Select the **Configure** icon for the subsection that
    will be hidden until the prerequisite is complete.
 
-#. Select the **Access** tab of the subsections settings screen.
+#. Select the **Access** tab.
 
-#. In the **Limit Access** section, select the name of the prerequisite
-   subsection in the **Prerequisite** menu.
+#. In the **Limit Access** > **Prerequisite** menu, select the name of the
+   subsection you want to specify as the prerequisite.
 
-#. In the **Limit Access** section, enter the percent of the total score that
-   learners must earn in the **Minimum Score** field. A learner's score for all
-   problems in the prerequisite subsection must be equal to or greater than
-   this percentage in order to satisfy the prerequisite and display the current
-   subsection.
+#. Enter the percent of the total score that learners must earn in the
+   **Minimum Score** field. A learner's score for all problems in the
+   prerequisite subsection must be equal to or greater than this percentage in
+   order to satisfy the prerequisite and display the current subsection.
 
    For example, if the prerequisite subsection includes four problems and each
    problem is worth the same number of points, set the **Minimum Score** to
-   ``75`` in order to require at least three correct answers.
+   ``75`` to require at least three correct answers.
 
 #. Select **Save**.
 
-#. The course outline will display the prerequisite for the subsection
-   underneath its name.
+#. In the course outline, if a subsection has a prerequisite, the prerequisite
+   name appears under the subsection name.
 
 .. note::
-    Make sure that you configure subsection prerequisites in the sequential
-    order that you intend for learners. The prerequisite configuration controls
-    will not prevent you from creating a circular chain of prerequisites that
-    will permanently hide them from learners. You can check the prerequisite
-    for each subsection in the course outline and alter the configuration of prerequisites if needed.
+    Make sure that you configure subsection prerequisites in the order that you
+    intend for learners to encounter them in the course content. The
+    prerequisite configuration controls do not prevent you from creating a
+    circular chain of prerequisites that will permanently hide them from
+    learners.
 
 

--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -151,7 +151,7 @@ these steps.
 
 #. In the **Enable Subsection Prerequisites** field, enter ``true``.
 
-#. At the bottom of the page, select **Save Changes**.
+#. SSelect **Save Changes**.
 
 .. _creating_a_prerequisite_subsection:
 
@@ -162,6 +162,13 @@ Creating a Prerequisite Subsection
 To prevent learners from seeing a subsection of your course until they have
 earned a minimum score in a prerequisite subsection, follow these steps.
 
+.. note::
+    Make sure that you configure subsection prerequisites in the order that you
+    intend for learners to encounter them in the course content. The
+    prerequisite configuration controls do not prevent you from creating a
+    circular chain of prerequisites that will permanently hide them from
+    learners.
+
 #. Enable subsection prerequisites for your course. For more information, see
    :ref:`enabling_subsection_gating`.
 
@@ -169,7 +176,7 @@ earned a minimum score in a prerequisite subsection, follow these steps.
    must be completed first. This is the prerequisite subsection.
 
    .. image:: ../../../shared/images/subsections-settings-icon.png
-     :alt: The subsection settings icon circled.
+     :alt: The subsection configuration icon circled.
 
 #. Select the **Access** tab.
 
@@ -179,7 +186,7 @@ earned a minimum score in a prerequisite subsection, follow these steps.
 #. Select **Save**.
 
 #. Select the **Configure** icon for the subsection that
-   will be hidden until the prerequisite is complete.
+   will be hidden until the prerequisite is met.
 
 #. Select the **Access** tab.
 
@@ -200,11 +207,6 @@ earned a minimum score in a prerequisite subsection, follow these steps.
 #. In the course outline, if a subsection has a prerequisite, the prerequisite
    name appears under the subsection name.
 
-.. note::
-    Make sure that you configure subsection prerequisites in the order that you
-    intend for learners to encounter them in the course content. The
-    prerequisite configuration controls do not prevent you from creating a
-    circular chain of prerequisites that will permanently hide them from
-    learners.
+
 
 

--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -9,10 +9,10 @@ visible to learners and when.
 
 You control content visibility through these features in Studio.
 
-.. contents:: 
+.. contents::
   :local:
   :depth: 1
-  
+
 These features work together to control content visibility for learners.
 
 .. _Release Dates:
@@ -36,13 +36,13 @@ Prior to release, content is visible to course team members by
 :ref:`previewing the course <Preview Course Content>` or :ref:`viewing the live
 course as staff<View Your Live Course>`.
 
-.. note:: The release times that you set, and the times that learners see, 
+.. note:: The release times that you set, and the times that learners see,
    are in Coordinated Universal Time (UTC). You might want to verify that you
    have specified the times that you intend by using a time zone converter such
    as `Time and Date Time Zone Converter
    <http://www.timeanddate.com/worldclock/converter.html>`_
 
-For more information about setting release dates, see the following topics. 
+For more information about setting release dates, see the following topics.
 
 * :ref:`Set a Section Release Date`
 * :ref:`Set a Subsection Release Date`
@@ -126,3 +126,55 @@ groups of learners.
 
 For details, see :ref:`About Content Groups` and :ref:`Cohorted Courseware
 Overview`.
+
+.. _configuring_prerequisite_content:
+
+********************************
+Configuring Prerequisite Content
+********************************
+
+You can hide subsections of your course until learners complete other,
+prerequisite subsections. If a subsection has a prerequisite, it will not be
+visible in the course navigation until a learner has earned a minimum score in
+the prerequisite subsection.
+
+.. _enabling_subsection_gating:
+
+==========================
+Enabling Subsection Gating
+==========================
+
+To enable subsection gating in a course, follow these steps.
+
+#. From the **Settings** menu, select **Advanced Settings**.
+
+#. In the **Enable Subsection Gating** field, enter ``true``.
+
+#. At the bottom of the page, select **Save Changes**.
+
+.. _creating_a_prerequisite_subsection:
+
+==================================
+Creating a Prerequisite Subsection
+==================================
+
+To prevent learners from seeing a subsection of your course until they have
+earned a minimum score in a prerequisite subsection, follow these steps.
+
+#. Enable subsection gating for your course. For more information, see
+   :ref:`enabling_subsection_gating`.
+
+#. Select the **Configure** icon for the prerequisite subsection.
+
+   .. image:: ../../../shared/images/subsections-settings-icon.png
+     :alt: The subsection settings icon circled.
+
+#. Select the **Access** tab of the subsections settings screen.
+
+#. Select **Yes, set this as a prerequisite which can be used to limit access
+   to other content** in the **Use this as a Prerequisite** section.
+
+#. Select the **Configure** icon for the subsection that will be hidden until the prerequisite is complete.
+
+
+

--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -148,7 +148,7 @@ To enable subsection gating in a course, follow these steps.
 
 #. From the **Settings** menu, select **Advanced Settings**.
 
-#. In the **Enable Subsection Gating** field, enter ``true``.
+#. In the **Enable Subsection Prerequisites** field, enter ``true``.
 
 #. At the bottom of the page, select **Save Changes**.
 
@@ -164,17 +164,35 @@ earned a minimum score in a prerequisite subsection, follow these steps.
 #. Enable subsection gating for your course. For more information, see
    :ref:`enabling_subsection_gating`.
 
-#. Select the **Configure** icon for the prerequisite subsection.
+#. Select the **Configure** icon for the subsection that must be completed
+   first. This is the prerequisite subsection.
 
    .. image:: ../../../shared/images/subsections-settings-icon.png
      :alt: The subsection settings icon circled.
 
 #. Select the **Access** tab of the subsections settings screen.
 
-#. Select **Yes, set this as a prerequisite which can be used to limit access
-   to other content** in the **Use this as a Prerequisite** section.
+#. Select **Make this subsection available as a prerequisite to other content**
+   in the **Use as a Prerequisite** section.
 
-#. Select the **Configure** icon for the subsection that will be hidden until the prerequisite is complete.
+#. Select **Save**.
 
+#. Select the **Configure** icon for the subsection that will be hidden until
+   the prerequisite is complete.
 
+#. Select the **Access** tab of the subsections settings screen.
 
+#. In the **Limit Access** section, select the name of the prerequisite
+   subsection in the **Prerequisite** menu.
+
+#. In the **Limit Access** section, enter the percent of the total score that
+   learners must earn in the **Minimum Score** field. A learner's score for all
+   problems in the prerequisite subsection must be equal to or greater than
+   this percentage in order to satisfy the prerequisite and display the current
+   subsection.
+
+   For example, if the prerequisite subsection includes four problems and each
+   problem is worth the same number of points, set the **Minimum Score** to 75
+   in order to require at least three correct answers.
+
+#. Select **Save**.

--- a/en_us/shared/developing_course/workflow.rst
+++ b/en_us/shared/developing_course/workflow.rst
@@ -69,9 +69,9 @@ Content>` throughout the creation process.
 
 .. _Making Course Content Visible to Students:
 
-******************************************************
+*****************************************
 Making Course Content Visible to Students
-******************************************************
+*****************************************
 
 When you create your content, you'll also specify if and when students will be
 able to see it. Content visibility depends on several factors:
@@ -79,6 +79,8 @@ able to see it. Content visibility depends on several factors:
 * The :ref:`course start date <Set Start and End Dates>`
 * The release dates of the :ref:`section<Set a Section Release Date>` and
   :ref:`subsection<Set a Subsection Release Date>`
+* The :ref:`prerequisite subsections<configuring_prerequisite_content>` that
+  you configure
 * The :ref:`publishing status<Hide a Unit from Students>` of the unit
 * The :ref:`Hide content from students<Hide a Unit from Students>` setting
 * The use of :ref:`Content Groups`


### PR DESCRIPTION
## [DOC-2540](https://openedx.atlassian.net/browse/DOC-2540)

This documentation update explains how course teams can configure subsection prerequisites. A subsection prerequisite will hide a subsection until a minimum score is achieved in another subsection. The software change for the new feature is https://openedx.atlassian.net/browse/PHX-205.

Corresponding updates to learner documentation are planned in https://openedx.atlassian.net/browse/DOC-2541.
### Reviewers
- [x] Subject matter expert: @douglashall 
- [ ] Doc team review (sanity check/copy edit/dev edit): @srpearce @lamagnifica @catong 
- [ ] Product review: @griffresch 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] http://draft-subsection-prerequisites.readthedocs.org/en/latest/developing_course/controlling_content_visibility.html#configuring-prerequisite-course-subsections
### Post-review
- [ ] Squash commits
