### PR TITLE
Add CERTIFICATES_ENABLED mention to instructions on enabling certs...

### DIFF
--- a/en_us/install_operations/source/configuration/enable_certificates.rst
+++ b/en_us/install_operations/source/configuration/enable_certificates.rst
@@ -37,12 +37,13 @@ To enable certificates, you modify the ``lms.env.json`` and ``cms.env.json``
 files, which are located one level above the ``edx-platform`` directory.
 
 #. In the ``lms.env.json`` and ``cms.env.json`` files, set the value of
-   ``CERTIFICATES_HTML_VIEW`` within the ``FEATURES`` object  to ``true``.
+   ``CERTIFICATES_ENABLED`` and ``CERTIFICATES_HTML_VIEW`` within the ``FEATURES`` object  to ``true``.
 
    .. code-block:: bash
 
      "FEATURES": {
          ...
+         'CERTIFICATES_ENABLED': true,
          'CERTIFICATES_HTML_VIEW': true,
          ...
      }


### PR DESCRIPTION
It seems there are two variables that need to be set for certificates to be enabled: CERTIFICATES_ENABLED and CERTIFICATES_HTML_VIEW.

Interestingly, the edxapp role in configuration [has CERTIFICATES_ENABLED set to true](https://github.com/edx/configuration/blob/a514fb9c9fc4315f7309cac8f768a3551f1ef223/playbooks/roles/edxapp/defaults/main.yml#L179), but doesn't have a default for CERTIFICATES_HTML_VIEW.

Meanwhile, the documentation [mentions CERTIFICATES_HTML_VIEW](http://edx.readthedocs.org/projects/open-edx-icr/en/named-release-dogwood.rc/configuration/enable_certificates.html) but doesn't mention CERTIFICATES_ENABLED. So, the reader may be confused between the meanings/purpose of these two similar variables. (Are they both needed? Are both to be set as true?).

Therefore, this PR assumes they are both needed for certificates to be enabled, and therefore the docs should specifically mention both and that they need to be set to true, regardless of which ones have been previously set by the edxapp role.
