### PR TITLE
DOC-2851 Android updates can take an hour

### DIFF
--- a/en_us/shared/developing_course/workflow.rst
+++ b/en_us/shared/developing_course/workflow.rst
@@ -64,7 +64,14 @@ The following diagram summarizes the content creation workflow:
  :alt: Diagram of the content creation process
 
 It is recommended that you :ref:`test course content <Testing Your Course
-Content>` throughout the creation process.
+Content>` throughout the creation process, including making sure that the
+content is available for learners who access courses using the edX mobile apps.
+For more information, see :ref:`Designing For a Mobile Experience`.
+
+.. note:: Keep in mind that course updates that you make might take longer to
+   appear in the edX mobile apps than on the edX site. In particular, newly
+   published content can take up to an hour to update on the Android app.
+
 
 .. _Making Course Content Visible to Students:
 
@@ -129,4 +136,10 @@ visibility:
  :alt: Diagram of the content creation process
 
 It is recommended that you :ref:`test course content <Testing Your Course
-Content>` during the revision process.
+Content>` during the revision process, including making sure that the content
+is available for learners who access courses using the edX mobile apps. For
+more information, see :ref:`Designing For a Mobile Experience`.
+
+.. note:: Keep in mind that course updates that you make might take longer to
+   appear in the edX mobile apps than on the edX site. In particular, newly
+   published content can take up to an hour to update on the Android app.

--- a/en_us/shared/reaching_learners/design_for_mobile.rst
+++ b/en_us/shared/reaching_learners/design_for_mobile.rst
@@ -16,6 +16,10 @@ To make the course experience for mobile learners as rewarding as it is for
 learners using desktop computers, keep the following best practices in mind as
 you design, test, and run your course.
 
+* Course updates that you make might take longer to appear in the edX mobile
+  apps than on the edX site. In particular, newly published content can take up
+  to an hour to update on the Android app.
+
 * Display names are critical for navigating through courses on smartphones. As
   you create course content, make sure you replace the default display names
   for every component with useful course component names.
@@ -26,8 +30,8 @@ you design, test, and run your course.
   differ only after that, learners using smartphones to access your course
   might have difficulty distinguishing between components.
 
-* Do not use Flash, which is not supported on mobile platforms, to create course
-  content.
+* Do not use Flash, which is not supported on mobile platforms, to create
+  course content.
 
 * Only use iFrames in course content where necessary, because iFrame content
   might not be responsive and cannot be optimized for viewing on a range of
@@ -82,4 +86,7 @@ To test the mobile experience of your course, sign in to your course using the
 edX Android or iPhone app, and view each course unit to make sure that it
 renders as you expect it to.
 
+.. note:: Keep in mind that course updates that you make might not be
+   immediately reflected in the edX mobile apps. In particular, newly
+   published content can take up to an hour to update on the Android app.
 


### PR DESCRIPTION
Update mobile best practices doc with reminder that it can take up to an hour for newly published course changes to be updated on the Android app.
DOC-2851/MA-2259

Reviewers:
@BenjiLee 
@lamagnifica or @srpearce or @pdesjardins 
FYI @jaakana
