### PR TITLE
Help and feedback links instead of GitHub.

### DIFF
--- a/en_us/_themes/edx_theme/breadcrumbs.html
+++ b/en_us/_themes/edx_theme/breadcrumbs.html
@@ -2,7 +2,9 @@
   <li><a href="{{ pathto(master_doc) }}">Table of Contents</a> &raquo;</li>
   <li><a href="">{{ title }}</a></li>
   <li class="wy-breadcrumbs-aside">
-    <a href="{{ help_url }}" target="_blank">Need Help?</a> |
+    {%- if help_url -%}
+      <a href="{{ help_url }}" target="_blank">Need Help?</a> |
+    {%- endif -%}
     <a href="{{ feedback_form_url(project, pagename) }}" target="_blank">Feedback</a>
   </li>
 </ul>

--- a/en_us/_themes/edx_theme/breadcrumbs.html
+++ b/en_us/_themes/edx_theme/breadcrumbs.html
@@ -1,11 +1,10 @@
 <ul class="wy-breadcrumbs">
   <li><a href="{{ pathto(master_doc) }}">Table of Contents</a> &raquo;</li>
   <li><a href="">{{ title }}</a></li>
-  {% if display_github %}
-    <li class="wy-breadcrumbs-aside">
-      <a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>
-    </li>
-  {% endif %}
+  <li class="wy-breadcrumbs-aside">
+    <a href="{{ help_url }}" target="_blank">Need Help?</a> |
+    <a href="{{ feedback_form_url(project, pagename) }}" target="_blank">Feedback</a>
+  </li>
 </ul>
 <hr/>
 

--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -13,7 +13,7 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'Building and Running an edX Course'
 
-tags.add('Partners')
+set_audience('Partners')
 
 product = 'Partners'
 

--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -13,7 +13,8 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'Building and Running an edX Course'
 
-set_audience('Partners')
+tags.add('Partners')
+set_audience(PARTNER, COURSE_TEAMS)
 
 product = 'Partners'
 

--- a/en_us/data/source/conf.py
+++ b/en_us/data/source/conf.py
@@ -12,6 +12,7 @@ html_theme_path = ['../../_themes']
 html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'EdX Research Guide'
+set_audience(PARTNER, RESEARCHERS)
 
 # Do not attempt to publish .rst files if they are included in
 # other .rst files. This suppresses WARNINGs about documents not

--- a/en_us/developers/source/conf.py
+++ b/en_us/developers/source/conf.py
@@ -12,5 +12,6 @@ html_theme_path = ['../../_themes']
 html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'Open edX Developer\'s Guide'
+set_audience(OPENEDX, DEVELOPERS)
 
 exclude_patterns = ['i18n.rst', 'i18n_translators_guide.rst']

--- a/en_us/install_operations/source/conf.py
+++ b/en_us/install_operations/source/conf.py
@@ -13,6 +13,7 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 # General information about the project.
 project = u'Installing, Configuring, and Running the Open edX Platform'
+set_audience(OPENEDX, DEVELOPERS)
 
 #remove directory when content is first added to it, and add to index
 exclude_patterns = ['links.rst', 'configuration/configure_milestone_app.rst']

--- a/en_us/olx/source/conf.py
+++ b/en_us/olx/source/conf.py
@@ -13,8 +13,8 @@ html_theme_path = ['../../_themes']
 html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 tags.add('OLX')
-
 product = 'OLX'
+set_audience(OPENEDX, DEVELOPERS)
 
 def setup(app):
     app.add_config_value('product', '', True)

--- a/en_us/open_edx_course_authors/source/conf.py
+++ b/en_us/open_edx_course_authors/source/conf.py
@@ -12,6 +12,7 @@ html_theme_path = ['../../_themes']
 html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 tags.add('Open_edX')
+set_audience('Open_edX')
 
 product = 'Open_edX'
 

--- a/en_us/open_edx_course_authors/source/conf.py
+++ b/en_us/open_edx_course_authors/source/conf.py
@@ -12,7 +12,7 @@ html_theme_path = ['../../_themes']
 html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 tags.add('Open_edX')
-set_audience('Open_edX')
+set_audience(OPENEDX, COURSE_TEAMS)
 
 product = 'Open_edX'
 

--- a/en_us/open_edx_release_notes/source/conf.py
+++ b/en_us/open_edx_release_notes/source/conf.py
@@ -12,6 +12,7 @@ html_theme_path = ['../../_themes']
 html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'Open edX Release Notes'
+set_audience(OPENEDX, DEVELOPERS)
 
 #remove directory when content is first added to it, and add to index
 exclude_patterns = ['links.rst']

--- a/en_us/open_edx_students/source/conf.py
+++ b/en_us/open_edx_students/source/conf.py
@@ -14,8 +14,8 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 project = u'Open edX Learner\'s Guide'
 
 tags.add('Open_edX')
-
 product = 'Open_edX'
+set_audience(OPENEDX, LEARNERS)
 
 def setup(app):
     app.add_config_value('product', '', True)

--- a/en_us/release_notes/source/conf.py
+++ b/en_us/release_notes/source/conf.py
@@ -17,3 +17,4 @@ project = u'EdX Release Notes'
 #remove directory when content is first added to it, and add to index
 exclude_patterns = ['links.rst', 'reusables/*', '20??/*/*20??.rst']
 
+set_audience(PARTNER, COURSE_TEAMS)

--- a/en_us/students/source/conf.py
+++ b/en_us/students/source/conf.py
@@ -15,8 +15,8 @@ project = u'EdX Learner\'s Guide'
 
 
 tags.add('Partners')
-
 product = 'Partners'
+set_audience(PARTNER, LEARNERS)
 
 def setup(app):
     app.add_config_value('product', '', True)

--- a/en_us/xblock-tutorial/source/conf.py
+++ b/en_us/xblock-tutorial/source/conf.py
@@ -14,6 +14,7 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 # General information about the project.
 project = u'Open edX XBlock Tutorial'
+set_audience(OPENEDX, DEVELOPERS)
 
 #remove directory when content is first added to it, and add to index
 exclude_patterns = ['reusable/*']

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -41,6 +41,9 @@ if on_rtd:
     html_context["github_project"] = 'edx-documentation'
 
 FEEDBACK_FORM_FMT = "https://docs.google.com/forms/d/1gGBVXUS84Q8jVEJdlpYYIkOQmaCg5JnzBTG1x4ASWKM/viewform?entry.930288665&entry.672882205={url}"
+OPEN_HELP = "http://open.edx.org/help"              # JUST A PLACEHOLDER
+PARTNER_HELP = "http://partners.edx.org/help"       # DON'T FREAK, JUST ANOTHER PLACEHOLDER
+GENERIC_HELP = "http://help.com"                    # OBVIOUSLY A JOKE
 
 def feedback_form_url(project, page):
     """Create a URL for feedback on a particular page in a project."""
@@ -48,7 +51,16 @@ def feedback_form_url(project, page):
 
 html_context['feedback_form_url'] = feedback_form_url
 
-html_context['help_url'] = 'http://open.edx.org'
+
+html_context['help_url'] = GENERIC_HELP
+
+def set_audience(tag):
+    """Used from specific conf.py files to set the audience for a book."""
+    if tag == "Open_edX":
+        html_context['help_url'] = OPEN_HELP
+    elif tag == "Partners":
+        html_context['help_url'] = PARTNER_HELP
+
 
 # General information about the project.
 

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -40,27 +40,44 @@ if on_rtd:
     html_context["github_base_account"] = 'edx'
     html_context["github_project"] = 'edx-documentation'
 
+# Help and Feedback links.  These are customized for the category and audience
+# of the book.  Add a line to the book's conf.py like this:
+#
+#   set_audience(PARTNER, COURSE_TEAMS)
+#
+
+# Categories
+PARTNER = object()
+OPENEDX = object()
+
+# Audiences
+COURSE_TEAMS = object()
+LEARNERS = object()
+RESEARCHERS = object()
+DEVELOPERS = object()
+
+HELP_LINKS = {
+    (PARTNER, COURSE_TEAMS): None, #"https://partners.edx.org/forums/partner-forums",
+    (PARTNER, LEARNERS): None, #"https://support.edx.org",
+    (PARTNER, RESEARCHERS): "http://edx.readthedocs.org/projects/devdata/en/latest/front_matter/preface.html#resources-for-researchers",
+    (PARTNER, DEVELOPERS): "https://open.edx.org/resources/e-mail-lists",
+    (OPENEDX, COURSE_TEAMS): "https://open.edx.org/resources/e-mail-lists",
+    (OPENEDX, DEVELOPERS): "https://open.edx.org/resources/e-mail-lists",
+}
+
+html_context['help_url'] = None
+
+def set_audience(category, audience):
+    """Used from specific conf.py files to set the audience for a book."""
+    html_context['help_url'] = HELP_LINKS.get((category, audience))
+
 FEEDBACK_FORM_FMT = "https://docs.google.com/forms/d/1gGBVXUS84Q8jVEJdlpYYIkOQmaCg5JnzBTG1x4ASWKM/viewform?entry.930288665&entry.672882205={url}"
-OPEN_HELP = "http://open.edx.org/help"              # JUST A PLACEHOLDER
-PARTNER_HELP = "http://partners.edx.org/help"       # DON'T FREAK, JUST ANOTHER PLACEHOLDER
-GENERIC_HELP = "http://help.com"                    # OBVIOUSLY A JOKE
 
 def feedback_form_url(project, page):
     """Create a URL for feedback on a particular page in a project."""
     return FEEDBACK_FORM_FMT.format(url=urllib.quote("{}: {}".format(project, page)))
 
 html_context['feedback_form_url'] = feedback_form_url
-
-
-html_context['help_url'] = GENERIC_HELP
-
-def set_audience(tag):
-    """Used from specific conf.py files to set the audience for a book."""
-    if tag == "Open_edX":
-        html_context['help_url'] = OPEN_HELP
-    elif tag == "Partners":
-        html_context['help_url'] = PARTNER_HELP
-
 
 # General information about the project.
 

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -1,5 +1,6 @@
+# Shared configuration for edX docs.
 
-import sys, os
+import sys, os, urllib
 
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -30,14 +31,24 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
+html_context = {}
+
 if on_rtd:
-    html_context = {
-       "on_rtd" : on_rtd,
-       "google_analytics_id" : '',
-       "disqus_shortname" : 'edx',
-       "github_base_account" : 'edx',
-       "github_project" : 'edx-documentation',
-    }
+    html_context["on_rtd"] = on_rtd
+    html_context["google_analytics_id"] = ''
+    html_context["disqus_shortname"] = 'edx'
+    html_context["github_base_account"] = 'edx'
+    html_context["github_project"] = 'edx-documentation'
+
+FEEDBACK_FORM_FMT = "https://docs.google.com/forms/d/1gGBVXUS84Q8jVEJdlpYYIkOQmaCg5JnzBTG1x4ASWKM/viewform?entry.930288665&entry.672882205={url}"
+
+def feedback_form_url(project, page):
+    """Create a URL for feedback on a particular page in a project."""
+    return FEEDBACK_FORM_FMT.format(url=urllib.quote("{}: {}".format(project, page)))
+
+html_context['feedback_form_url'] = feedback_form_url
+
+html_context['help_url'] = 'http://open.edx.org'
 
 # General information about the project.
 

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -71,11 +71,11 @@ def set_audience(category, audience):
     """Used from specific conf.py files to set the audience for a book."""
     html_context['help_url'] = HELP_LINKS.get((category, audience))
 
-FEEDBACK_FORM_FMT = "https://docs.google.com/forms/d/1gGBVXUS84Q8jVEJdlpYYIkOQmaCg5JnzBTG1x4ASWKM/viewform?entry.930288665&entry.672882205={url}"
+FEEDBACK_FORM_FMT = "https://docs.google.com/forms/d/1T5QGnYb_QnQoMO7T_eatq02miPTY40WVe3cgGphNAdY/viewform?entry.1952574704&entry.241692674={pageid}"
 
 def feedback_form_url(project, page):
     """Create a URL for feedback on a particular page in a project."""
-    return FEEDBACK_FORM_FMT.format(url=urllib.quote("{}: {}".format(project, page)))
+    return FEEDBACK_FORM_FMT.format(pageid=urllib.quote("{}: {}".format(project, page)))
 
 html_context['feedback_form_url'] = feedback_form_url
 


### PR DESCRIPTION
A proof-of-concept for adding "Need Help?" and "Feedback" links to the top of each page.  

The Need Help links can point to difference links, depending on the audience of the book.  Here there are three different audiences (Open_edX, Partners, and unspecified), but that can be changed.  The actual links are just placeholders, and we'll need to work with Ed Services and Open edX to decide where they should really go.

The Feedback link goes to a sample Google Form that Peter made, with an indication of the project and page included automatically.
