### PR TITLE
DOC-2912: Remove coming soon file from Apr 27 RN

### DIFF
--- a/en_us/release_notes/source/coming_soon.rst
+++ b/en_us/release_notes/source/coming_soon.rst
@@ -6,15 +6,5 @@ This topic describes features that are in development and that edX expects to
 release in the near future. After these features are released, the release
 notes will include links to related documentation.
 
-****************************************
-New Drag and Drop Problem Type
-****************************************
-
-A new drag and drop problem type is currently under development. The new drag
-and drop problem type is much easier to create, is more flexible and
-accessible, and works on mobile devices. The new problem type will eventually
-replace the current drag and drop problem type for new course content. The new
-drag and drop problem type will not affect existing courses that include drag
-and drop problems created using the older problem type.
 
 .. include:: ../../links/links.rst

--- a/en_us/release_notes/source/conf.py
+++ b/en_us/release_notes/source/conf.py
@@ -15,5 +15,5 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 project = u'EdX Release Notes'
 
 #remove directory when content is first added to it, and add to index
-exclude_patterns = ['links.rst', 'reusables/*', '20??/*/*20??.rst']
+exclude_patterns = ['links.rst', 'reusables/*', '20??/*/*20??.rst', 'coming_soon.rst']
 

--- a/en_us/release_notes/source/index.rst
+++ b/en_us/release_notes/source/index.rst
@@ -8,7 +8,6 @@ edX Release Notes
    :maxdepth: 2
 
    front_matter/index
-   coming_soon.rst
 
 
 ******************


### PR DESCRIPTION
Remove "Coming Soon" file from April 27 2016 release notes
Built locally with no errors, ran run_tests.sh with no errors.
@srpearce @lamagnifica or @pdesjardins sanity check before I squash commits and merge, please.
