### PR TITLE
Updated guidelines for single line docstrings

### DIFF
--- a/en_us/developers/source/style_guides/python_guidelines.rst
+++ b/en_us/developers/source/style_guides/python_guidelines.rst
@@ -179,17 +179,10 @@ Most of our code is written using an older style::
 
         """
 
-If you only have a single line in your docstring, first, consider that this is almost certainly not enough documentation, and write some more.  But if you do have just one line, format it similarly to a multi-line docstring::
+If you only have a single line in your docstring, first, consider that this is almost certainly not enough documentation, and write some more.  But if you do have just one line, place it on a single line.::
 
     def foo(a, b):
-        """
-        Computes the foo of a and b.
-        """
-
-Not like this::
-
-    def foo(a, b):
-        """Computes the foo of a and b.""" # NO NO NO
+        """Computes the foo of a and b."""
 
 **********
 References


### PR DESCRIPTION
The guideline now aligns with PEP 257. There is no obvious reason for deviating.
