### PR TITLE
Adds randomization as required for shuffling MC options

### DIFF
--- a/en_us/olx/source/problem-xml/create_problem.rst
+++ b/en_us/olx/source/problem-xml/create_problem.rst
@@ -265,21 +265,20 @@ Randomization
 
 .. note:: The **Randomization** setting serves a different purpose from
  "problem randomization". The **Randomization** setting affects how numeric
- values are randomized within a single problem and requires the inclusion of a
- Python script. Problem randomization offers different problems or problem
- versions to different learners. For more information, see :ref:`Problem
- Randomization`.
+ values or multiple choice options are randomized within a single problem.
+ Problem randomization offers different problems or problem versions to
+ different learners. For more information, see :ref:`Problem Randomization`.
 
-For problems that include a Python script to generate numbers randomly, this
-setting specifies how frequently the values in the problem change: each time a
-different learner accesses the problem, each time a single learner tries to
-answer the problem, both, or never.
+For numerical input problems that include a Python script to generate numbers
+randomly, or multiple choice problems that are set up to shuffle answers, this
+setting specifies when problem appearance changes.
 
 .. note:: This setting should only be set to an option other than **Never**
- for problems that are configured to do random number generation.
+ for problems that are configured to do random number generation or shuffle
+ multiple choice answers.
 
-For example, in this problem, the highlighted values change each time a learner
-submits an answer to the problem.
+For example, in this problem, the highlighted values change every time a
+learner selects **Check** for this problem.
 
 .. image:: ../../../shared/images/Rerandomize.png
  :alt: An image of the same problem shown twice, with color highlighting on
@@ -292,7 +291,17 @@ these steps.
 * Make sure that you edit your problem to include a Python script that randomly
   generates numbers.
 
-* Select an option other than **Never** for the **Randomization** setting.
+* Select **Edit** and then **Settings** for the problem to specify an option
+  other than **Never** for the **Randomization** setting.
+
+If you want to shuffle answers in a multiple choice problem, you complete both
+of these steps.
+
+* Use the simple or advanced editor to set up your problem to :ref:`shuffle
+  answers<Shuffle Answers in a Multiple Choice Problem>`.
+
+* Select **Edit** and then **Settings** for the problem to specify an option
+  other than **Never** for the **Randomization** setting.
 
 ..  For more information, see :ref:`Use Randomization in a Numerical Input Problem`.
 ..  ^^ add back to first bullet when DOC-2175 gets done - Alison 30 Jul 15

--- a/en_us/shared/exercises_tools/multiple_choice.rst
+++ b/en_us/shared/exercises_tools/multiple_choice.rst
@@ -664,8 +664,9 @@ want to include the answer "All of the Above" and have it always appear at the
 end of the list, but shuffle the other answers.
 
 You can configure the problem to shuffle answers using the simple editor or
-advanced editor.
-
+advanced editor. To shuffle the answers, you also edit the problem to set
+**Randomization** to a value other than **Never**. For more information, see
+:ref:`Randomization`.
 
 Use the Simple Editor to Shuffle Answers
 *********************************************
@@ -714,6 +715,10 @@ show the correct answer in a fixed location, you can use both ``x`` and ``@``.
 
   (x@) The iPod
 
+When you complete problem setup in the simple editor, select **Edit** and then
+**Settings** to specify an option other than **Never** for the
+**Randomization** setting.
+
 Use the Advanced Editor to Shuffle Answers
 *********************************************
 
@@ -761,7 +766,7 @@ To fix an answer's location in the list, add ``fixed="true"`` to the
 
 .. code-block:: xml
 
- <problem>
+ <problem rerandomize="always">
   <p>What Apple device competed with the portable CD player?</p>
   <multiplechoiceresponse>
    <choicegroup type="MultipleChoice" shuffle="true">
@@ -773,6 +778,10 @@ To fix an answer's location in the list, add ``fixed="true"`` to the
    </choicegroup>
   </multiplechoiceresponse>
  </problem>
+
+You can set value randomization as an attribute of the ``problem`` element, as
+shown in this example, or select **Edit** and then **Settings** to specify an
+option other than **Never** for the **Randomization** setting.
 
 .. _Targeted Feedback in a Multiple Choice Problem:
 


### PR DESCRIPTION
## [DOC-2831](https://openedx.atlassian.net/browse/DOC-2831)

For shuffling answers in a multiple choice problem to work, Randomization must be set to something other than Never. Previously, it was thought that Randomization applied only to numeric input problems. The PR is MVP work on the Randomization and multiple choice problem topics to correct the instructions for these features.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @jaakana
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check/copy edit/dev edit): @catong @pdesjardins @srpearce 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @sstack22
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment
- [x] Squash commits
