### PR TITLE
DOC-2452: Modify wording re browsing while taking exam

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/online_proctoring_rules_students.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/online_proctoring_rules_students.rst
@@ -60,8 +60,9 @@ The Room You are Taking the Test In
 
    * Phones.
    * Programs such as Excel, Word, Powerpoint.
-   * Any website other than edX.org.
    * Communication programs such as Skype.
+   * Any website page other than the exam window in your course, including
+     other content on edX.org.
 
 #. Make sure there is no writing visible on the desk or on the walls around
    you.
@@ -106,9 +107,9 @@ The Computer You are Taking the Test With
 #. The following tools should not be used during your proctored exam.
 
    * Programs such as Excel, Word, Powerpoint.
-   * Any website other than edX.org.
    * Communication programs such as Skype.
-
+   * Any website page other than the exam window in your course, including
+     other content on edX.org.
 
 ==========================================
 Your Personal Behavior

--- a/en_us/students/source/SFD_credit_courses/online_proctoring_rules_students.rst
+++ b/en_us/students/source/SFD_credit_courses/online_proctoring_rules_students.rst
@@ -72,8 +72,9 @@ The Room You are Taking the Test In
 
    * Phones.
    * Programs such as Excel, Word, Powerpoint.
-   * Any website other than edX.org.
    * Communication programs such as Skype.
+   * Any website page other than the exam window in your course, including
+     other content on edX.org.
 
 #. Make sure there is no writing visible on the desk or on the walls around
    you.
@@ -117,9 +118,9 @@ The Computer You are Taking the Test With
 #. The following tools should not be used during your proctored exam.
 
    * Programs such as Excel, Word, Powerpoint.
-   * Any website other than edX.org.
    * Communication programs such as Skype.
-
+   * Any website page other than the exam window in your course, including
+     other content on edX.org.
 
 ==========================================
 Your Personal Behavior


### PR DESCRIPTION
## [DOC-2452](https://openedx.atlassian.net/browse/DOC-2452)

Modifies online proctoring rules in both the student and course team guides to clarify what type of web browsing is not allowed: "Any website page other than the exam window in your course, including
     other content on edX.org."
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer
finishes and gives :+1:. 
- [ ] Subject matter expert: Julia Henderson
- [x] Doc team review (sanity check/copy edit/dev edit): @pdesjardins 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Post-review
- [ ] Add description to release notes task as a comment
- [ ] Squash commits
