### PR TITLE
Add course Home page events to research guide

### DIFF
--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -94,6 +94,12 @@ D, E, F
      - :ref:`enrollment`
    * - ``edx.course.enrollment.upgrade.succeeded``
      - :ref:`enrollment`
+   * - ``edx.course.home.resume_course.clicked``
+     - :ref:`course_home_page`
+   * - ``edx.course.home.course_update.toggled``
+     - :ref:`course_home_page`
+   * - ``edx.course.home.upgrade_verified.clicked``
+     - :ref:`course_home_page`
    * - ``edx.course.student_notes.added``
      - :ref:`notes`
    * - ``edx.course.student_notes.deleted``

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -610,6 +610,88 @@ event type also includes the following ``context`` member field.
 
 ``event`` **Member Fields**: None.
 
+.. _course_home_page:
+
+==============================
+Course Home Page Events
+==============================
+
+This section includes descriptions of the following events.
+
+.. contents::
+  :local:
+  :depth: 1
+
+Course **Home** page events track learner interactions with the course **Home**
+page in the LMS. An earlier version of the **Home** page was the **Course
+Info** page. The **Course Info** page did not have associated events.
+
+``edx.course.home.resume_course.clicked``
+********************************************
+
+The browser emits this event when a learner selects **Resume Course**.
+
+**Event Source**: Browser
+
+**History**: This event was added 3 Feb 2016.
+
+``event`` **Member Fields**:
+
+This event has the following ``event`` member fields.
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``url``
+     - string
+     - The URL of the last courseware page the learner visited. This is the
+       ``href`` attribute of the link.
+
+``edx.course.home.course_update.toggled``
+********************************************
+The browser emits this event when the learner shows or hides a course update.
+
+**Event Source**: Browser
+
+**History**: This event was added 3 Feb 2016.
+
+``event`` **Member Fields**:
+
+This event has the following ``event`` member fields.
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``action``
+     - string
+     - Indicates whether the learner showed or hid the update. Valid values are
+       ``hide`` and ``show``.
+   * - ``publish_date``
+     - string
+     - The date the update was published, in International Organization for
+       Standardization (ISO) 8601 format. An example value is
+       ``"2016-01-20T00:00:00-05:00"``.
+
+``edx.course.home.upgrade_verified.clicked``
+********************************************
+
+The browser emits this event when the learner selects **Upgrade to Verified**
+on the course **Home** page.
+
+**History**: This event was added 3 Feb 2016.
+
+``event`` **Member Fields**:
+
+None.
+
 .. _navigational:
 
 ==============================


### PR DESCRIPTION
## [DOC-2850](https://openedx.atlassian.net/browse/DOC-2850)

Documentation for events added back in February for the new course **Home** page. (Events were accidentally merged before receiving approval from Analytics team; confusion ensued over when and whether to document them.)
### Date Needed

As soon as convenient.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @peter-fogg  
- [ ] Subject matter expert: @stroilova  
- [ ] Doc team review (copy edit, sanity check): @lamagnifica @catong @pdesjardins  
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
