### PR TITLE
Add NA info for Verification Status column of grade report

### DIFF
--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -200,6 +200,8 @@ columns that provide the following information.
   in the verified or professional tracks. The value in this column indicates
   whether the verified or professional education learner has verified her
   identity to edX by using a webcam to submit her photo and an official ID.
+  The value is "N/A" for learners who are not in the verified or professional
+  tracks.
 
 * The **Certificate Eligible** column indicates whether a learner is eligible
   for a certificate for your course. The value in this column is "Y" for


### PR DESCRIPTION
## [DOC-2050](https://openedx.atlassian.net/browse/DOC-2050)

Add information about when an "N/A" value appears in the Verification Status column of the grade report.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer
finishes and gives :+1:. 
- [x] Doc team review (sanity check/copy edit/dev edit): @srpearce @lamagnifica or @pdesjardins 

FYI
Partner support: @jaakana
Product: @scottrish @marcotuts 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
