### PR TITLE
DOC-1184: In content experiment doc, add xref to grade report info

### DIFF
--- a/en_us/shared/course_features/content_experiments/content_experiments_overview.rst
+++ b/en_us/shared/course_features/content_experiments/content_experiments_overview.rst
@@ -20,10 +20,14 @@ experiments enable you to research and compare the performance of learners in
 different groups to gain insight into the relative effectiveness of your course
 content.
 
-Information on analyzing events from content experiments is included in the
-`edX Researcher Guide`_.
+If your course uses content experiments, the grade report that you generate
+from the Instructor Dashboard includes a column identifying the experiment
+group that each learner has been assigned to. For more information, see
+:ref:`Interpret the Grade Report`.
 
-.. _edX Researcher Guide: http://edx.readthedocs.org/projects/devdata/en/latest/internal_data_formats/tracking_logs.html#a-b-testing-events
+For information about analyzing events from content experiments, see
+:ref:`data:AB_Event_Types` in the *EdX Research Guide*.
+
 
 .. _Courses with Multiple Content Experiments:
 

--- a/en_us/shared/students/Section_register_account.rst
+++ b/en_us/shared/students/Section_register_account.rst
@@ -30,5 +30,3 @@
 
 You can modify your account information, reset your password, and link or
 unlink accounts on the :ref:`account settings<SFD Account Settings>` page.
-
-.. include:: ../../links/links.rst


### PR DESCRIPTION
## [DOC-1184](https://openedx.atlassian.net/browse/DOC-1184)

Adds a cross reference from the content experiment overview topic to the grade report info within the same guide. Also cleans up the ref format to a link in the Research Guide.
### Reviewers
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
