### PR TITLE
Updated description of the LTI modal height and modal width settings

### DIFF
--- a/en_us/shared/exercises_tools/lti_component.rst
+++ b/en_us/shared/exercises_tools/lti_component.rst
@@ -304,13 +304,15 @@ LTI Component Settings
        **Inline**.
 
    * - Modal Height
-     - Specifies the on-screen height of the LTI content window in pixels.
+     - Specifies the on-screen height of the LTI content window as a percentage
+       of the visible web browser window height. Enter the percentage in whole numbers.
 
        This setting is only applied if the **LTI Launch Target** control is set
        to **Modal**.
 
    * - Modal Width
-     - Specifies the on-screen width of the LTI content window in pixels.
+     - Specifies the on-screen width of the LTI content window as a percentage
+       of the web browser window width. Enter the percentage in whole numbers.
 
        This setting is only applied if the **LTI Launch Target** control is set
        to **Modal**.


### PR DESCRIPTION
## [DOC-2609](https://openedx.atlassian.net/browse/DOC-2609)

Updated the description of modal height and modal width. These are now percentages of the browser window, instead of pixel dimensions.

The software change is described in https://openedx.atlassian.net/browse/PHX-241.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @douglashall 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @srpearce @catong 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
