### PR TITLE
DOC-2819: Modify description of Check button

### DIFF
--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -55,11 +55,11 @@ All problems on the edX platform have several component parts.
 #. **Rendered answer.** For some problem types, Studio uses MathJax to
    render plain text as "beautiful math".
 
-#. **Check button.** The learner selects **Check** to submit a response or find
-   out if his answer is correct. If the answer is correct, a green check mark
-   appears. If it is incorrect, a red X appears. When the learner selects
-   **Check**, the Learning Management System saves the grade and current
-   state of the problem.
+#. **Check button.** After entering or selecting an answer, a learner can
+   select **Check** to find out if his answer is correct. If the answer is
+   correct, a green check mark appears. If it is incorrect, a red X appears.
+   When the learner selects **Check**, the Learning Management System saves
+   the grade and current state of the problem.
 
 #. **Save button.** The learner can select **Save** to save her current
    response without submitting it for a grade. This allows the learner to


### PR DESCRIPTION
## [DOC-2819](https://openedx.atlassian.net/browse/DOC-2819)

Modifies description of Check button to reflect PR-154 (Platform setting (not adjustable by course teams) to disable Check and Final Check buttons if learners have not yet entered or selected an answer. 
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer
finishes and gives :+1:. 
- [x] Subject matter expert: @dianakhuang 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @srpearce @pdesjardins 

FYI: @jaakana
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment
- [x] Squash commits
