### PR TITLE
Fixing links that seem to have been introduced by the ICR guide reorganization

### DIFF
--- a/en_us/install_operations/source/front_matter/change_log.rst
+++ b/en_us/install_operations/source/front_matter/change_log.rst
@@ -96,6 +96,6 @@ For information about changes made to the edX documentation set, the
      - Added the section :ref:`Installing Open edX Fullstack`.
    * - 21 May 2014
      - The initial release of this guide, with the sections :ref:`Installing
-       the Open edX Developer Stack` and :ref:`Running the Open edX Developer
+       the Open edX Developer Stack` and :ref:`Starting the Open edX Developer
        Stack`.
 

--- a/en_us/install_operations/source/installation/analytics/troubleshooting_vm_installation.rst
+++ b/en_us/install_operations/source/installation/analytics/troubleshooting_vm_installation.rst
@@ -1,1 +1,7 @@
+.. _troubleshooting_analytics_devstack_installation:
+
+***********************************************
+Troubleshooting Analytics Devstack Installation
+***********************************************
+
 .. include:: ../../../../shared/installation/troubleshooting_vm_installation.rst

--- a/en_us/install_operations/source/installation/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/installation/devstack/install_devstack.rst
@@ -1,4 +1,4 @@
-.. _Installing the Open edX Developer Stack:
+.. _Installing the Open edX Developer stack:
 
 ########################################
 Installing Open edX Devstack
@@ -76,8 +76,9 @@ computer.
 
       export OPENEDX_RELEASE="named-release/dogwood"
 
-    If you do not set this environment variable, Vagrant will install the
-    most recent snapshot version of the Open edX platform. The snapshot version is not a supported release.
+    If you do not set this environment variable, Vagrant will install the most
+    recent snapshot version of the Open edX platform. The snapshot version is
+    not a supported release.
 
 #. Create and start the devstack virtual machine.
 
@@ -92,11 +93,11 @@ computer.
 
    When prompted, enter the administrator password for your local computer.
 
-When you have completed these steps, see :ref:`Running the Open edX Developer
+When you have completed these steps, see :ref:`Starting the Open edX Developer
 Stack` to begin using devstack.
 
-For help with the devstack installation, see :ref:`Troubleshooting the Devstack
-Installation`.
+For help with the devstack installation, see
+:ref:`troubleshooting_devstack_installation`.
 
 .. _install_devstack_with_torrent_file:
 
@@ -197,10 +198,10 @@ client, follow these steps.
 
    When prompted, enter the administrator password for your local computer.
 
-When you have completed these steps, see :ref:`Running the Open edX Developer
+When you have completed these steps, see :ref:`Starting the Open edX Developer
 Stack` to begin using devstack.
 
-For help with the devstack installation, see :ref:`Troubleshooting the Devstack
-Installation`.
+For help with the devstack installation, see
+:ref:`troubleshooting_devstack_installation`.
 
 .. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/installation/devstack/troubleshooting_vm_installation.rst
+++ b/en_us/install_operations/source/installation/devstack/troubleshooting_vm_installation.rst
@@ -1,1 +1,7 @@
+.. _troubleshooting_devstack_installation:
+
+*************************************
+Troubleshooting Devstack Installation
+*************************************
+
 .. include:: ../../../../shared/installation/troubleshooting_vm_installation.rst

--- a/en_us/install_operations/source/installation/fullstack/troubleshooting_vm_installation.rst
+++ b/en_us/install_operations/source/installation/fullstack/troubleshooting_vm_installation.rst
@@ -1,1 +1,7 @@
+.. _troubleshooting_fullstack_installation:
+
+**************************************
+Troubleshooting Fullstack Installation
+**************************************
+
 .. include:: ../../../../shared/installation/troubleshooting_vm_installation.rst

--- a/en_us/install_operations/source/platform_releases/birch.rst
+++ b/en_us/install_operations/source/platform_releases/birch.rst
@@ -53,7 +53,8 @@ The following Open edX Git repositories have the Git tag **named-release/birch.2
 Installing the Birch Release
 ******************************
 
-You can install the Open edX Birch release using :ref:`Devstack <Install DevStack>` or :ref:`Fullstack <Install Open edX Fullstack>`.
+You can install the Open edX Birch release using :ref:`Devstack <Installing the
+Open edX Developer stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
 
 Review the prerequisites and instructions for each option, then choose the
 option that best meets your needs. Ensure you install the required software to

--- a/en_us/install_operations/source/platform_releases/cypress.rst
+++ b/en_us/install_operations/source/platform_releases/cypress.rst
@@ -52,8 +52,8 @@ Installing the Cypress Release
 ******************************
 
 You can install the Open edX Cypress release using
-:ref:`Devstack <Install DevStack>` or
-:ref:`Fullstack <Install Open edX Fullstack>`.
+:ref:`Devstack <Installing the Open edX Developer stack>` or
+:ref:`Fullstack <Installing Open edX Fullstack>`.
 
 Review the prerequisites and instructions for each option, and then choose the
 option that best meets your needs. Ensure that you install the

--- a/en_us/install_operations/source/platform_releases/dogwood.rst
+++ b/en_us/install_operations/source/platform_releases/dogwood.rst
@@ -47,8 +47,8 @@ The following Open edX Git repositories have the Dogwood Git tag.
 Installing the Dogwood Release
 ******************************
 
-You can install the Open edX Dogwood release using :ref:`Devstack <Install
-DevStack>` or :ref:`Fullstack <Install Open edX Fullstack>`.
+You can install the Open edX Dogwood release using :ref:`Devstack <Installing
+the Open edX Developer stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
 
 Review the prerequisites and instructions for each option, and then choose the
 option that best meets your needs. Ensure that you install the

--- a/en_us/shared/installation/troubleshooting_vm_installation.rst
+++ b/en_us/shared/installation/troubleshooting_vm_installation.rst
@@ -1,7 +1,3 @@
-*************************************************
-Troubleshooting Virtual Machine Installations
-*************************************************
-
 In some cases, you see an error when you attempt to create an edX virtual
 machine (``vagrant up``). For example:
 

--- a/en_us/xblock-tutorial/source/edx_platform/devstack.rst
+++ b/en_us/xblock-tutorial/source/edx_platform/devstack.rst
@@ -20,7 +20,7 @@ Prerequisites
 Before proceeding with the steps to deploy your XBlock, ensure the following
 requirements are met.
 
-* Devstack is running. For instructions, see the :ref:`installation:Running
+* Devstack is running. For instructions, see the :ref:`installation:Starting
   the Open edX Developer Stack`.
 
 * Ensure you have the XBlock directory in a location you can access from the


### PR DESCRIPTION
This PR fixes broken links in the Installing, Configuring, and Running the Open edX Platform guide.
### Reviewers
- [x] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @srpearce 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [x] http://draft-fix-broken-links-in-icr.readthedocs.org/
### Post-review
- [x] Squash commits
