### PR TITLE
Learner doc explaining how course content becomes available during a course

### DIFF
--- a/en_us/open_edx_students/source/SFD_content_availability.rst
+++ b/en_us/open_edx_students/source/SFD_content_availability.rst
@@ -1,0 +1,1 @@
+.. include:: ../../shared/students/SFD_content_availability.rst

--- a/en_us/open_edx_students/source/index.rst
+++ b/en_us/open_edx_students/source/index.rst
@@ -12,6 +12,7 @@ Open edX Learner's Guide
    SFD_introduction
    sfd_dashboard_profile/index
    SFD_self_paced
+   SFD_content_availability
    SFD_licensing
    SFD_course_search
    SFD_video_player

--- a/en_us/shared/students/SFD_content_availability.rst
+++ b/en_us/shared/students/SFD_content_availability.rst
@@ -6,27 +6,23 @@ Understanding Course Content Availability and Scheduling
 
 When you begin a course, you see the sections of the course content in the left
 pane of the course window. You can use the left pane to view the sections and
-subsections of the course canyon and to open them in the course page.
+subsections of the course content and to open them in the course page.
 
-In many courses, all of the sections and subsections of the course content are
-visible in the left pane when you open the course for the first time. In some
-courses, additional content may appear in the left pane as you work through the
-course. New content may appear in the course because it has been scheduled for
-release as a specific date or because it has prerequisite content that you must
-complete first.
+In some courses, all of the sections and subsections of the course content are
+visible in the left pane when you open the course for the first time. In other
+courses, additional content becomes available as you work, either because it
+was scheduled for release on a specific date, or because you completed required
+content that allowed you to proceed to further content.
 
-If you are taking an instructor-paced course, the course team schedules the
-dates on which the sections of the course content become available to you. On
-the date that the course team chooses, the course content appears in the left
-pane. In self-paced courses, course content does not become available according
-to a schedule. For more information about self-paced and instructor-paced
-courses, see :ref:`SFD Self Paced`.
+In some courses, the course team schedules the dates on which the sections of
+the course content become available to you. On the date that the course team
+chooses, the course content appears in the left pane.
 
-Some sections of course content have prerequisite sections that you must
-complete before they become available. Your course team sets a minimum score
-that you must earn in the problems of a prerequisite section in order to
-display the following sections.
+Some courses include content that has prerequisite sections. Prerequisite
+sections require that you complete other, previous sections before they become
+available. The course team sets a minimum score that you must earn in the
+problems of a prerequisite section in order to display the following sections.
 
 Not all courses include scheduled course content or prerequisites. Your course
-may display all of the course content in the left pane as soon as you begin
+might display all of the course content in the left pane as soon as you begin
 taking it.

--- a/en_us/shared/students/SFD_content_availability.rst
+++ b/en_us/shared/students/SFD_content_availability.rst
@@ -4,7 +4,7 @@
 Understanding Course Content Availability and Scheduling
 ########################################################
 
-When you begin a course you see the sections of the course content in the left
+When you begin a course, you see the sections of the course content in the left
 pane of the course window. You can use the left pane to view the sections and
 subsections of the course canyon and to open them in the course page.
 
@@ -18,9 +18,9 @@ complete first.
 If you are taking an instructor-paced course, the course team schedules the
 dates on which the sections of the course content become available to you. On
 the date that the course team chooses, the course content appears in the left
-pane. In self-paced courses, all of the course content is visible at all times.
-For more information about self-paced and instructor-paced courses, see
-:ref:`SFD Self Paced`.
+pane. In self-paced courses, course content does not become available according
+to a schedule. For more information about self-paced and instructor-paced
+courses, see :ref:`SFD Self Paced`.
 
 Some sections of course content have prerequisite sections that you must
 complete before they become available. Your course team sets a minimum score

--- a/en_us/shared/students/SFD_content_availability.rst
+++ b/en_us/shared/students/SFD_content_availability.rst
@@ -8,10 +8,10 @@ When you begin a course, you see the sections of the course content in the left
 pane of the course window. You can use the left pane to view the sections and
 subsections of the course content and to open them in the course page.
 
-In some courses, all of the sections and subsections of the course content are
-visible in the left pane when you open the course for the first time. In other
-courses, additional content becomes available as you work, either because it
-was scheduled for release on a specific date, or because you completed required
+In some courses, all of the sections of the course content are visible in the
+left pane when you open the course for the first time. In other courses,
+additional content becomes available as you work, either because it was
+scheduled for release on a specific date, or because you completed required
 content that allowed you to proceed to further content.
 
 In some courses, the course team schedules the dates on which the sections of
@@ -26,3 +26,7 @@ problems of a prerequisite section in order to display the following sections.
 Not all courses include scheduled course content or prerequisites. Your course
 might display all of the course content in the left pane as soon as you begin
 taking it.
+
+If you do not see course content that you expect, you can check for information
+about the course schedule and content prerequisites on the course **Home** page
+or course discussions.

--- a/en_us/shared/students/SFD_content_availability.rst
+++ b/en_us/shared/students/SFD_content_availability.rst
@@ -1,0 +1,32 @@
+.. _course_content_availability:
+
+########################################################
+Understanding Course Content Availability and Scheduling
+########################################################
+
+When you begin a course you see the sections of the course content in the left
+pane of the course window. You can use the left pane to view the sections and
+subsections of the course canyon and to open them in the course page.
+
+In many courses, all of the sections and subsections of the course content are
+visible in the left pane when you open the course for the first time. In some
+courses, additional content may appear in the left pane as you work through the
+course. New content may appear in the course because it has been scheduled for
+release as a specific date or because it has prerequisite content that you must
+complete first.
+
+If you are taking an instructor-paced course, the course team schedules the
+dates on which the sections of the course content become available to you. On
+the date that the course team chooses, the course content appears in the left
+pane. In self-paced courses, all of the course content is visible at all times.
+For more information about self-paced and instructor-paced courses, see
+:ref:`SFD Self Paced`.
+
+Some sections of course content have prerequisite sections that you must
+complete before they become available. Your course team sets a minimum score
+that you must earn in the problems of a prerequisite section in order to
+display the following sections.
+
+Not all courses include scheduled course content or prerequisites. Your course
+may display all of the course content in the left pane as soon as you begin
+taking it.

--- a/en_us/shared/students/SFD_self_paced.rst
+++ b/en_us/shared/students/SFD_self_paced.rst
@@ -24,8 +24,8 @@ Differences between Instructor- and Self-Paced Courses
 Instructor-paced courses follow a set schedule. Course materials become
 available at specific times as the course progresses. Assignments have due
 dates, and exams have start and end dates. During the course, indicators show
-you when you have a homework assignment or exam, as well as the due date for
-the assignment or exam.
+when you have a graded assignment, as well as the due date for
+the assignment.
 
 .. image:: ../../shared/students/Images/Pacing_Inst.png
  :width: 200

--- a/en_us/shared/students/SFD_self_paced.rst
+++ b/en_us/shared/students/SFD_self_paced.rst
@@ -32,8 +32,8 @@ the assignment or exam.
  :alt: Part of the left pane in an instructor-paced course, with due dates
      visible for homework.
 
-Self-paced courses do not follow a set schedule. All course materials are
-available as soon as the course begins. Assignments and exams do not have start
+Self-paced courses do not follow a set schedule. Course materials do not become
+available according to a schedule. Assignments and exams do not have start
 or due dates. The course shows indicators for homework assignments, but not due
 dates.
 
@@ -44,3 +44,4 @@ dates.
 
 In self-paced courses, you can submit an assignment or exam at any time before
 the course end date.
+

--- a/en_us/shared/students/SFD_self_paced.rst
+++ b/en_us/shared/students/SFD_self_paced.rst
@@ -33,9 +33,9 @@ the assignment or exam.
      visible for homework.
 
 Self-paced courses do not follow a set schedule. Course materials do not become
-available according to a schedule. Assignments and exams do not have start
-or due dates. The course shows indicators for homework assignments, but not due
-dates.
+available according to a schedule, but are completely available as soon as the
+course begins. Assignments and exams do not have start or due dates. The course
+shows indicators for homework assignments, but not due dates.
 
 .. image:: ../../shared/students/Images/Pacing_Self.png
  :width: 200

--- a/en_us/students/source/SFD_content_availability.rst
+++ b/en_us/students/source/SFD_content_availability.rst
@@ -1,0 +1,1 @@
+.. include:: ../../shared/students/SFD_content_availability.rst

--- a/en_us/students/source/index.rst
+++ b/en_us/students/source/index.rst
@@ -15,6 +15,7 @@ EdX Learner's Guide
    SFD_self_paced
    SFD_enrolling
    SFD_credit_courses/index
+   SFD_content_availability
    SFD_licensing
    SFD_video_player
    SFD_bookmarks


### PR DESCRIPTION
## [DOC-2541](https://openedx.atlassian.net/browse/DOC-2541)

This PR adds learner documentation to explain how course content becomes available while a course is in progress. It adds a new top-level section to the edx.org and open edX learner documentation. Other changes alter statements that are no longer true, such as that self-paced courses display all content at all times.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @douglashall 
- [ ] Doc team review (sanity check/copy edit/dev edit): @catong @srpearce @lamagnifica 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] http://draft-prereqs-learners.readthedocs.org/en/latest/SFD_content_availability.html#understanding-course-content-availability-and-scheduling
### Post-review
- [ ] Squash commits
