### PR TITLE
Checkbox Problem: delete mention of direction vertical from code examples

### DIFF
--- a/en_us/shared/course_features/content_experiments/subsection_content_experiments_OLX.rst
+++ b/en_us/shared/course_features/content_experiments/subsection_content_experiments_OLX.rst
@@ -49,8 +49,8 @@ different sets of content.
 
 .. code-block:: xml
 
-    <split_test url_name="AB_Test.xml" display_name="A/B Test" user_partition_id="0" 
-                group_id_to_child='{"0": "i4x://path-to-course/vertical/group_a", 
+    <split_test url_name="AB_Test.xml" display_name="A/B Test" user_partition_id="0"
+                group_id_to_child='{"0": "i4x://path-to-course/vertical/group_a",
                                     "1": "i4x://path-to-course/vertical/group_b"}'>
         <vertical url_name="group_a" display_name="Group A">
            <html>Welcome to group A.</html>
@@ -59,10 +59,10 @@ different sets of content.
         <vertical url_name="group_b" display_name="Group B">
             <html>Welcome to group B.</html>
             <problem display_name="Checkboxes">
-                <p>A checkboxes problem presents checkbox buttons for learner input. 
+                <p>A checkboxes problem presents checkbox buttons for learner input.
                    Learners can select more than one option presented.</p>
                 <choiceresponse>
-                    <checkboxgroup direction="vertical" label="Select the answer that matches">
+                    <checkboxgroup label="Select the answer that matches">
                         <choice correct="true">correct</choice>
                         <choice correct="false">incorrect</choice>
                         <choice correct="true">correct</choice>

--- a/en_us/shared/exercises_tools/checkbox.rst
+++ b/en_us/shared/exercises_tools/checkbox.rst
@@ -295,7 +295,7 @@ For example, the following problem has feedback for each option.
 
   <choiceresponse>
     <checkboxgroup label="Which of the following is an example
-    of a fruit? Check all that apply." direction="vertical">
+    of a fruit? Check all that apply.">
       <choice correct="true">apple
         <choicehint selected="true">You are correct that an apple is a fruit
           because it is the fertilized ovary that comes from an apple tree and


### PR DESCRIPTION
## [DOC-2162](https://openedx.atlassian.net/browse/DOC-2162)

This PR removes the direction attribute from <checkboxgroup> problems in code examples. Per https://openedx.atlassian.net/browse/TNL-231 and https://openedx.atlassian.net/browse/DOC-2162.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Doc team review (sanity check/copy edit/dev edit): @srpearce @lamagnifica 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
