### PR TITLE
DOC-2861: Mobile support for DnD and Math exp input 

### DIFF
--- a/en_us/shared/exercises_tools/Section_mobile_problems.rst
+++ b/en_us/shared/exercises_tools/Section_mobile_problems.rst
@@ -6,6 +6,7 @@ they use the edX mobile app.
 * :ref:`Checkbox`
 * :ref:`drag_and_drop_problem`
 * :ref:`Dropdown`
+* :ref:`Math Expression Input`
 * :ref:`Multiple Choice`
 * :ref:`Numerical Input`
 * :ref:`Text Input`

--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -248,7 +248,7 @@ this table.
    * - :ref:`drag_and_drop_problem`
      - In drag and drop problems, learners respond to a question by dragging
        text or objects to a specific location on an image.
-     - Provisional support
+     - Provisional support; mobile-ready
    * - :ref:`Full Screen Image`
      - The full screen image tool allows a learner to enlarge an image in the
        whole browser window. This is useful when the image contains a large
@@ -344,7 +344,7 @@ engineering, or math courses are listed alphabetically in this table.
        answer a question. These problems can include unknown variables and more
        complex symbolic expressions. You can specify a correct answer either
        explicitly or by using a Python script.
-     - Full support
+     - Full support; mobile-ready
    * - :ref:`Molecule Editor`
      - The molecule editor allows learners to draw molecules that follow the
        rules for covalent bond formation and formal charge, even if the


### PR DESCRIPTION
In the Exercises and Tools section of the B&R Guide, add indication that Drag and Drop (need v2) and math expression input problems are mobile ready. Some changes in this PR might not be needed if updated Drag and Drop doc PR merges first.

@pdesjardins Can you please sanity check this PR, especially for anything that might conflict with your Drag and Drop PR? Thanks!
