### PR TITLE
DOC-2950: Update quality docs for safe templates

### DIFF
--- a/en_us/developers/source/conventions/safe_templates.rst
+++ b/en_us/developers/source/conventions/safe_templates.rst
@@ -936,7 +936,15 @@ The safe template linter is a tool to help you make sure that you are
 following best practices inside edx-platform. It is not yet possible to run the
 linter against other repositories.
 
-To run the linter on all of edx-platform, use the following command.
+To run the linter on the changes in your current Git branch, use the following
+command.
+
+.. code-block:: bash
+
+    paver run_safecommit_report
+
+To run the linter on the entire edx-platform repository, use the following
+command.
 
 .. code-block:: bash
 
@@ -949,18 +957,12 @@ example of how to lint a single file.
 
     ./scripts/safe_template_linter.py cms/templates/base.html
 
-For additional options you can use to run the linter, use the following command.
-
-.. code-block:: bash
-
-    ./scripts/safe_template_linter.py --help
-
-To run the linter on the changes in your current Git branch, use the following
+For additional options that you can use to run the linter, use the following
 command.
 
 .. code-block:: bash
 
-    ./scripts/safe-commit-linter.sh
+    ./scripts/safe_template_linter.py --help
 
 The following code block shows sample output from the linter.
 

--- a/en_us/developers/source/testing/code-quality.rst
+++ b/en_us/developers/source/testing/code-quality.rst
@@ -4,43 +4,76 @@
 Code Quality
 ************
 
-In order to keep our code as clear and readable as possible, we use various
-tools to assess the quality of pull requests:
+We use a variety of tools to check for errors and vulerabilities, and to enforce
+a coding standard and coding style.
 
-* We use the `pep8`_ tool to follow `PEP-8`_ guidelines
-* We use `pylint`_ for static analysis and uncovering trouble spots in our code
-
-Our codebase is far from perfect, but the goal is to steadily improve our quality
-over time. To do this, we wrote a tool called `diff-quality`_ that will
-only report on the quality violations on lines that have changed in a
-pull request. Using this tool, we can ensure that pull requests do not introduce
-any new quality violations -- and ideally, they clean up existing violations
-in the process of introducing other changes.
-
-To check the quality of your pull request, just go to the top level of the
-edx-platform codebase and run::
+To check the quality of your pull request, go to the top level of the edx-
+platform codebase and run the following command. ::
 
     $ paver run_quality
 
-You can also use the `paver run_pep8`` and ``paver run_pylint`` commands to run just pep8 or
-pylint.
+The following topics provide additional details on the tools that we use.
+
+.. contents::
+   :depth: 1
+   :local:
+
+Clean Code
+==========
+
+Here are the primary tools we use to keep our code clean.
+
+* We use the `pep8`_ tool to follow `PEP-8`_ guidelines.
+* We use `pylint`_ for static analysis and to uncover trouble spots in our
+  code.
+
+Our codebase is far from perfect, but the goal is to steadily improve its
+quality over time. To do this, we wrote a pypi package called `diff-cover`_,
+which includes the tool diff-quality. The diff-quality tool reports on quality
+violations only on lines that have changed in a pull request. Using this tool,
+we can ensure that pull requests do not introduce new quality violations, and
+also clean up existing violations in the process of introducing other changes.
+
+To run diff-quality along with our other quality based tools, go to the top
+level of the edx-platform codebase and run the following command. ::
+
+    $ paver run_quality
+
+You can also use the ``paver run_pep8`` and ``paver run_pylint`` commands to
+run only pep8 or pylint.
 
 This will print a report of the quality violations that your branch has made.
 
-Although we try to be vigilant and resolve all quality violations, some Pylint
-violations are just too challenging to resolve, so we opt to ignore them via
+Although we try to be vigilant in resolving all quality violations, some
+Pylint violations are too challenging to resolve, so we opt to ignore them via
 use of a pragma. A pragma tells Pylint to ignore the violation in the given
 line. An example is::
 
     self.assertEquals(msg, form._errors['course_id'][0])  # pylint: disable=protected-access
 
 The pragma starts with a ``#`` two spaces after the end of the line. We prefer
-that you use the full name of the error (``pylint: disable=unused-argument`` as
-opposed to ``pylint: disable=W0613``), so it's more clear what you're disabling
-in the line.
+that you use the full name of the error (``pylint: disable=unused-argument``
+as opposed to ``pylint: disable=W0613``), to make more clear what you are
+disabling in the line.
 
 .. _PEP-8: http://legacy.python.org/dev/peps/pep-0008/
 .. _pep8: https://pypi.python.org/pypi/pep8
 .. _coverage.py: https://pypi.python.org/pypi/coverage
 .. _pylint: http://pylint.org/
-.. _diff-quality: https://github.com/Bachmann1234/diff-cover
+.. _diff-cover: https://github.com/Bachmann1234/diff-cover
+
+Safe Code
+=========
+
+To keep our code safe from Cross Site Scripting (XSS) vulnerabilities,
+the Safe Template Linter is also run as part of ``paver run_quality``.
+
+To run the Safe Template Linter against your current branch, run the following
+command.
+
+.. code-block:: bash
+
+   paver run_safecommit_report
+
+For more options for running the Safe Template Linter, or instructions for
+fixing violations, see :ref:`Safe Template Linter`.


### PR DESCRIPTION
## [DOC-2950](https://openedx.atlassian.net/browse/DOC-2950)

Update quality docs for safe templates.  This is dependent on the related TNL-4509 landing.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @benpatterson 
- [x] Subject matter expert: @jzoldak 
- [x] Doc team review (sanity check/copy edit/dev edit): @catong  
### Testing
- [X] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment
- [x] Squash commits
