### PR TITLE
Fix typo in April 18 release notes

### DIFF
--- a/en_us/release_notes/source/2016/openedx/openedx_0418_2016.rst
+++ b/en_us/release_notes/source/2016/openedx/openedx_0418_2016.rst
@@ -18,5 +18,5 @@ The Dogwood.2 patch release is now available. This release includes fixes for
 several security and installation issues, updates Django to version 1.8.12, and
 adds a control for discontinuing audit certificates.
 
-For more information, see the :ref:`openreleasenotes:Open edX release
-notes<Open edX Dogwood Release>` for Dogwood.
+For more information, see the :ref:`Open edX release
+notes for Dogwood <openreleasenotes:Open edX Dogwood Release>`.


### PR DESCRIPTION
### [DOC-2911](https://openedx.atlassian.net/browse/DOC-2911)

Fixes a typo in the April 18 release notes - link text appears on RTD as "For more information, see the openreleasenotes:Open edX release notes for Dogwood."

_Reviewer_: @lamagnifica @catong @pdesjardins 
