### PR TITLE
Updated import guidelines

### DIFF
--- a/en_us/developers/source/style_guides/python_guidelines.rst
+++ b/en_us/developers/source/style_guides/python_guidelines.rst
@@ -90,11 +90,10 @@ Imports Order
 PEP 8 recommends a most-general to most-specific import order, which means this order:
 
 * Standard library imports
-* Third Party Library imports
-* Core Django imports
-* Third party Django app imports
-* Other edX repo imports
+* Third party library imports
 * Local imports
+
+Each group of imports should be alphabetized; and, you should put a blank line between each group.
 
 *******************************
 Pylint Guidelines and Practices


### PR DESCRIPTION
Using the actual PEP 8 guideline, instead of the edX customization. The customization is rather burdensome to maintain—some tools/IDEs (e.g. PyCharm) automatically adhere to PEP 8, but cannot be configured with additional customizations—and offers no obvious value over the PEP 8 recommendation.
