### PR TITLE
Revised devstack installation instructions

### DIFF
--- a/en_us/data/source/internal_data_formats/ora2_data.rst
+++ b/en_us/data/source/internal_data_formats/ora2_data.rst
@@ -13,7 +13,7 @@ This section describes the data schema for the edX open response assessment
 
 The schema includes a number of tables, and the ORA system offers a range of
 uses. As a result, the data can be complex. EdX recommends that you set up a
-course on a Devstack instance so that you can create assessments and test the
+course on a devstack instance so that you can create assessments and test the
 possible learner interactions.
 
 * For more information about how course teams can set up open response
@@ -22,7 +22,7 @@ possible learner interactions.
 * For more information about how learners respond to these assessments, see
   :ref:`learners:SFD_ORA`.
 
-* For more information about setting up a Devstack Vagrant instance, see
+* For more information about setting up a devstack Vagrant instance, see
   :ref:`installation:Installing the Open edX Developer Stack`.
 
 **History**:  These tables were added to the ``ora`` subdirectory of the

--- a/en_us/install_operations/source/birch.rst
+++ b/en_us/install_operations/source/birch.rst
@@ -10,7 +10,7 @@ This section describes how to install the Open edX Birch release.
  :local:
  :depth: 1
 
-.. note:: 
+.. note::
   Now that the Open edX Cypress release is available, edX no longer
   supports the Birch release.
 
@@ -108,13 +108,13 @@ See `BitTorrent`_ for more information.
 If you download the Vagrant box through BitTorrent, you must add the box to
 Vagrant before continuing with the installation process.
 
-* For Devstack installations, run the following command.
+* For devstack installations, run the following command.
 
    .. code-block:: bash
 
      $ vagrant box add /path-to-downloaded-box/vagrant-images-birch-2-devstack.box --name birch-devstack-2
 
-* For Fullstack installations, run the following command.
+* For fullstack installations, run the following command.
 
    .. code-block:: bash
 
@@ -163,9 +163,9 @@ Birch release, using the ``migrate.sh`` script in the configuration repository,
 On the computer or virtual machine running the Aspen release of Open edX, run
 the upgrade script for your type of installation:
 
-* For Devstack, run ``./migrate.sh -t named-release/birch.2 -c devstack``.
+* For devstack, run ``./migrate.sh -t named-release/birch.2 -c devstack``.
 
-* For Fullstack, run ``./migrate.sh -t named-release/birch.2 -c fullstack``.
+* For fullstack, run ``./migrate.sh -t named-release/birch.2 -c fullstack``.
 
 * You can also run ``./migrate.sh -h`` to see which other options the script accepts.
 

--- a/en_us/install_operations/source/configuration/tpa/tpa_SAML_IdP.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_SAML_IdP.rst
@@ -151,8 +151,8 @@ steps.
    If the check mark does not appear, make sure that celery is configured
    correctly and is running. You can also manually trigger an update by running
    the management command ``./manage.py lms saml --pull --settings=aws`` on
-   Fullstack or ``./manage.py lms saml --pull --settings=devstack`` on
-   Devstack.
+   fullstack or ``./manage.py lms saml --pull --settings=devstack`` on
+   devstack.
 
 #. For additional information about the data fetched from the IdP, on the
    Django administration console select **SAML Provider Data**, and then select

--- a/en_us/install_operations/source/configuration/youtube_api.rst
+++ b/en_us/install_operations/source/configuration/youtube_api.rst
@@ -53,7 +53,7 @@ edX.
 To set your YouTube API key in Ansible's configuration file, complete the following steps.
 
 #. Find the `configuration`_ repository on your Open edX server. If you are
-   running Devstack or Fullstack, the directory is
+   running devstack or fullstack, the directory is
    ``/edx/app/edx_ansible/edx_ansible``.
 
 #. In that repository, open the ``playbooks/roles/edxapp/defaults/main.yml``
@@ -92,12 +92,12 @@ To set your YouTube API key by editing JSON files, complete the following
 steps.
 
 #. Find the `edx-platform`_ repository on your Open edX server. If you are
-   running Devstack or Fullstack, the directory is
+   running devstack or fullstack, the directory is
    ``/edx/app/edxapp/edx-platform``.
 
 #. In the directory *above* your repository, there should be several JSON
    files, including ``lms.auth.json`` and ``cms.auth.json``. If you are running
-   Devstack or Fullstack, the directory is ``/edx/app/edxapp``.
+   devstack or fullstack, the directory is ``/edx/app/edxapp``.
 
 #. Open the ``lms.auth.json`` file in your text editor.
 

--- a/en_us/install_operations/source/cypress.rst
+++ b/en_us/install_operations/source/cypress.rst
@@ -108,7 +108,7 @@ See `BitTorrent`_ for more information.
 If you download the Vagrant box through BitTorrent, you must add the box to
 Vagrant before continuing with the installation process.
 
-* For Devstack installations, run the following command.
+* For devstack installations, run the following command.
 
    .. code-block:: bash
 
@@ -116,7 +116,7 @@ Vagrant before continuing with the installation process.
        cypress-devstack
 
 
-* For Fullstack installations, run the following command.
+* For fullstack installations, run the following command.
 
    .. code-block:: bash
 
@@ -165,9 +165,9 @@ repository, `available here
 On the computer or virtual machine that is running the Birch release of Open
 edX, run the upgrade script for your type of installation:
 
-* For Devstack, run ``./migrate.sh -c devstack``.
+* For devstack, run ``./migrate.sh -c devstack``.
 
-* For Fullstack, run ``./migrate.sh -c fullstack``.
+* For fullstack, run ``./migrate.sh -c fullstack``.
 
 * You can also run ``./migrate.sh -h`` to see which other options the script
   accepts.

--- a/en_us/install_operations/source/devstack/analytics_devstack.rst
+++ b/en_us/install_operations/source/devstack/analytics_devstack.rst
@@ -4,7 +4,7 @@
 Installing the Open edX Analytics Developer Stack
 #################################################
 
-This section describes how to install and run the Open edX Analytics Developer
+This section describes how to install and run the Open edX analytics developer
 Stack.
 
 .. contents::
@@ -15,7 +15,7 @@ Stack.
 Overview
 **********
 
-The Open edX Analytics Developer stack, known as the Analytics Devstack, is a
+The Open edX analytics developer stack, known as the analytics devstack, is a
 modified version of the :ref:`Open edX Developer Stack<Installing the Open edX
 Developer Stack>`.
 
@@ -26,12 +26,12 @@ edX Analytics Pipeline, Data API, and Insights projects.
 Components
 ********************
 
-The Analytics Devstack includes the following additional components.
+The analytics devstack includes the following additional components.
 
 * edX Analytics Data API
 * edX Insights
 
-The Analytics Devstack also includes all of the components needed to run the
+The analytics devstack also includes all of the components needed to run the
 Open edX Analytics Pipeline, which is the primary ETL (extract, transform, and
 load) tool that extracts and analyzes data from the other Open edX services.
 
@@ -39,7 +39,7 @@ load) tool that extracts and analyzes data from the other Open edX services.
 Install the Software Prerequisites
 ***********************************
 
-To install and run the Analytics Devstack, you must first install the following
+To install and run the analytics devstack, you must first install the following
 required software.
 
 * `VirtualBox`_ 4.3.12 or higher.
@@ -68,7 +68,7 @@ deploy itself. To make use of these tools, follow these steps.
       $ source venv/bin/activate
       $ make bootstrap
 
-The system is now ready to start running tasks on the Analytics Devstack
+The system is now ready to start running tasks on the analytics devstack
 using the ``remote-task`` tool.
 
 
@@ -78,7 +78,7 @@ using the ``remote-task`` tool.
 Install the Analytics Devstack
 ******************************
 
-To install the Analytics Devstack extensions directly from the command line,
+To install the analytics devstack extensions directly from the command line,
 follow these steps.
 
 #. Create the ``analyticstack`` directory and navigate to it in the command
@@ -89,13 +89,13 @@ follow these steps.
      $ mkdir analyticstack
      $ cd analyticstack
 
-#. Download the Analytics Devstack Vagrant file.
+#. Download the analytics devstack Vagrant file.
 
    .. code-block:: bash
 
      $ curl -L https://raw.github.com/edx/configuration/master/vagrant/release/analyticstack/Vagrantfile > Vagrantfile
 
-#. Create the Analytics Devstack virtual machine.
+#. Create the analytics devstack virtual machine.
 
    .. code-block:: bash
 
@@ -109,7 +109,7 @@ Using the Analytics Devstack
 Run the Open edX LMS
 ====================
 
-#. Log in to the Analytics Devstack.
+#. Log in to the analytics devstack.
 
    .. code-block:: bash
 
@@ -131,7 +131,7 @@ Run the Open edX LMS
 Run the Open edX Analytics Data API
 ===================================
 
-#. Log in to the Analytics Devstack.
+#. Log in to the analytics devstack.
 
    .. code-block:: bash
 
@@ -153,7 +153,7 @@ Run the Open edX Analytics Data API
 Run Open edX Insights
 =====================
 
-#. Log in to the Analytics Devstack.
+#. Log in to the analytics devstack.
 
    .. code-block:: bash
 

--- a/en_us/install_operations/source/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/devstack/install_devstack.rst
@@ -14,7 +14,7 @@ This section describes how to install the Open edX Developer Stack.
 Overview
 **********
 
-The Open edX Developer Stack, known as **Devstack**, is a Vagrant instance
+The Open edX Developer Stack, known as **devstack**, is a Vagrant instance
 designed for local development.
 
 Devstack uses the same system requirements as :ref:`Open edX Fullstack
@@ -22,8 +22,8 @@ Devstack uses the same system requirements as :ref:`Open edX Fullstack
 configuration issues early in development.
 
 Devstack simplifies certain production settings to make development more
-convenient. For example, `nginx`_ and `gunicorn`_ are disabled in Devstack;
-Devstack uses Django's runserver instead.
+convenient. For example, `nginx`_ and `gunicorn`_ are disabled in devstack;
+devstack uses Django's runserver instead.
 
 See the `Vagrant documentation`_ for more information.
 
@@ -45,7 +45,7 @@ Devstack also includes a demonstration edX course.
 Knowledge Prerequisites
 **************************
 
-To use Devstack, you should meet the following knowledge requirements.
+To use devstack, you should meet the following knowledge requirements.
 
 * Understand basic terminal usage. If you are using a Mac computer, see
   `Introduction to the Mac OS X Command Line`_. If you are using a Windows
@@ -58,7 +58,7 @@ To use Devstack, you should meet the following knowledge requirements.
 Software Prerequisites
 **************************
 
-To install and run Devstack, you must first install the following required
+To install and run devstack, you must first install the following required
 software.
 
 * `VirtualBox`_ 4.3.12 or higher.
@@ -71,76 +71,190 @@ software.
 .. _Install DevStack:
 
 **************************
-Install DevStack
+Install Devstack
 **************************
 
-To install Devstack directly from the command line, follow the instructions
-below. You can also install DevStack using a Torrent file, as explained in the
-next section.
+To install devstack directly from the command line, follow these steps.
 
-Before beginning the installation, ensure that you have the administrator
-password for your local computer. The administrator password is needed so that
-NFS can be set up to allow users to access code directories directly from your
+.. note::
+
+   The first time you start the devstack virtual machine, Vagrant downloads a
+   ``box`` file, which has a file size of approximately four gigabytes. You can
+   also install devstack using a torrent file that you download separately. For
+   more information, see :ref:`install_devstack_with_torrent_file`.
+
+Before beginning the installation, make sure that you have the administrator
+password for your local computer. The administrator password is needed to
+configure NFS to allow users to access code directories directly from your
 computer.
 
-#. Ensure the ``nfsd`` client is running.
+#. Ensure the ``nfsd`` client is running. Use the ``nfsd status`` command.
 
-#. Create the ``devstack`` directory and navigate to it in the command prompt.
+   .. code-block:: bash
+
+     sudo nfsd status
+     nfsd service is enabled
+     nfsd is running (pid 313, 8 threads)
+
+   If the nfsd service is not running, use the ``nfsd start`` command.
+
+   .. code-block:: bash
+
+     sudo nfsd start
+     Starting the nfsd service
+
+#. Create a ``devstack`` directory and navigate to it in the command prompt.
 
    .. code-block:: bash
 
      mkdir devstack
      cd devstack
 
-#. Download the Devstack Vagrant file.
+#. Download the devstack Vagrant file.
 
    .. code-block:: bash
 
      curl -L https://raw.github.com/edx/configuration/master/vagrant/release/devstack/Vagrantfile > Vagrantfile
 
-#. Install the Vagrant ``vbguest`` plugin.
+#.  Set the ``OPENEDX_RELEASE`` environment variable to the Git tag name of the
+    named release of the Open edX platform that you are installing. For
+    information about the latest Open edX releases and the Git tag names for
+    them, see `Open edX Releases Wiki page`_.
 
-   .. code-block:: bash
+    For example, ``named-release/dogwood`` is the Git tag name for the Dogwood
+    named release. The following command sets the value of the OPENEDX_RELEASE
+    environment variable to ``named-release/dogwood``.
 
-     vagrant plugin install vagrant-vbguest
+    .. code-block:: bash
 
-#. Create the Devstack virtual machine.
+      export OPENEDX_RELEASE="named-release/dogwood"
+
+    If you do not set this environment variable, Vagrant will install the
+    most recent snapshot version of the Open edX platform. The snapshot version is not a supported release.
+
+#. Create and start the devstack virtual machine.
 
    .. code-block:: bash
 
      vagrant up
 
-   The first time you create the Devstack virtual machine, Vagrant downloads
+   The first time you start the devstack virtual machine, Vagrant downloads
    the base box, which has a file size of about 4GB. If you destroy and
    recreate the virtual machine, Vagrant re-uses the box it downloaded. See
    `Vagrant's documentation on boxes`_ for more information.
 
-#. When prompted, enter the administrator password for your local computer.
+   When prompted, enter the administrator password for your local computer.
 
 When you have completed these steps, see :ref:`Running the Open edX Developer
-Stack` to begin using Devstack.
+Stack` to begin using devstack.
 
-For help with the Devstack installation, see :ref:`Troubleshooting the Devstack
+For help with the devstack installation, see :ref:`Troubleshooting the Devstack
 Installation`.
 
+.. _install_devstack_with_torrent_file:
+
 *****************************************
-Install Devstack using the Torrent file
+Install Devstack Using a Torrent File
 *****************************************
 
-You can use BitTorrent to download the box file.  Follow all of the
-instructions in :ref:`Install DevStack`, but instead of downloading
-the Vagrant file with curl, do this:
+You can use a BitTorrent client to download the Vagrant box file. Downloading
+the box file and installing it in your Vagrant environment will prevent Vagrant
+from downloading the box file directly when you start it for the first time.
+This may be useful if you have a limited  or intermittent connection to the
+internet and cannot download a large file.
 
-#. Download the Torrent file for the latest Open edX release.
-   See the `Open edX Releases Wiki page`_ to find out what the latest Open edX
-   release is, and where to download the Torrent file.
+To install devstack using a box file that you download with a BitTorrent
+client, follow these steps.
 
-#. When you have the file on your computer, add the virtual machine using the
-   following command.
+#. Ensure the ``nfsd`` client is running. Use the ``nfsd status`` command.
+
+   .. code-block:: bash
+
+     sudo nfsd status
+     nfsd service is enabled
+     nfsd is running (pid 313, 8 threads)
+
+   If the nfsd service is not running, use the ``nfsd start`` command.
+
+   .. code-block:: bash
+
+     sudo nfsd start
+     Starting the nfsd service
+
+#. Create a ``devstack`` directory and navigate to it in the command prompt.
+
+   .. code-block:: bash
+
+     mkdir devstack
+     cd devstack
+
+#. Download the devstack Vagrant file.
+
+   .. code-block:: bash
+
+     curl -O https://raw.github.com/edx/configuration/master/vagrant/release/devstack/Vagrantfile
+
+#. Download the torrent file for the latest Open edX release. For information
+   about the latest Open edX releases and to download torrent files for them,
+   see `Open edX Releases Wiki page`_.
+
+   .. code-block:: bash
+
+     curl -O https://s3.amazonaws.com/edx-static/vagrant-images/20151221-dogwood-devstack-rc2.box?torrent
+
+#. Use a BitTorrent client to open the torrent file and download the ``.box``
+   file. For more information about using a BitTorrent client, see the
+   documentation for the client software that you choose.
+
+#.  Set the ``OPENEDX_RELEASE`` environment variable to the Git tag name for
+    the Open edX release that you are installing. To find the Git tag name for
+    an Open edX release, see `Open edX Releases Wiki page`_.
+
+    For example, the following command sets the value of the OPENEDX_RELEASE
+    environment variable to ``named-release/dogwood``.
 
     .. code-block:: bash
 
-     vagrant box add box-name path-to-box-file
+      export OPENEDX_RELEASE="named-release/dogwood"
+
+    .. note::
+
+        If you do not set this environment variable, Vagrant will install the
+        most recent snapshot version of the Open edX platform, and will
+        download the ``box`` file for it directly. The size of the ``box`` file
+        is approximately four gigabytes.  The snapshot version is not a
+        supported release.
+
+#. Find the name of the Vagrant ``box`` for the named Open edX release that you
+   are installing. To find the Vagrant ``box`` name for an Open edX release,
+   see `Open edX Releases Wiki page`_.
+
+#. Create a Vagrant ``box`` using the ``vagrant box add`` command. Specify the
+   name of the box and the file path of the box file that you downloaded. The
+   name of the box you create must match the box name for the Open edX release
+   you are installing.
+
+   For example, the following command creates a box named ``dogwood-devstack-
+   rc2``.
+
+   .. code-block:: bash
+
+     vagrant box add dogwood-devstack-rc2 \
+     /path/to/vagrant-images_20151221-dogwood-devstack-rc2.box
+
+#. Create and start the devstack virtual machine.
+
+   .. code-block:: bash
+
+     vagrant up
+
+   When prompted, enter the administrator password for your local computer.
+
+When you have completed these steps, see :ref:`Running the Open edX Developer
+Stack` to begin using devstack.
+
+For help with the devstack installation, see :ref:`Troubleshooting the Devstack
+Installation`.
 
 .. _Troubleshooting the Devstack Installation:
 
@@ -148,7 +262,7 @@ the Vagrant file with curl, do this:
 Troubleshooting the Devstack Installation
 *****************************************
 
-In some cases, you see an error when you attempt to create the Devstack virtual
+In some cases, you see an error when you attempt to create the devstack virtual
 machine (``vagrant up``). For example:
 
 ``mount.nfs: mount to NFS server '192.168.33.1:/path/to/edx-platform' failed: timed out, giving up``

--- a/en_us/install_operations/source/devstack/run_devstack.rst
+++ b/en_us/install_operations/source/devstack/run_devstack.rst
@@ -14,14 +14,14 @@ This section describes how to run the Open edX Developer Stack.
 Connect to the Devstack Virtual Machine
 ****************************************
 
-#. To connect to the Devstack virtual machine, use the SSH command from the
+#. To connect to the devstack virtual machine, use the SSH command from the
    `devstack` directory.
 
    .. code-block:: bash
 
      vagrant ssh
 
-#. To use Devstack and perform any of the tasks described in this section, you
+#. To use devstack and perform any of the tasks described in this section, you
    must connect as the user **edxapp**.
 
    .. code-block:: bash
@@ -39,7 +39,7 @@ Connect to the Devstack Virtual Machine
 Set Up Ability to Preview Units (Mac/Linux Only)
 ****************************************************
 
-If you are installing Devstack on a Linux or Macintosh computer, in order to
+If you are installing devstack on a Linux or Macintosh computer, in order to
 use the preview feature in edX Studio, you must add the following line to the
 ``etc/hosts`` file.
 
@@ -52,7 +52,7 @@ Customize the Source Code Location
 ************************************
 
 You can customize the location of the edX source code that gets cloned when you
-provision Devstack. You may want to do this to have Devstack work with source
+provision devstack. You may want to do this to have devstack work with source
 code that already exists on your computer.
 
 By default, the source code location is the directory in which you run
@@ -66,13 +66,13 @@ cs_comments_service source code directories.
 Run the LMS on Devstack
 ************************************
 
-When you run the LMS on Devstack, the command updates requirements and
+When you run the LMS on devstack, the command updates requirements and
 compiles assets, unless you use the ``fast`` option.
 
 The command uses the file ``lms/envs/devstack.py``. This file
 overrides production settings for the LMS.
 
-To run the LMS on Devstack, follow these steps.
+To run the LMS on devstack, follow these steps.
 
 #. `Connect to the Devstack Virtual Machine`_.
 
@@ -99,13 +99,13 @@ To run the LMS on Devstack, follow these steps.
 Run Studio on Devstack
 ************************************
 
-When you run Studio on Devstack, the command updates requirements and compiles
+When you run Studio on devstack, the command updates requirements and compiles
 assets, unless you use the ``fast`` option.
 
-You run Studio on Devstack with the file ``cms/envs/devstack.py``. This file
+You run Studio on devstack with the file ``cms/envs/devstack.py``. This file
 overrides production settings for Studio.
 
-To run Studio on Devstack, follow these steps.
+To run Studio on devstack, follow these steps.
 
 #. `Connect to the Devstack Virtual Machine`_.
 
@@ -143,7 +143,7 @@ To view all available commands for Studio, enter the following command.
 Run Discussion Forums on Devstack
 ************************************
 
-To run discussion forums on Devstack, follow these steps.
+To run discussion forums on devstack, follow these steps.
 
 #. `Connect to the Devstack Virtual Machine`_.
 
@@ -180,7 +180,7 @@ at ``http://localhost:18080/``.
 Default Accounts on Devstack
 ************************************
 
-When you install Devstack, the following accounts are created.
+When you install devstack, the following accounts are created.
 
   .. list-table::
    :widths: 20 60

--- a/en_us/install_operations/source/dogwood.rst
+++ b/en_us/install_operations/source/dogwood.rst
@@ -103,14 +103,14 @@ See `BitTorrent`_ for more information.
 If you download the Vagrant box through BitTorrent, you must add the box to
 Vagrant before continuing with the installation process.
 
-* For Devstack installations, run the following command.
+* For devstack installations, run the following command.
 
    .. code-block:: bash
 
      $ vagrant box add /{path-to-downloaded-box}/{name-of-vagrant-box} --name dogwood-devstack
 
 
-* For Fullstack installations, run the following command.
+* For fullstack installations, run the following command.
 
    .. code-block:: bash
 
@@ -165,9 +165,9 @@ The ``migrate.sh`` script is in the configuration repository, `available here
 On the computer or virtual machine that is running the Cypress release of Open
 edX, run the upgrade script for your type of installation:
 
-* For Devstack, run ``./migrate.sh -c devstack -t named-release/dogwood``.
+* For devstack, run ``./migrate.sh -c devstack -t named-release/dogwood``.
 
-* For Fullstack, run
+* For fullstack, run
   ``./migrate.sh -c fullstack -t named-release/dogwood``.
 
 * You can also run ``./migrate.sh -h`` to see which other options the script

--- a/en_us/install_operations/source/fullstack/install_fullstack.rst
+++ b/en_us/install_operations/source/fullstack/install_fullstack.rst
@@ -4,7 +4,7 @@
 Installing Open edX Fullstack
 ####################################
 
-This section describes how to install the Open edX Fullstack.
+This section describes how to install the Open edX fullstack.
 
 .. contents::
    :local:
@@ -14,7 +14,7 @@ This section describes how to install the Open edX Fullstack.
 Overview
 **********
 
-Open edX Fullstack is a Vagrant instance designed for deploying all Open edX
+Open edX fullstack is a Vagrant instance designed for deploying all Open edX
 services on a single server.
 
 See the `Vagrant documentation`_ for more information.
@@ -23,7 +23,7 @@ See the `Vagrant documentation`_ for more information.
 Components
 ********************
 
-Open edX Fullstack includes the following edX components.
+Open edX fullstack includes the following edX components.
 
 * The Learning Management System (LMS).
 * EdX Studio.
@@ -38,7 +38,7 @@ Open edX Fullstack includes the following edX components.
 Knowledge Prerequisites
 **************************
 
-To use Fullstack, you should meet the following knowledge requirements.
+To use fullstack, you should meet the following knowledge requirements.
 
 * Understand basic terminal usage. If you are using a Mac computer, see
   `Introduction to the Mac OS X Command Line`_. If you are using a Windows
@@ -51,7 +51,7 @@ To use Fullstack, you should meet the following knowledge requirements.
 Software Prerequisites
 **************************
 
-To install and run Open edX Fullstack, you must first install the following
+To install and run Open edX fullstack, you must first install the following
 software.
 
 * `VirtualBox`_ 4.3.12 or higher
@@ -67,7 +67,7 @@ software.
 Install Open edX Fullstack
 *********************************
 
-To install Open edX Fullstack directly from the command line, follow the
+To install Open edX fullstack directly from the command line, follow the
 instructions below.
 
 Before beginning the installation, ensure that you have your local computer's
@@ -95,13 +95,13 @@ allow users to access code directories directly from your computer.
 
      vagrant plugin install vagrant-hostsupdater
 
-#. Create the Fullstack virtual machine.
+#. Create the fullstack virtual machine.
 
    .. code-block:: bash
 
      vagrant up
 
-   The first time you create the Fullstack virtual machine, Vagrant downloads
+   The first time you create the fullstack virtual machine, Vagrant downloads
    the base box, which has a file size of about 4GB. If you destroy and
    recreate the virtual machine, Vagrant re-uses the box it downloaded. See
    `Vagrant's documentation on boxes`_ for more information.
@@ -117,6 +117,6 @@ In your browser, go to ``preview.localhost``, which is an alias entry for
 
 The latest version of fullstack is preloaded with the demonstration course and
 the same set of :ref:`default user accounts<Default Accounts on Devstack>` that
-is created for Devstack.
+is created for devstack.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/install_options.rst
+++ b/en_us/install_operations/source/install_options.rst
@@ -14,12 +14,12 @@ This section describes the Open edX installation options.
 Open edX Developer Stack
 ***************************
 
-The Open edX Developer Stack, known as **Devstack**, is a Vagrant instance
+The Open edX Developer Stack, known as **devstack**, is a Vagrant instance
 designed for local development.
 
 Devstack is in the `edx configuration repository`_ on GitHub.
 
-This guide includes the following sections about Devstack:
+This guide includes the following sections about devstack:
 
 * :ref:`Installing the Open edX Developer Stack`
 
@@ -28,8 +28,8 @@ This guide includes the following sections about Devstack:
 Additional sections are planned for future versions of this guide.
 
 See the `edx configuration repository wiki`_ for information from edX and the
-Open edX community about Devstack and other installation and configuration
-options. This wiki contains pages with more information about Devstack.
+Open edX community about devstack and other installation and configuration
+options. This wiki contains pages with more information about devstack.
 
 * `Devstack wiki`_
 * `Developing on Devstack`_
@@ -45,7 +45,7 @@ analytics devstack:
 Open edX Fullstack
 *********************
 
-Open edX Fullstack, known as **Fullstack**, is a Vagrant instance designed for
+Open edX fullstack, known as **fullstack**, is a Vagrant instance designed for
 deploying all edX services on a single server.
 
 Fullstack is in the `edx configuration repository`_ on GitHub.
@@ -53,14 +53,14 @@ Fullstack is in the `edx configuration repository`_ on GitHub.
 This guide includes :ref:`Installing Open edX Fullstack`.
 
 See the `edx configuration repository wiki`_ for information from edX and the
-Open edX community on Fullstack and other installation and configuration
+Open edX community on fullstack and other installation and configuration
 options.
 
 ==================
 Ubuntu 12.04 64
 ==================
 
-You can install Fullstack on a single Ubuntu 12.04 64-bit server.
+You can install fullstack on a single Ubuntu 12.04 64-bit server.
 
 Ubuntu information is planned for future versions of this guide.
 

--- a/en_us/shared/preface.rst
+++ b/en_us/shared/preface.rst
@@ -265,8 +265,8 @@ Documentation for developers is available on the `docs.edx.org`_ web page.
   the edX public sandboxes, instrumenting analytics, and testing.
 
 * `Installing, Configuring, and Running the edX Platform`_ provides procedures
-  for getting an edX developer stack (Devstack) and production stack
-  (Fullstack) operational.
+  for getting an edX developer stack (devstack) and production stack
+  (fullstack) operational.
 
 * `Open edX XBlock Tutorial`_ guides developers through the process of
   creating an XBlock, and explains the concepts and anatomy of XBlocks.
@@ -361,7 +361,7 @@ is available.
   needed in course updates or discussions.
 
 * `Installing, Configuring, and Running the edX Platform`_ provides
-  information about installing and using Devstack and Fullstack.
+  information about installing and using devstack and fullstack.
 
 * The `edX Platform Developer's Guide`_ includes guidelines for
   contributing to Open edX, options for extending the Open edX platform, using

--- a/en_us/xblock-tutorial/source/edx_platform/devstack.rst
+++ b/en_us/xblock-tutorial/source/edx_platform/devstack.rst
@@ -4,13 +4,13 @@
 Deploy Your XBlock in Devstack
 ###############################
 
-This section provides instructions for deploying your XBlock in Devstack.
+This section provides instructions for deploying your XBlock in devstack.
 
 .. contents::
  :local:
  :depth: 1
 
-For more information about Devstack, see the :ref:`installation:Installing,
+For more information about devstack, see the :ref:`installation:Installing,
 Configuring, and Running the Open edX Platform`.
 
 *******************
@@ -24,23 +24,23 @@ requirements are met.
   the Open edX Developer Stack`.
 
 * Ensure you have the XBlock directory in a location you can access from the
-  Devstack Vagrant instance.
+  devstack Vagrant instance.
 
 *******************
 Install the XBlock
 *******************
 
-#. Use SSH to access the Devstack Vagrant instance.
-      
+#. Use SSH to access the devstack Vagrant instance.
+
    .. code-block:: bash
 
       $ vagrant ssh
 
 #. Install the XBlock.
-   
+
    .. code-block:: bash
 
-      vagrant@precise64:~$ sudo -u edxapp /edx/bin/pip.edxapp install /path/to/your/block 
+      vagrant@precise64:~$ sudo -u edxapp /edx/bin/pip.edxapp install /path/to/your/block
 
 **************************************
 Enable the XBlock in the edX Platform
@@ -57,25 +57,25 @@ Enable the XBlock in the edX Platform
    are not commented out::
 
      from xmodule.x_module import prefer_xmodules
-     XBLOCK_SELECT_FUNCTION = prefer_xmodules 
+     XBLOCK_SELECT_FUNCTION = prefer_xmodules
 
 #. In ``edx-platform/cms/envs/common.py``, change the
    ``'ALLOW_ALL_ADVANCED_COMPONENTS'`` value to ``True``.::
 
-     'ALLOW_ALL_ADVANCED_COMPONENTS': True, 
+     'ALLOW_ALL_ADVANCED_COMPONENTS': True,
 
 ************************
 Start the LMS and Studio
 ************************
 
 #. Start the LMS server.
-      
+
    .. code-block:: bash
 
       edxapp@precise64:~$ paver devstack lms
 
 #. Start the Studio server.
-      
+
    .. code-block:: bash
 
       edxapp@precise64:~$ paver devstack studio
@@ -89,11 +89,11 @@ You must enable the XBlock in each course in which you intend to use it.
 #.  Log in to Studio.
 
 #.  Open the course.
-    
+
 #. From the **Settings** menu, select **Advanced Settings**.
 
 #. In the **Advanced Module List** field, place your cursor between the braces,
-   and then type the exact name of the XBlock. 
+   and then type the exact name of the XBlock.
 
    .. note::
      The name you enter must match exactly the name specified in your XBlock's
@@ -101,7 +101,7 @@ You must enable the XBlock in each course in which you intend to use it.
 
    If you see other values in the **Advanced Module List** field, add a comma
    after the closing quotation mark for the last value, and then type the name
-   of your XBlock.   
+   of your XBlock.
 
 #. At the bottom of the page, select **Save Changes**.
 
@@ -111,7 +111,7 @@ Add an Instance of the XBlock to a Unit
 
 You can add instances of the XBlock in any unit in the course.
 
-On the unit page, under **Add New Component**, select **Advanced**. 
+On the unit page, under **Add New Component**, select **Advanced**.
 
 Your XBlock is listed as one of the types you can add.
 


### PR DESCRIPTION
## [DOC-2604](https://openedx.atlassian.net/browse/DOC-2604)

I revised the installation instructions for devstack. The procedure for using a torrent file was missing some steps. I also updated the non-torrent instructions. This documentation section came up in Slack discussions twice lately.
### Reviewers
- [ ] Subject matter expert: @feanil 
- [ ] Subject matter expert: @nedbat 
- [ ] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @srpearce @catong 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] http://draft-devstack-install.readthedocs.org/en/latest/devstack/install_devstack.html#install-devstack
- [ ] http://draft-devstack-install.readthedocs.org/en/latest/devstack/install_devstack.html#install-devstack-using-the-torrent-file 
### Post-review
- [x] Squash commits
