### PR TITLE
Remove references to deprecated Randomize XBlock

### DIFF
--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -4,6 +4,12 @@
 
 .. EdX Links
 
+.. _Using edX Insights: http://edx.readthedocs.org/projects/edx-insights/en/latest/
+
+.. _Review Answers to Graded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Answers.html#review-answers-to-graded-problems
+
+.. _Review Answers to Ungraded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Ungraded.html#review-answers-to-ungraded-problems
+
 .. _Open edX Analytics wiki: http://edx-wiki.atlassian.net/wiki/display/OA/Open+edX+Analytics+Home
 
 .. _Entity Relationship Diagram for ORA Data: https://openedx.atlassian.net/wiki/display/AN/Entity+Relationship+Diagram+for+ORA+Data

--- a/en_us/olx/source/problem-xml/create_problem.rst
+++ b/en_us/olx/source/problem-xml/create_problem.rst
@@ -112,9 +112,10 @@ All problems on the edX platform have several component parts.
 There are also some attributes of problems that are not immediately
 visible. You can set these attributes in Studio.
 
-*  **Randomization.** For some problems, you can specify
-   whether a problem will use randomly generated numbers that vary from
-   learner to learner.
+*  **Randomization.** In certain types of problems, you can include a Python
+   script to randomize the values that are presented to learners. You use this
+   setting to define when values are randomized. For more information, see
+   :ref:`Randomization`.
 
 *  **Weight.** Different problems in a particular problem set can be
    given different weights.
@@ -262,50 +263,75 @@ answers, the learner's score is 0.5 out of 2 points.
 Randomization
 ===============
 
-This setting specifies whether certain values in your problem change each time
-a different learner accesses the problem, or each time a single learner tries
-to answer the problem. For example, the highlighted values in the problem below
-change each time a learner submits an answer to the problem.
+.. note:: The **Randomization** setting serves a different purpose from
+ "problem randomization". The **Randomization** setting affects how numeric
+ values are randomized within a single problem and requires the inclusion of a
+ Python script. Problem randomization offers different problems or problem
+ versions to different learners. For more information, see :ref:`Problem
+ Randomization`.
+
+For problems that include a Python script to generate numbers randomly, this
+setting specifies how frequently the values in the problem change: each time a
+different learner accesses the problem, each time a single learner tries to
+answer the problem, both, or never.
+
+.. note:: This setting should only be set to an option other than **Never**
+ for problems that are configured to do random number generation.
+
+For example, in this problem, the highlighted values change each time a learner
+submits an answer to the problem.
 
 .. image:: ../../../shared/images/Rerandomize.png
- :alt: The same problem shown twice, with color highlighting on values that
-       can change
+ :alt: An image of the same problem shown twice, with color highlighting on
+   values that change.
+ :width: 800
 
-If you want to change, or "randomize," specific values in your problem, you
-have to complete both of the following settings.
+If you want to randomize numeric values in a problem, you complete both of
+these steps.
 
-* Make sure that your problem contains a Python script that randomizes the
-  values that you want.
+* Make sure that you edit your problem to include a Python script that randomly
+  generates numbers.
 
-* Enable randomization in the Problem component.
+* Select an option other than **Never** for the **Randomization** setting.
 
-.. note:: Note that specifying this **Randomization** setting is different
- from *problem randomization*. The **Randomization** setting randomizes
- variables within a single problem. Problem randomization offers different
- problems or problem versions to different learners. For more information, see
- :ref:`Problem Randomization`.
+..  For more information, see :ref:`Use Randomization in a Numerical Input Problem`.
+..  ^^ add back to first bullet when DOC-2175 gets done - Alison 30 Jul 15
 
-To enable randomization, select an option for the **Randomization** setting.
-This setting has the following options.
+The edX Platform has a 20-seed maximum for randomization. This means that
+learners see up to 20 different problem variants for every problem that has
+**Randomization** set to an option other than **Never**. It also means that
+every answer for the 20 different variants is reported by the Answer
+Distribution report and edX Insights. Limiting the number of variants to a
+maximum of 20 allows for better analysis of learner submissions by allowing you
+to detect common incorrect answers and usage patterns for such answers.
 
-+-------------------+--------------------------------------+
-| **Always**        | Learners see a different version of  |
-|                   | the problem each time they select    |
-|                   | **Check**.                           |
-+-------------------+--------------------------------------+
-| **On Reset**      | Learners see a different version of  |
-|                   | the problem each time they select    |
-|                   | **Reset**.                           |
-+-------------------+--------------------------------------+
-| **Never**         | All learners see the same version    |
-|                   | of the problem. This is the default. |
-+-------------------+--------------------------------------+
-| **Per Student**   | Individual learners see the same     |
-|                   | version of the problem each time     |
-|                   | they look at it, but that version    |
-|                   | is different from the version that   |
-|                   | other learners see.                  |
-+-------------------+--------------------------------------+
+For more information, see :ref:`Student_Answer_Distribution` in this guide, and
+`Review Answers to Graded Problems`_ or `Review Answers to Ungraded Problems`_
+in *Using edX Insights*.
+
+You can choose the following options for the **Randomization** setting.
+
+.. list-table::
+   :widths: 15 70
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - **Always**
+     - Learners see a different version of the problem each time they select
+       Check.
+   * - **On Reset**
+     - Learners see a different version of the problem each time they select
+       Reset.
+   * - **Never**
+     - All learners see the same version of the problem. For most courses, this
+       option is supplied by default. Select this option for every problem in
+       your course that does not include a Python script to generate random
+       numbers.
+   * - **Per Student**
+     - Individual learners see the same version of the problem each time they
+       look at it, but that version is different from the version that other
+       learners see.
 
 
 You set value randomization as an attribute of the ``problem`` element.
@@ -314,7 +340,7 @@ You set value randomization as an attribute of the ``problem`` element.
 
   <problem rerandomize="always" . . . >
 
-.. note:: The edX Platform has a 20-seed limit for randomization.
+
 
 .. _Show Answer:
 
@@ -511,60 +537,38 @@ answers for all the problems in the component appear.
 
 .. _Problem Randomization:
 
-===========================
+***********************************
 Problem Randomization
-===========================
+***********************************
 
-You can present different learners with different problems, or different
-versions of the same problem. To do this, you create a ``problem`` element for
-each problem or version in Studio, and then edit your course outside of Studio
-to randomize the problem that learners see.
+Presenting different learners with different problems or with different
+versions of the same problem is referred to as "problem randomization".
 
-Note that *problem randomization* is different from the **Randomization**
-setting in Studio. The **Randomization** setting randomizes variables within a
-single problem. Problem randomization offers different problems or problem
-versions to different learners.
+You can provide different learners with different problems by using randomized
+content blocks, which randomly draw problems from pools of problems stored in
+content libraries. For more information, see :ref:`Randomized Content Blocks`.
+
+.. note:: Problem randomization is different from the **Randomization** setting
+   in Studio. Problem randomization offers different problems or problem
+   versions to different learners, whereas the **Randomization** setting
+   controls when a Python script randomizes the variables within a single
+   problem. For more information about the **Randomization** setting, see
+   :ref:`Randomization`.
 
 
 .. _Create Randomized Problems:
 
+====================================
 Create Randomized Problems
-****************************
+====================================
 
-#. Create a separate ``problem`` element component for each version or problem
-   that you want to randomize. For example, if you want to offer four versions
-   or problems, you'll create four separate ``problem`` elements. Make a note
-   of the 32-digit unit ID that appears in the **Unit Identifier** field under
-   **Unit Location**.
+.. note:: Creating randomized problems by exporting your course and editing
+   some of your course's XML files is no longer supported.
 
-#. Open the ``vertical`` element that contains the randomized problems.
-
-   The file contains a list of all the components in the unit, together with
-   the URL names of the components. For example, the following file contains
-   four ``problem`` elements.
-
-   .. code-block:: xml
-
-       <vertical display_name="Test Unit">
-          <problem url_name="random_problem_1"/>
-          <problem url_name="random_problem_2"/>
-          <problem url_name="random_problem_3"/>
-          <problem url_name="random_problem_4"/>
-       </vertical>
-
-#. Add ``<randomize> </randomize>`` tags around the components for the problems
-   that you want to randomize.
-
-   .. code-block:: xml
-
-       <vertical display_name="Test Unit">
-         <randomize>
-            <problem url_name="d9d0ceb3ffc74eacb29501183e26ad6e"/>
-            <problem url_name="ea66d875f4bf4a9898d8e6d2cc9f3d6f"/>
-            <problem url_name="2616cd6324704f85bc315ec46521485d"/>
-            <problem url_name="88987707294d4ff0ba3b86921438d0c0"/>
-         </randomize>
-       </vertical>
+You can provide different learners with different problems by using randomized
+content blocks, which randomly draw problems from pools of problems stored in
+content libraries. For more information, see
+:ref:`partnercoursestaff:Randomized Content Blocks`.
 
 .. include:: ../../../shared/exercises_tools/Section_adding_tooltip.rst
 

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -418,6 +418,13 @@ answers, the learner's score is 0.5 out of 2 points.
 Randomization
 ===============
 
+.. note:: The **Randomization** setting serves a different purpose from
+ "problem randomization". The **Randomization** setting affects how numeric
+ values are randomized within a single problem and requires the inclusion of a
+ Python script. Problem randomization offers different problems or problem
+ versions to different learners. For more information, see :ref:`Problem
+ Randomization`.
+
 For problems that include a Python script to generate numbers randomly, this
 setting specifies how frequently the values in the problem change: each time a
 different learner accesses the problem, each time a single learner tries to
@@ -440,18 +447,10 @@ these steps.
 * Make sure that you edit your problem to include a Python script that randomly
   generates numbers.
 
-..  For more information, see :ref:`Use Randomization in a
-  Numerical Input Problem`.
-.. ^^ add back when DOC-2175 gets done - Alison 30 Jul 15
-
 * Select an option other than **Never** for the **Randomization** setting.
 
-.. note:: The **Randomization** setting serves a different purpose from
- "problem randomization". The **Randomization** setting affects how numeric
- values are randomized within a single problem and requires the inclusion of a
- Python script. Problem randomization offers different problems or problem
- versions to different learners. For more information, see :ref:`Problem
- Randomization`.
+..  For more information, see :ref:`Use Randomization in a Numerical Input Problem`.
+..  ^^ add back to first bullet when DOC-2175 gets done - Alison 30 Jul 15
 
 The edX Platform has a 20-seed maximum for randomization. This means that
 learners see up to 20 different problem variants for every problem that has
@@ -674,6 +673,7 @@ answers for all the problems in the component appear.
 
 .. include:: ../../../shared/exercises_tools/Section_partial_credit.rst
 
+
 .. _Problem Randomization:
 
 ***********************************
@@ -683,22 +683,17 @@ Problem Randomization
 Presenting different learners with different problems or with different
 versions of the same problem is referred to as "problem randomization".
 
-To use problem randomization, you first create a problem component in Studio
-for each of the problems or versions you want to include. You then edit your
-course outside of Studio, using OLX, to randomize the problem that learners
-see. For more information, see :ref:`Create Randomized Problems`.
+You can provide different learners with different problems by using randomized
+content blocks, which randomly draw problems from pools of problems stored in
+content libraries. For more information, see :ref:`Randomized Content Blocks`.
 
-Note that problem randomization is different from the **Randomization**
-setting in Studio. Problem randomization offers different problems or problem
-versions to different learners, whereas the **Randomization** setting controls
-when a Python script randomizes the variables within a single problem. For
-more information about the **Randomization** setting, see
-:ref:`Randomization`.
+.. note:: Problem randomization is different from the **Randomization** setting
+   in Studio. Problem randomization offers different problems or problem
+   versions to different learners, whereas the **Randomization** setting
+   controls when a Python script randomizes the variables within a single
+   problem. For more information about the **Randomization** setting, see
+   :ref:`Randomization`.
 
-Another method of providing different learners with different problems is to
-use randomized content blocks, which randomly draw problems from pools of
-problems stored in content libraries. For more information, see
-:ref:`Randomized Content Blocks`.
 
 
 ============================================
@@ -736,91 +731,15 @@ contains. To find a unit, look in the **Vertical** directory.
 Create Randomized Problems
 ==========================
 
-.. note:: Creating problems with versions that can be randomized requires you
-   to export your course, edit some of your course's XML files in a text
-   editor, and then re-import your course. We recommend that you create a
-   backup copy of your course before you do this. We also recommend that you
-   edit your course files in the text editor only if you are very familiar
-   with editing XML.
+.. note:: Creating randomized problems by exporting your course and editing
+   some of your course's XML files is no longer supported.
 
-#. In the unit where you want to create a randomized problem, create a separate
-   problem component for each version or problem that you want to randomize.
-   For example, if you want to offer four versions or problems, create
-   four separate problem components. Make a note of the 32-digit unit ID that
-   appears in the **Unit Identifier** field under **Unit Location**.
+You can provide different learners with different problems by using randomized
+content blocks, which randomly draw problems from pools of problems stored in
+content libraries. For more information, see
+:ref:`partnercoursestaff:Randomized Content Blocks`.
 
-#. Export your course. For more information, see
-   :ref:`Exporting and Importing a Course`. Save and extract the .tar.gz file
-   that contains your course in a memorable location so that you can find
-   it easily.
-
-#. In the list of directories and files, open the **Vertical** directory.
-
-   .. note:: If your unit is not published, open the **Drafts** directory, and
-    then open the **Vertical** directory in the **Drafts** folder.
-
-#. In the **Vertical** folder, locate the .xml file that has the same name as
-   the unit ID that you noted in step 1, and then open the file in a text
-   editor such as Sublime. For example, if the unit ID is
-   ``e461de7fe2b84ebeabe1a97683360d31``, open the
-   ``e461de7fe2b84ebeabe1a97683360d31.xml`` file.
-
-   The file contains a list of all the components in the unit, together with
-   the URL names of the components. For example, the following file contains
-   four problem components.
-
-   .. code-block:: xml
-
-       <vertical display_name="Test Unit">
-          <problem url_name="d9d0ceb3ffc74eacb29501183e26ad6e"/>
-          <problem url_name="ea66d875f4bf4a9898d8e6d2cc9f3d6f"/>
-          <problem url_name="2616cd6324704f85bc315ec46521485d"/>
-          <problem url_name="88987707294d4ff0ba3b86921438d0c0"/>
-       </vertical>
-
-#. Add ``<randomize> </randomize>`` tags around the components for the problems
-   that you want to randomize.
-
-   .. code-block:: xml
-
-       <vertical display_name="Test Unit">
-         <randomize>
-            <problem url_name="d9d0ceb3ffc74eacb29501183e26ad6e"/>
-            <problem url_name="ea66d875f4bf4a9898d8e6d2cc9f3d6f"/>
-            <problem url_name="2616cd6324704f85bc315ec46521485d"/>
-            <problem url_name="88987707294d4ff0ba3b86921438d0c0"/>
-         </randomize>
-       </vertical>
-
-#. After you add the ``<randomize> </randomize>`` tags, save and close the .xml
-   file.
-
-#. Re-package your course as a .tar.gz file.
-
-   For information about how to do this on a Mac, see `How to Create a Tar GZip
-   File from the Command Line <http://osxdaily.com/2012/04/05/create-tar-gzip/>`_.
-
-   For information about how to do this on a Windows computer, see `How to Make
-   a .tar.gz on Windows <http://stackoverflow.com/questions/12774707/how-to-make-a-tar-gz-on-windows>`_.
-
-#. In Studio, re-import your course.
-
-.. note::
-
-  * After you implement randomization, you can only see one of the versions or
-    problems in Studio. You can edit that single problem directly in Studio,
-    but to edit any of the other problems, you must export your course, edit
-    the problems in a text editor, and then re-import the course. The same
-    procedure applies to all course team members, regardless of their assigned
-    roles.
-
-  * A .csv file for learner responses contains the responses to each of the
-    problems in the problem bank.
 
 .. include:: ../../../shared/exercises_tools/Section_adding_tooltip.rst
 
-.. _Using edX Insights: http://edx.readthedocs.org/projects/edx-insights/en/latest/
-
-.. _Review Answers to Graded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Answers.html#review-answers-to-graded-problems
-
-.. _Review Answers to Ungraded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Ungraded.html#review-answers-to-ungraded-problems
+.. include:: ../../../links/links.rst


### PR DESCRIPTION
## [DOC-2695](https://openedx.atlassian.net/browse/DOC-2695)

Remove references to deprecated Randomize XBlock and methods of creating randomized problems by exporting a course and editing XML files. Provide pointers instead to supported Randomized Content Blocks. (https://openedx.atlassian.net/browse/TNL-3203, https://openedx.atlassian.net/browse/TNL-4109)
### Date Needed: Wednesday Feb 24

The feature is deprecated as of Wed Feb 24 release.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer
finishes and gives :+1:. 
- [x] Subject matter expert: @symbolist 
- [x] Doc team review (sanity check): @lamagnifica @pdesjardins or @srpearce 
- [ ] Product review: @scottrish 

FYI 
@jaakana
@sstack22
### Draft HTML Version
- [x] http://draft-br-deprecated-randomize.readthedocs.org/en/latest/course_components/create_problem.html#problem-randomization
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [x] Squash commits
