### PR TITLE
Badges doc: fix numbering after note

### DIFF
--- a/en_us/install_operations/source/configuration/enable_badging.rst
+++ b/en_us/install_operations/source/configuration/enable_badging.rst
@@ -446,14 +446,13 @@ these steps.
 #. When you have finished defining the badge class, select **Save**.
 
 #. Next, you create a new course event badge configuration that defines all of
-   the course event badges that you want to issue.
+   the course event badges that you want to issue. Select **Site
+   Administration** > **Badges** > **Course event badges configurations** >
+   **Add course event badges configuration**.
 
-.. important:: You can create more than one course event badge configuration,
-   but you can only mark one configuration as **Enabled**. Only the most
-   recently activated course event badge configuration is used.
-
-#. Select **Site Administration** > **Badges** > **Course event badges
-   configurations** > **Add course event badges configuration**.
+   .. important:: You can create more than one course event badge configuration,
+      but you can only mark one configuration as **Enabled**. Only the most
+      recently activated course event badge configuration is used.
 
 #. Within the new course event badge configuration, set the following
    parameters.


### PR DESCRIPTION
Fixes continuing numbering within a numbered list when interrupted by a note.
@srpearce would you mind doing a quick sanity check? Thanks!
