### PR TITLE
make redirect URI consistent across processes.

### DIFF
--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -91,7 +91,7 @@ To create and register a new OIDC client, follow these steps.
 #. Leave the **User** field blank.
 #. For **Client Name**, enter ``E-Commerce Service``.
 #. For **URL**, enter ``http://localhost:8002/``.
-#. For **Redirect URL**, enter ``https://localhost:8002/complete/edx-oidc/``.
+#. For **Redirect URL**, enter ``http://127.0.0.1:8002/complete/edx-oidc/``.
    This is the OIDC client endpoint.
 
    The system automatically generates values in the **Client ID** and **Client


### PR DESCRIPTION
There is a general issue with consistency when defining the redirect URL between using localhost and 127.0.0.1. This is true for edxapp and ecommerce.  

For this specific proposed change, I got the systems communicating correctly by changing the Redirect URL to http://127.0.0.1:8002/complete/edx-oidc/ on my devstack instance (no https).

without this change I received the error, "The requested redirect didn't match the client settings." when rendering page: http://127.0.0.1:8000/oauth2/authorize/confirm

traced back to  file venvs/edxapp/src/django-oauth2-provider/provider/oauth2/forms.py where is does a string compare of the two configured redirect uris here: 
if not redirect_uri == self.client.redirect_uri: @line 167. 

Also, in /edx/etc/ecommerce.yml, ECOMMERCE_URL_ROOT is defined as http://localhost:8002.  I also changed that to http://127.0.0.1:8002.
