### PR TITLE
DOC-2745: Add notes re only one ORA component per unit

### DIFF
--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -32,6 +32,9 @@ Step 1. Create the Component
 To create the component for your open response assessment, complete these
 steps.
 
+.. note:: Do not add more than one ORA component in a course unit. Multiple ORA
+   assignments in a unit cause errors when learners submit their assessments.
+
 #. In Studio, open the unit where you want to create the open response
    assessment.
 

--- a/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
+++ b/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
@@ -79,6 +79,9 @@ subjective assessments of text, images, or other contributions, but they might
 not be the ideal tool in chemistry assignments where there are definitively
 correct or incorrect answers to questions.
 
+.. note:: Do not add more than one ORA component in a course unit. Multiple ORA
+   assignments in a unit cause errors when learners submit their assessments.
+
 EdX suggests that you follow these guidelines and best practices when you use
 open response assessments in your courses.
 


### PR DESCRIPTION
## [DOC-2745](https://openedx.atlassian.net/browse/DOC-2745)

(in response to https://openedx.atlassian.net/browse/TNL-4155)
Add notes to ORA content indicating that only one ORA component should be added in each course unit.
### Date Needed: March 3, 2016
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer
finishes and gives :+1:. 
- [x] Subject matter expert: @jaakana
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica or @srpearce or @pdesjardins 
- [x] Product review: @scottrish 

FYI: @sstack22, @cahrens
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add description to release notes task as a comment
- [ ] Squash commits
