### PR TITLE
DOC: Add anchor to Django file in Dev guide

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -1327,7 +1327,7 @@ than for the other videos in the course. This section presents the pre-roll
 video events alphabetically.
 
 For more information about pre-roll videos, see :ref:`partnercoursestaff:Adding
-a Pre-Roll Video` in the *Building and Running an edX Course* guide.
+a PreRoll Video` in the *Building and Running an edX Course* guide.
 
 **Component**: Video
 

--- a/en_us/developers/source/conventions/django.rst
+++ b/en_us/developers/source/conventions/django.rst
@@ -1,3 +1,5 @@
+.. _Django Good Practices:
+
 *********************
 Django Good Practices
 *********************

--- a/en_us/release_notes/source/2015/documentation/doc_0610_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0610_2015.rst
@@ -6,7 +6,7 @@ Building and Running an edX Course
 **********************************
 
 The :ref:`partnercoursestaff:Working with Video Components` section now
-includes an :ref:`partnercoursestaff:Adding a Pre-Roll Video` topic.
+includes an :ref:`partnercoursestaff:Adding a PreRoll Video` topic.
 
 EdX Research Guide
 **********************************

--- a/en_us/release_notes/source/2015/lms/lms_0610_2015.rst
+++ b/en_us/release_notes/source/2015/lms/lms_0610_2015.rst
@@ -1,6 +1,6 @@
 
 ====================================
-Report of Not-Yet-Enrolled Students 
+Report of Not-Yet-Enrolled Students
 ====================================
 
 Course teams for invitation-only courses can now track enrollment status from
@@ -22,4 +22,4 @@ to the video that they selected, or **Do not show again** to permanently opt
 out of seeing pre-roll videos in the course.
 
 For information about how course teams can add a pre-roll video and its
-transcripts to a course, see :ref:`partnercoursestaff:Adding a Pre-Roll Video` in *Building and Running an edX Course*.
+transcripts to a course, see :ref:`partnercoursestaff:Adding a PreRoll Video` in *Building and Running an edX Course*.

--- a/en_us/release_notes/source/2015/studio/studio_0610_2015.rst
+++ b/en_us/release_notes/source/2015/studio/studio_0610_2015.rst
@@ -17,4 +17,4 @@ can be used to advertise your organization, promote an XSeries, publicize an
 event, and so on.
 
 For information about adding a pre-roll video and its transcripts to your
-course, see :ref:`partnercoursestaff:Adding a Pre-Roll Video` in *Building and Running an edX Course*.
+course, see :ref:`partnercoursestaff:Adding a PreRoll Video` in *Building and Running an edX Course*.


### PR DESCRIPTION
This PR adds an anchor/label to the top of the Django file in the Developer's Guide, to allow linking using intersphinx mapping. Also fixes broken xrefs causing Travis test failures.

@lamagnifica for sanity check.
