### PR TITLE
DOC-2740: Fix description of Scored field

### DIFF
--- a/en_us/shared/exercises_tools/randomized_content_blocks.rst
+++ b/en_us/shared/exercises_tools/randomized_content_blocks.rst
@@ -117,9 +117,9 @@ component.
     indicate whether the assignment should be graded.
 
   .. note:: Grading is subject to the setting of this unit's subsection or
-   section. If the subsection or section is not graded, selecting **True** here
-   has no impact. Selecting **False** means that this assignment is not graded
-   even if the subsection or section is graded.
+     section. If the subsection or section is not graded, selecting **True**
+     here has no impact. If the subsection or section is graded, this assignment
+     is graded, even if you have selected **False**.
 
 #. Select **Save** when you have finished specifying the details of your
    randomized content block.


### PR DESCRIPTION
## [DOC-2740](https://openedx.atlassian.net/browse/DOC-2740)

Fixes the description of the Scored field in the randomized content blocks topic to correctly describe that the Scored value is subject to the graded setting of the subsection or section.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer
finishes and gives :+1:. 
- [x] Subject matter expert: @bradenmacdonald 
- [x] Doc team review (sanity check): @srpearce @lamagnifica or @pdesjardins 
- [ ] Product review: @scottrish (FYI)
- [ ] Partner support: @jaakana
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment - NA
- [ ] Squash commits
