### PR TITLE
Removes info in MsMoS, copy edits and streamlines

### DIFF
--- a/en_us/edx_style_guide/source/DocTranslationGuidelines.rst
+++ b/en_us/edx_style_guide/source/DocTranslationGuidelines.rst
@@ -26,47 +26,53 @@ When you translate edX documentation source .rst files, follow these general
 guidelines. For examples of each type of element, see :ref:`the Example .rst
 file<Anchor For ExampleRSTFile>`.
 
+.. contents::
+  :local:
+  :depth: 1
+
+For information about working with edX documentation source files, see
+:ref:`Work with edX Documentation Source Files`.
+
+For information about the documentation translation process, see
+:ref:`Documentation Translation Process`.
+
 
 *************************
-What To Translate
+What to Translate
 *************************
 
 In addition to obvious text, do translate the following items.
 
-* Note and Warning text. Translate text following the tags ``.. note::`` or
-  ``.. warning::``. Be careful to wrap and indent lines correctly, as described
-  in :ref:`Work with edX Documentation Source Files`.
+* The text of notes and warnings. Translate text following the tags ``..
+  note::``, ``.. important::``,  or ``.. warning::``. Be careful to wrap and
+  indent lines correctly, as described in :ref:`Work with edX Documentation
+  Source Files`.
 
-* Link text in inline links. Distinguish between anchor text and link text.
-  Only translate link text; if you translate anchor text, the link will be
-  broken.
+* The link text in cross references. Link text is optional, so be sure to
+  identify the difference between link text and anchor text if both are present
+  in a cross reference. Only translate link text; if you translate anchor text,
+  the link will be broken.
 
-  For example, in
+  For example, in ``:ref:`Work with edX Documentation Source Files``` the text
+  between the accent characters (`) is the anchor text and should not be
+  translated.
 
-  ``:ref:`Work with edX Documentation Source Files``` or
-  ```Work with edX Documentation Source Files`_``
+  However, in the example ``:ref:`this is link text<Work with edX Documentation
+  Source Files>``` link text is also present. The anchor text is between the
+  angle brackets and should not be translated. The text string between the
+  first grave accent character and the opening bracket ("this is link text") is
+  link text, and should be translated.
 
-  the text between the grave accent
-  characters (`) is actual anchor text and should not be translated.
-
-  However, in the example
-
-  ``:ref:`this is link text<Work with edX Documentation Source Files>```
-
-  the actual anchor text is between the carets and should not be
-  translated. The text string between the first grave accent character and the
-  first caret ("this is link text") is link text, and should be translated.
-
-* Alt text in image references. Translate text following the tag ``:alt:`` so
+* The ``alt`` text for images. Translate text following the tag ``:alt:`` so
   that a useful description is provided for screen readers.
 
-  For example, ::
+  An example of the formatting used to include an image follows.
 
-   .. image:: ../../../data/source/Images/DataCzar_Initialization.png
-      :width: 100
-      :alt: Flowchart showing process for initializing a data czar
+  ::
 
-
+     .. image:: ../../../data/source/Images/DataCzar_Initialization.png
+        :width: 100
+        :alt: Flowchart showing process for initializing a data czar.
 
 
 *****************************
@@ -79,13 +85,13 @@ Do not translate or alter any of the following elements.
 
 * The filenames and locations of any image files in the repository. If you
   replace any original source images with localized images, make sure the
-  replacement image files have exactly the same filenames, and replace them in
-  the same Images folder location, so that image links within the
+  replacement image files have exactly the same filenames, and place them in
+  the same ``images`` folder location, so that image links within the
   documentation are not broken.
 
 * Words in file paths in cross-references or image references.
 
-* Words that are part of .rst directives, including "note" or "warning".
+* Words that are part of .rst directives, including ``note`` anf ``important``.
   Examples are listed in :ref:`Work with edX Documentation Source Files` and
   :ref:`ExampleRSTFile<Anchor For ExampleRSTFile>`.
 
@@ -96,14 +102,24 @@ Do not translate or alter any of the following elements.
 * Variables, database field names, or code examples that are tagged with
   monospace code font (placed between double grave accent characters).
 
-  For example, in the following sentence, do not translate the event names that are between pairs of double grave accent characters.
+  For example, in the following sentence, do not translate the event names that
+  are between pairs of double grave accent characters.
 
   The edX mobile app for iOS now emits ````play_video````, ````pause_video````,
   ````stop_video````, ````load_video````, and ````seek_video```` events.
 
+If a specific instance of one of these elements should be translated, the
+writer will include a translator note in a comment immediately before that
+element. An example follows.
 
-For information about working with edX Documentation source files, see
-:ref:`Work with edX Documentation Source Files`.
+::
 
-For information about the documentation translation process, see
-:ref:`Documentation Translation Process`.
+  .. Translators: the "msg" text that is included between the paragraph <p></p> tags can be translated.
+
+  ::
+
+    {
+     "correct": true,
+     "score": 1,
+     "msg": "<p>The code passed all tests.</p>"
+    }

--- a/en_us/edx_style_guide/source/formattinglayout.rst
+++ b/en_us/edx_style_guide/source/formattinglayout.rst
@@ -1,45 +1,46 @@
 .. _Formatting and Layout:
 
-#############################
-Formatting and Content Layout
-#############################
+####################################
+Style Conventions and Content Layout
+####################################
 
-For an .rst file that contains examples of the markup used by the
+The edX documentation is authored using reStructuredText markup syntax. For a
+description and complete documentation, see `reStructuredText`_ .
+
+For a sample .rst file that contains examples of the markup used by the edX
 documentation team, see the
-edx-documentation/en_us/edx_style_guide/source/Format Cheat
-Sheet.rstnouse file.
+``edx-documentation/en_us/edx_style_guide/source/ExampleRSTFile.rst`` file.
 
 .. list-table::
   :widths: 15 15 15 25
 
   * - Item
-    - rST Formatting
+    - .rst Formatting
     - Examples
     - Notes
   * - Book or guide name
-    - *Italic*
+    - ``*italic*``
     - *Building and Running an edX Course*
-    - When mentioning the guide in general, link the title to the HTML rather
-      than presenting in italics. When providing the title in addition to a
-      specific section or topic in the guide, link the section or topic and
-      then place the name of the guide in italics.
+    - When you provide the title of the guide in addition to a cross-reference
+      to a specific section or topic in the guide, link the section or topic
+      and then place the name of the guide in italics. Otherwise, make the
+      title the cross reference link instead of presenting it in italics.
 
       Translator guidance is that strings in italic font should be translated.
 
   * - Code samples
-    - ``monospace``
+    - ````monospace````
     - The member fields of this dictionary are ``display_name`` and
       ``usage_key``.
-    - To make the efforts of translators easier, use ``monospace`` markup only
-      for strings that should not be translated: code, commands, SQL table
-      columns, and event names.
+    - Use ``monospace`` markup only for strings that should not be translated,
+      including code, settings, commands, SQL table columns, and event names.
 
-      For longer examples, such as XML templates, which include text that can
+      For longer examples, such as XML templates that include text that can
       be translated, use the code block markup and include a comment for
       translators with explicit instructions.
 
-      .. Translators: In the following XML code block, do not translate any
-      .. text that is between the < > characters.
+      ``.. Translators: In the following XML code block, do not translate any
+        .. text that is between the < > characters.``
 
       .. code-block:: xml
 
@@ -47,7 +48,7 @@ Sheet.rstnouse file.
           In the image below, click the cone.
 
   * - Programming elements
-    - ``monospace``
+    - ````monospace````
     - The ``event_type`` parameter enables downstream processing.
 
       An XBlock must set ``has_score`` to ``True``.
@@ -63,48 +64,47 @@ Sheet.rstnouse file.
 
       * Set ``has_score`` to ``True``.
 
-      * Incorrect: Set the has_score to True.
+      * Incorrect: Set the has_score to true.
 
   * - Unnamed icons
-    - Enclose a description in quotation marks
+    - "brief description"
     - Select "back 30 seconds" on the playback bar.
-    - In most cases, icons have a label or mouseover tip. If the icon has a
-      mouseover tip, use the mouseover tip text as the name of the control and
-      put it in **bold** like other UI elements.
+    - In most cases, icons have mouseover help text. If the icon has
+      help text, use that text as the name of the control and
+      use ``**bold**`` like other UI elements.
   * - New term
-    - link to glossary definition
-    -
+    - optional: link to glossary definition
+    - This section provides conceptual and procedural information about
+      using ``:ref:`teams_g``` in your courses.
     - Add new terms to the glossary. If you want to be sure that people
       understand how you are using the term, provide a link to the glossary
-      definition.
-  * - UI item
-    - **bold**
+      definition. Do not italicize newly introduced terms.
+  * - User interface controls
+    - ``**bold**``
     - From the **Tools** menu, select **Import**.
 
       In the left pane, select **Filter messages like this**.
 
-    - A UI item is anything that the user views, clicks, selects, or interacts
-      with and that has a name or a tooltip. If it doesn't have a label or
-      tooltip, see Unnamed icons above.
+    - For more information about user interface controls in edX products, see
+      :ref:`Documenting the User Interface`.
 
-      Translator guidance is that strings in boldface font should be
+      Translator guidance is that strings in boldface font can be
       translated.
 
   * - User input
-    - ``monospace``
+    - ````monospace````
     - In the **Show Calculator** field, type ``true``.
     - Follow the same rules as for code samples. The assumption is that values
-      presented in monospace font must be entered exactly as documented, and that translated versions of the value are not acceptable.
+      presented in monospace font must be entered exactly as documented, and
+      that translated versions of the value are not acceptable.
 
-      If the user input value can be translated, add a "Translator:" comment
-      to that effect.
-
-      Inline if the user input is short (one line); indented if more than one
-      line.
+      If the user input value can be translated, add a "Translator:" comment to
+      that effect.
 
   * - Variables
     - Surround with braces ({}).
-    -
-    - Avoid angle brackets (< >) because rST interprets angle brackets as
-      setting off XML examples.
+    - ...in the format ``{org}-{course}-{run}-{site}.mongo``.
+    - Avoid angle brackets (< >) because rST uses angle brackets to identify
+      XML examples.
 
+.. _reStructuredText: http://docutils.sourceforge.net/rst.html

--- a/en_us/edx_style_guide/source/images.rst
+++ b/en_us/edx_style_guide/source/images.rst
@@ -5,7 +5,7 @@ Images
 #######
 
 Because the user interface can change rapidly and frequently, and because it is
-very expensive for translation teams to localize screen shots, the
+very expensive for translation teams to localize screen shots, the edX
 documentation team uses screen shot images sparingly.
 
 ***************
@@ -19,9 +19,9 @@ data) are available on edX Edge.
 
 * `La Tierra Centroamericana`_
 
-*****************
-Guidelines
-*****************
+****************************
+Guidelines for Adding Images
+****************************
 
 ==========
 Messages
@@ -29,7 +29,11 @@ Messages
 
 Avoid using a screen shot to show an error, warning, or informational
 message. Instead, just include the text of the message as part of the procedure
-or concept.
+or concept. Message text should be enclosed in quotation marks.
+
+If you choose to show message text in a code block, you must include a
+translator note in a comment immediately before that element. For more
+information and an example, see :ref:`Documentation Translation Guidelines`.
 
 =========================
 Colors
@@ -42,11 +46,14 @@ Browser Width
 ====================
 
 Before you take a screen shot, reduce the window width to avoid extra white
-space. Usually this means you narrow until page is no longer responsive (unless
-this will make screen shot too long).
+space. Usually this means you narrow the width of your browser until the page
+is no longer responsive. However, you do have the aesthetic control over when
+reducing the width of the intended image will have the effect of making the
+screen shot too long.
 
-The following image has a lot of white space inside the component editor,
-which narrowing the window will correct.
+The following image has a lot of white space inside the component editor. To
+produce a better illustration of the component editor, make the browser
+narrower.
 
 .. image:: Images/DiscussionComponentEditor.png
   :width: 450
@@ -64,12 +71,13 @@ Capturing Screen Shots
 
 You can use any tool you like to capture images.
 
-With SnagIt, you can configure preferences to include a timing delay and
+If you use SnagIt, you can configure preferences to include a timing delay and
 specific on-screen objects, including the cursor, as well as setting keyboard
-shortcuts for different configurations.
+shortcuts for different configurations. References to the edX documentation
+team's SnagIt Style Gallery follow.
 
-You can also use the Mac's built-in screen capture functionality to take screen
-shots. To capture part of the screen, follow these steps.
+If you use a Mac computer, you can use the built-in screen capture application
+to take screen shots. To capture part of the screen, follow these steps.
 
 .. note:: This method does not capture the positioning of the cursor.
 
@@ -82,34 +90,34 @@ shots. To capture part of the screen, follow these steps.
 Editing Images
 *****************
 
-You can use any tool you like to edit images. Some guidelines for SnagIt and
-Adobe Photoshop are included here.
+You can use any tool you like to edit images. Some guidelines for SnagIt are
+included here.
 
 =========================
 SnagIt Style Gallery
 =========================
 
 SnagIt 3.3.5 has a Style Gallery feature that saves the customizations that you
-make to borders, arrows, etc. for easy reuse.
+make to borders, arrows, and so on for easy reuse.
 
 If you use SnagIt, note that the following .snagstyles files are included in
 the Images directory of this guide.
 
-* arrows.snagstyles (adds arrows in three edX base colors)
-* color_fill.snagstyles (adds three edX base colors)
-* outline_shapes.snagstyles (adds three outline shapes in each of the
-  three edX base colors)
-* numbered_callouts.snagstyles (adds numbered callouts in three edX base
-  colors)
+* ``arrows.snagstyles`` adds arrows in three edX base colors.
+* ``color_fill.snagstyles`` adds three edX base colors.
+* ``outline_shapes.snagstyles`` adds three outline shapes in each of the three
+  edX base colors.
+* ``numbered_callouts.snagstyles`` adds numbered callouts in three edX base
+  colors.
 
-To add edX SnagIt styles to your SnagIt application, drag a .snagstyles file
-onto the SnagIt icon in the toolbar of your Mac.
+To add these edX SnagIt styles to your SnagIt application, drag each
+.snagstyles file onto the SnagIt icon in the toolbar of your computer.
 
-=========================
-Border
-=========================
+========
+Borders
+========
 
-To every image, add a border with the following characteristics.
+Add a border with the following characteristics to every image.
 
 (In SnagIt: Effects > Border; In Photoshop: Cmd + a, Edit > Stroke)
 
@@ -119,7 +127,7 @@ To every image, add a border with the following characteristics.
 
 In SnagIt, the first time you make these selections for a border, a new tile
 appears in the Style Gallery with these characteristics. Save that new style
-(select the + icon) so that you can reuse it in the future.
+(select its + icon) so that you can reuse it in the future.
 
 =========================
 File Size and Format
@@ -177,10 +185,11 @@ follow these steps.
 #. Close and reopen any application that you want to use the font in.
 
 **************************
-Adding Images to Files
+Adding an Image to a File
 **************************
 
-When you add an image to a file, include three lines.
+When you add an image to a file, include a directive with the following
+information.
 
 * The image directive
 * The image width
@@ -198,8 +207,8 @@ Alt Text for Accessibility
 ===========================
 
 The purpose of alt text is to serve as a functional equivalent for an image.
-Every image added to the documentation must have alt text that makes the
-purpose of the image clear to those who are using screen readers.
+Every image that you add to the edX documentation must have alt text that makes
+the purpose of the image clear to those who are using screen readers.
 
 The following examples are of useful alt text.
 
@@ -236,8 +245,8 @@ When you write alt text, follow these guidelines.
 Image Sizes
 ===========================
 
-Save the screen shot as the original size. Set size in document. This way a
-user can click the image in the document to enlarge it.
+When you save a screen shot, do not reduce it in size. You can define the image width in the rst file.
+
 
 .. note that this only seems to control size in HTML output, not in PDFs.
 .. - Alison 25 Sept 2015

--- a/en_us/edx_style_guide/source/intro.rst
+++ b/en_us/edx_style_guide/source/intro.rst
@@ -10,8 +10,6 @@ edX documentation team, other edX employees, and translation teams and open
 source contributors around the world.
 
 The edX documentation team follows the *Microsoft Manual of Style*, 4th
-edition. Terms that are not covered by the *Microsoft Manual of Style*, and 
-company or team decisions about usage which differs from those the 
-manual are documented here.
-
-
+edition. This guide documents terms and usage choices that are not covered by
+the *Microsoft Manual of Style*. It also documents company and team decisions
+about usage that differ from the *Microsoft Manual of Style*.

--- a/en_us/edx_style_guide/source/preferred.rst
+++ b/en_us/edx_style_guide/source/preferred.rst
@@ -4,159 +4,109 @@
 Preferred Usage
 #################
 
-* Write short, clear sentences of no more than 20 words. Avoid dependent
-  clauses.
-
-* Beware of fused sentences. Use commas to break sentences into component
-  phrases. For example, change "Locate the course you want to re-run and click
-  **Re-Run Course**." to "Locate the course you want to re-run, and then
-  select **Re-Run Course**."
-
-* Do not use "the following" as a noun or to introduce a list.
-
-* Use "have to," "must," or "EdX recommends" rather than "should."
-
-* Avoid redundancy in phrases.
-
-  * Create a new {noun} --> prefer Create a {noun}
-
-  * Delete or edit an existing {noun} --> prefer Delete or edit a {noun}
-
-
 .. list-table::
   :widths: 20 80
 
-  * - Abbreviations
-    - Only use for standards of measurement, such as kB.
+  * - can, might, and may
+    - Use the verb "can" to describe ability, capability, or capacity. Use
+      "might" to describe possibility or eventuality. Because "may" implies
+      permission, the edX documentation team prefers to use one of the other
+      two verbs.
+  * - capitalization
+    - Use title capitalization for headings. When referring to elements in the
+      user interface, follow the capitalization that is used in the labels or
+      text.
 
-      Do not use Latin abbreviations. For example, replace "etc." with "and so
-      on".
+      Do not capitalize job titles, such as professor, instructor, or program
+      manager. Do not capitalize terms unless they are trademarks, so refer to
+      the instructor dashboard or a course about video rather than the
+      Instructor Dashboard or a course About video.
 
-      Do not use clipped terms, such as spec, quotes, or rep. Exception: "The
-      edX mobile app" is the correct term.
-
-  * - Active voice
-    - Use active voice as much as possible. For example, rephrase "These events
-      are emitted by the browser when a user selects **Save**." as "The browser
-      emits these events when a user select **Save**."
-
-  * - Acronyms
-    - Always spell out the term, then follow it with the acronym in
-      parentheses, the first time it is mentioned in an .rst file.
-
-      For example, "Students see your course in the learning management system
-      (LMS)."
-
-  * - Capitalization
-    - Capitalize headings. Do not capitalize job titles, such as professor,
-      instructor, or program manager.
-  * - Caution block
-    - Do not use. Use a note block or a warning block instead.
-  * - Contractions
+  * - contractions
     - Do not use.
-  * - Cross-references
-    - Introduce stand-alone cross-references with "For more information, see
-      ``{topic name}``. (Do not use the more abrupt "See ``{topic name}``.")
-      An exception is in the Glossary, where cross-references to other entries
-      in the Glossary should use "See" (when there is no other information in
-      the current entry) or See Also (when the current entry is complete in
-      itself and you provide a cross-reference to a related entry).
+  * - cross-references
+    - Introduce standalone cross-references to other edX topics with the
+      phrase, "For more information, see ``:ref:`{topic name}```". To include
+      more specific information about the material you are referencing, use the
+      expanded phrase, "For more information about {task or concept}, see
+      ``:ref:`{topic name}```".
 
-      For inline cross-references, create links to words in the sentence, but
-      don't use the name of the topic itself unless the capitalization works
-      with the sentence. For example: "You can use the ``:ref:`course launch
-      checklist<Course Launch Checklist>``` to verify that the course is
-      ready for release."
+      Exception: In the glossary, cross-references to other glossary entries
+      begin with, "See ``:ref:`{topic name}```" if the current entry consists
+      only of the cross reference. To refer to a related entry, use "See also
+      ``:ref:`{topic name}```".
 
-      To promote a better experience for screen readers, provide the title of
-      the destination in each cross-reference link, and not just a URL. In
-      addition, avoid including multiple links to the same destination on a
-      single HTML page.
+      To include a cross-reference inline, extend the cross-reference to
+      include a phrase that makes sense in context. In this example, to create
+      a sentence with the correct capitalization, "course launch checklist" is
+      added to the cross-reference markup. "To verify that the course is ready
+      for release, you can use the ``:ref:`course launch checklist<Course
+      Launch Checklist>```."
 
-  * - Dates
-    - Format dates as ``DD Mon YYYY`` or ``DD Month YYYY``. For example: ``11
-      Jan 2015``
-  * - File types
-    - Include the period before the file type abbreviation, and make the file
-      type lowercase. For example: "Download a .csv file on the Instructor
-      Dashboard." If necessary, explain the file type. For example: "A Word
-      (.doc) file."
-  * - Headings
-    - Use a gerund to start the title of top level section headings. For topics
-      that introduce a concept, use a gerund to start the title. For topics
-      that describe a procedure, use an imperative verb to start the title. Do
-      not use nouns or noun phrases.
-  * - Hyphenation
-    - Minimize the use of hyphenation and present combinations as either two
-      separate words or a single word. Use hyphens only when the meaning is
-      unclear without them. For exceptions to this rule, see the :ref:`word
-      list<Word List>`.
-  * - Images
-    - Minimize use of screen shots. For more information, see :ref:`Images`.
+      For a cross-reference to an external resource, provide the title of the
+      destination, not just a URL. This style promotes a better experience
+      for those using screen readers. In addition, avoid repeating links to the
+      same destination multiple times on a single HTML page.
 
-  * - Lists
-    - Introduce an unordered list with a complete sentence that ends in a
-      period. See also "steps."
+      Exception: use "edx.org" to refer to the https://www.edx.org website.
 
-      Each item in the list should be able to stand on its own, rather than
-      complete an introductory sentence fragment. Present listed items as
-      complete sentences with terminal periods, unless each item is short
-      (three words or fewer).
+  * - dates
+    - Format dates as ``DD Mon YYYY`` or ``DD Month YYYY``. For example, ``11
+      Jan 2015``. Do not use both date formats within the same .rst file.
+  * - first person
+    - Do not use "I" or "me" unless you are following the text of a user
+      interface label or message. Avoid using "we". If edX or another entity
+      has established a best practice, identify the the entity that recommends
+      that practice by name.
+  * - heading style
+    - Use title case for all headings. For a top level section heading and for
+      topics that introduce concepts, use a verb in gerund form to start the
+      title. For topics that describe a procedure, use an imperative verb to
+      start the title.
 
-  * - Mood
-    - Use the indicative and imperative moods. Avoid the subjunctive mood.
-  * - Notes
-    - Use when you want the user to pay special attention to an instruction or
-      idea.
-  * - Numbers
-    - Spell out numbers from zero to nine and use numerals for 10 and above,
-      even in the same sentence. For example: "You may select five, six, or 12
-      users."
-  * - Passive voice
-    - Do not use unless absolutely necessary. It frequently makes the actor
-      unclear.
-  * - Pronouns
+      For example, "Adding Course Updates and Handouts", "Adding a Course
+      Update", and "Identify a Course Handout".
+
+      Avoid the use of nouns or noun phrases without a verb as headings.
+
+  * - hyphenation
+    - Minimize the use of hyphenated compounds. Present compound words as
+      either two separate words or a single word. Use hyphens only when the
+      meaning is unclear without them. For exceptions to this rule, see the
+      :ref:`word list<Word List>`.
+  * - images
+    - Minimize the use of screen shots. For more information, see
+      :ref:`Images`.
+  * - lists
+    - Introduce a list with a complete sentence that ends in a period. Do not
+      use "the following" as a noun or to introduce a list. Instead, include
+      the noun. For example, "The .csv file includes the following columns." or
+      "When pretty printed, this comment has the following format.""
+  * - pronouns
     - Avoid ambiguous pronouns such as all, each, many, several, some, that,
       them, these, those.
-  * - Punctuation
+  * - punctuation
     - Avoid slashes, particularly "and/or". They introduce ambiguity.
 
       Avoid em dashes. Putting non-restrictive relative clauses into separate
       sentences leads to simpler, clearer writing.
 
-      Do not use smart quotes or smart apostrophes. Use the straight versions.
+      Do not use smart quotes or smart apostrophes. Use the straight versions
+      of these marks.
 
-  * - Steps
-    - To introduce an ordered list of procedural steps, use "To do this,
-      follow these steps." Note the complete sentence and terminal period.
-
-      If you are describing a procedure for the user to follow, use numbered
-      steps instead of writing out the procedure as a narrative.
-
-      If you are explaining a problem that occurs, and the problem is
-      relatively simple, use a narrative. For example: "When you go to the
-      Instructor Dashboard, download a .csv file of your learners, and then
-      open the .csv file, you may see incorrect information in the file." If
-      the problem is more complex, write it out as steps.
-
-  * - Tables
-    - When you include a table, be sure to include a heading row or column.
-  * - Tense
-    - Prefer the present tense, particularly for procedural steps.
-  * - UI terms
-    - When you describe UI elements, leave out the UI element name. For
-      example, type "click OK" instead of "click the OK button."
-
-      If the UI label has an error, such as a spelling mistake, write the word
-      or phrase correctly in the documentation.
-
-  * - Warnings
-    - Only use when a user might have significant problems, such as data loss
-      or a security vulnerability.
-  * - White space
-    - Plan for the expansion of text, particularly in images such as
-      flowcharts.
-  * - Word choice
+  * - redundancy
+    - Avoid including unnecessary words. For example, instead of "Create a new
+      {noun}", use "Create a {noun}", and instead of "Delete or edit an
+      existing {noun}", use "Delete or edit a {noun}."
+  * - steps
+    - To introduce an ordered list of procedural steps, use "To {verb task},
+      follow these steps." Note the complete sentence and terminal period. For
+      example, "To add a course update, follow these steps.""
+  * - tables
+    - When you include a table, be sure to include a heading row. In addition,
+      consider whether a stub column is appropriate. The heading row and stub
+      column provide useful context for users of screen readers.
+  * - word choice
     - See the :ref:`Word List` for our preferred terminology. Avoid jargon,
       colloquialisms, and humor.
 
@@ -166,6 +116,3 @@ Preferred Usage
       Be careful of commonly used phrases that introduce ambiguity. For
       example, instead of "When the process completes..." use "After the
       process completes..."
-
-
-

--- a/en_us/edx_style_guide/source/templates/concept.rst
+++ b/en_us/edx_style_guide/source/templates/concept.rst
@@ -14,11 +14,11 @@ while additions might be needed to support new options and their use cases,
 they tend to require less rewriting than task topics.
 
 Concept topics are typically followed by at least one task topic. When they
-introduce complex features, they are followed by a set of additional concept
+introduce complex features, they can be followed by a set of additional concept
 topics and related task topics.
 
 ******************************
-Structure of a Concept Topic
+Structuring a Concept Topic
 ******************************
 
 At a minimum, a concept topic includes the following components.
@@ -38,7 +38,7 @@ For more information, see the :ref:`Concept Template`.
 Example Concept Topics
 ******************************
 
-The :ref:`partnercoursestaff:document index` guide contains these examples of
+The *Building and Running an edX Course* guide contains these examples of
 concept topics.
 
 * :ref:`partnercoursestaff:Cohorts Overview` introduces a complex
@@ -54,13 +54,6 @@ concept topics.
 * :ref:`partnercoursestaff:Course_Wiki` introduces a section of related
   concepts and tasks. It defines a wiki in the context of an edX course, and
   provides example uses.
-
-The :ref:`partnercoursestaff:Processing Video Files Index` guide contains these
-examples.
-
-* :ref:`partnercoursestaff:Video Processing Overview` introduces the entire
-  guide. It describes the purpose, and value, of the video pipeline to course
-  teams and media specialists at edX member partner organizations.
 
 * :ref:`partnercoursestaff:Add a Video Transcript` introduces a series of
   tasks.

--- a/en_us/edx_style_guide/source/templates/concept_template.rst
+++ b/en_us/edx_style_guide/source/templates/concept_template.rst
@@ -4,31 +4,30 @@
 {Using this Concept Template}
 ###############################
 
-{Replace this sentence, and all subsequent values in braces ({}), with your
-own text.}
+{Replace or remove this sentence, and all subsequent values within and
+including braces ({}), with your own text.}
 
 {Place the introductory statement here.}
 
-{Optional: include an additional paragraph with a link to a related topic.
-Alternative: include a list of links to related topics.}
+{Include a contents directive. This directive resolves to a set of
+linked cross references to the next level headings in this file.}
 
-* {link}
-* {link}
-
-******************************
-{Optional Example}
-******************************
-
-{Description}
+.. contents::
+  :local:
+  :depth: 1
 
 ******************************
-{Optional Subheading} 
+{Optional Overview}
 ******************************
 
 {Description}
 
 ******************************
-{Optional Subheading}
+{Optional Procedure}
 ******************************
 
-{Description}
+Before you {complete task, list its prerequisites if any}.
+
+To {complete task}, follow these steps.
+
+#. {first step}.

--- a/en_us/edx_style_guide/source/userinterface.rst
+++ b/en_us/edx_style_guide/source/userinterface.rst
@@ -1,110 +1,76 @@
 .. _Documenting the User Interface:
 
-###############################
-Documenting the User Interface
-###############################
+########################################
+Documenting User Interface Interactions
+########################################
 
-In describing UI interactions, we refer to labels alone, rather than include
-specific descriptions of the UI controls.
+When you describe interactions with the user interface, refer to the control
+labels and do not describe the control types.
 
-* Incorrect: In the **Randomization** drop-down list, click the **Never** option.
+* Incorrect: In the **Randomization** drop-down list, click the **Never**
+  option.
 
 * Correct: From the **Randomization** list, select **Never**.
 
-This is primarily to reduce word count, and also because the UI can change
-without notice. Another reason is related to the use of screen readers:
-controls can be styled to appear as other controls, such as a link that is
-styled to look like a button. The screen reader organizes all link selections
-together, and all button selections together, so if the documentation refers
-to a link as a button, we can actually make it harder for people to find the
-choice that they want.
+This convention reduces word count and makes the documentation less likely to
+go out of date after a software change.
 
-*******************
-List of UI Elements
-*******************
+Because screen readers organize all link selections together, and all button
+selections together, and so on, if you do include the control type, it is
+critical that you describe it as it is coded, even if it is styled to look like
+a different type of control.
 
-To do: Add images to table
+***********************
+List of edX UI Elements
+***********************
+
+This table lists edX-specific terms and exceptions to Microsoft style.
 
 .. list-table::
    :widths: 20 80
 
-   * - box
-     -
-   * - button
-     -
    * - checkbox
-     - One word. Users can select more than one checkbox at a time. See also
-       "radio button".
+     - Use a single word, not "check box". Users can select more than one
+       checkbox at a time.
 
-       Users "select" or "clear"  a checkbox. They do not "check" or
-       "deselect" them.
+       Users "select" or "clear" a checkbox. They do not "check" or "deselect"
+       them.
 
    * - component editor
-     -
-   * - control
-     -
+     - Present in lower case.
    * - course accordion
-     - Do not use. Use "left pane." Formerly the list of sections and
-       subsections in the left pane of the **Course** page in the LMS.
-   * - course pages
-     -
-   * - course tabs
-     -
+     - Do not use. Previously used to describe the navigation frame that shows
+       course sections and subsections at the left side of the **Course** page
+       in the LMS. Use "left pane."
    * - dialog box
-     - A small box that opens temporarily when a user performs an action. The
-       user interacts with elements in the dialog box, which then disappears.
-       A dialog box might just have cancel/OK buttons, or it may ask a user to
-       specify a file.
-   * - dropdown menu or list
-     -
+     - Do not use "dialog" alone to refer to the user interface control. Do not
+       use "modal" or "modal dialog".
    * - field
-     - A box that a user types or pastes text into. Preferred over "text box".
-   * - heading
-     -
+     - A control that accepts user input that is typed or pasted in. Use in
+       place of "text box".
    * - icon
-     - A UI control that has an image for a label instead of words. Named
-       icons have a mouseover tip that is used for identification. Unnamed
-       icons, such as icons in a smartphone app, must be described.
+     - A user interface control that has an image for a label instead of text.
+       To identify icons, use the mouseover help text as the icon label. If the
+       icon does not have help text, such as an icon in a mobile app, it must
+       be described.
    * - learning sequence, the
-     - The strip at the top of the **Course** page in the LMS that lists
-       the units in a subsection. Learning sequence is preferred over the
-       previous term, "course ribbon".
-   * - left pane
-     - For an unnamed panel on the left side of the screen.
-   * - page
-     -
-   * - pane
-     -
-   * - panel
-     - A field on the right or left that doesn't extend for the entire length
-       of the page.
-   * - pop-up menu
-     - A list of related options that opens when a user performs an action.
-       The menu disappears after the user selects an option.
-   * - publishing status panel
-     -
-   * - radio button
-     - A circular control that allows users to select only one of a list of
-       options. See also "checkbox".
-   * - right pane
-     - For an unnamed panel on the right side of the screen.
-   * - screen
-     - Larger than a dialog box, with more options.
-   * - window
-     -
+     - The horizontal navigation frame that appears above course content on
+       the **Course** page in the LMS. An icon appears in the learning sequence
+       for each unit in the selected subsection. Use learning sequence instead
+       of "course ribbon" or "filmstrip".
 
 
-****************************
-Standards for UI Labels
-****************************
+***********************************
+Standards for User Interface Labels
+***********************************
 
-When the doc team contributes to the wording and formatting of UI labels, we
-follow these standards.
+When the edX documentation team writes or copy edits labels, we follow these
+standards.
 
-All UI elements should use sentence capitalization except the following items,
-which use title capitalization.
+Use title capitalization for labels for the following user interface elements.
 
 * Page titles
 * Tab titles
 * Buttons (these usually have only a few words)
 
+Use sentence capitalization for all other labels.

--- a/en_us/edx_style_guide/source/wordlist.rst
+++ b/en_us/edx_style_guide/source/wordlist.rst
@@ -11,27 +11,27 @@ Word List
    * - Term
      - Description and Examples
    * - course team, course team member
-     - Use instead of "instructor", professor", "course author", "course
-       staff", "faculty",  etc.
+     - Use instead of instructor, professor, course author, course
+       staff, faculty, and so on.
    * - discussion, course discussions
-     - Use instead of "forum" or "discussion forum".
-   * - drop-down
-     - Use drop-down throughout the guides except when directly referring to
-       the edX problem type, which is labeled "dropdown". As always, avoid
-       using in procedural steps to describe a particular type of UI control.
-   * - edx, EdX, edX
-     - The name of our company is presented in mixed case: edX. However, when a
-       sentence begins with the company name, the first letter is also
-       capitalized as in the following example. "EdX is the name of our
-       company." Our websites, edx.org and edge.edx.org, are presented in all
-       lower case.
+     - Use instead of forum or discussion forum.
+   * - drop-down, dropdown
+     - The edX problem type is labeled "dropdown". If it is necessary to
+       describe a particular type of user interface control, use drop-down.
+   * - edx, edX, EdX
+     - The company name is presented in mixed case: edX or edX, Inc. However,
+       when a sentence begins with the company name, the first letter is also
+       capitalized, as in the following example. "EdX provides the edX Demo
+       course..." Present the edx.org website in all lower case.
    * - email
-     - Not e-mail or Email. Can be a noun or adjective (for example, "Send an
-       email" or "Send an email message"). Do not use as a verb.
+     - Do not hyphenate e-mail, and use Email only at the start of a sentence
+       or when using title capitalization. Use email to modify a noun. For
+       example, prefer "Send an email message" to "Send an email". Do not use
+       as a verb.
    * - ID
-     - Use instead of id or Id.
-   * - Instructor Dashboard
-     - Capitalize both words.
+     - Capitalize. Use instead of id or Id.
+   * - instructor dashboard
+     - Lowercase both words.
    * - learner
      - Use instead of "student", except when referring to a UI label.
    * - page
@@ -43,18 +43,18 @@ Word List
      - Use to refer to partners' main edX contact, not program manager. Do not
        capitalize either word.
    * - plug-in
-     - Use instead of plugin.
+     - Use instead of plugin or plug in.
    * - privilege
      - Use instead of "user rights". The roles that grant privileges to users
-       are "course creator", "admin", and "staff". The name of the role should
-       only be used when the privilege is an explicit requirement to complete
+       are "course creator", "admin", and "staff". These role names should only
+       be used when having the privilege is an explicit requirement to complete
        an activity.
    * - sample
      - Use instead of "snippet". "Example" can also be used.
    * - section
-     - In our guides, refers to any part of a guide that is a parent to other
-       content, including other sections or individual topics. Use instead of
-       chapter.
+     - In the edX guides, use "section" to refer to any part of a guide that is
+       a parent to other content, including other sections or individual
+       topics. Use instead of "chapter".
    * - select
      - Use instead of "click" (mouse), "press" (keyboard), or "tap"
        (smartphone). Accessible alternatives are "choose" (for a UI element
@@ -65,26 +65,18 @@ Word List
    * - sign-in (adj)
      - Use instead of "login" or "log in".
    * - smartphone
-     - One word. Use instead of "mobile device": Android smartphones and
-       iPhones.
-   * - Student Dashboard
-     - TBD: Capitalize?
+     - One word. Use instead of "mobile device". For example, Android
+       smartphones and iPhones.
+   * - student dashboard
+     - Present both words in lowercase.
    * - third party (n), third-party (adj)
      - "Third party" is a noun: "This product comes from a third party".
        "Third-party" is the adjective form: "third-party software".
    * - topic
-     - In our guides, refers to the concepts or procedures that are the
-       lowest-level contents of a section.
-   * - URL
-     - Use instead of url. When providing a URL in documentation, omit trailing
-       slashes (http://edx.org instead of http://edx.org/).
+     - In the edX guides, the concepts or procedures that are the
+       lowest level contents of a section are referred to as topics.
    * - username
      - Use instead of "user name".
-   * - View as Staff (or Student)
-     - Be sure to cast sentences in terms of the selections that people
-       actually have to make in the user interface. As an example, if you
-       select a control labeled **View as Staff**, avoid referring to the
-       result as the staff view or student view.
    * - XBlock
      - Use instead of "Xblock" or "xBlock".
    * - GitHub

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -62,7 +62,7 @@
 .. _edX Partner Support: https://partners.edx.org/edx_zendesk
 
 
-.. _edX pattern library: http://ux.edx.org/elements/colors/
+.. _edX pattern library: http://ux.edx.org/design_elements/colors/
 
 .. GitHub Links
 

--- a/en_us/shared/exercises_tools/external_graders.rst
+++ b/en_us/shared/exercises_tools/external_graders.rst
@@ -150,7 +150,7 @@ The grader receives a submission as a JSON object that has the following keys:
 
     * **random_seed**: An integer that contains the seed that was used to
       initialize the randomization script that may be attached to the problem.
-        
+
   * **student_response**: A string that contains the learner's code
     submission. A learner can submit code by entering a string in the LMS or by
     attaching a file.
@@ -191,13 +191,17 @@ that indicates whether the submission was correct, the score, and any message
 the tests create.
 
 In the following example, the learner's submission was correct, the score was
-1, and the tests created a brief message::
+1, and the tests created a brief message.
 
- {
-  "correct": true,
-  "score": 1,
-  "msg": "<p>The code passed all tests.</p>"
- }
+.. Translators: The "msg" text that is included between the paragraph <p></p> tags can be translated.
+
+::
+
+  {
+   "correct": true,
+   "score": 1,
+   "msg": "<p>The code passed all tests.</p>"
+  }
 
 .. _Building an External Grader:
 


### PR DESCRIPTION
@catong @srpearce, @pdesjardins  I’m moving ahead a bit with bringing our style guide up to date with recent decisions, removing information that is already covered in the Microsoft Manual of Style, streamlining, and otherwise preparing for publication.
Please comment on any errors or items that both surprise you and that you disagree with ;)
