### PR TITLE
DOC-2822 - Correct doc to indicate that hiding graded content affects grading

### DIFF
--- a/en_us/shared/course_features/timed_exams.rst
+++ b/en_us/shared/course_features/timed_exams.rst
@@ -133,6 +133,10 @@ exams, but are available again for viewing after the exam due date has passed.
 You can configure a timed exam to remain hidden even after the exam due date
 has passed.
 
+When you keep a timed exam hidden after its due date, learners cannot see the
+content of the exam, but the grades that they received on the exam are not
+affected, and their scores for the exam remain visible on the **Progress** page.
+
 .. note:: This setting applies only to timed exams. It has no effect on other
    types of special exams, including proctored or practice exams.
 

--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -84,9 +84,9 @@ the following topics.
 Content Hidden from Learners
 *****************************
 
-You can hide content from learners. You can hide content in both
-instructor-paced and self-paced courses. Such content is never visible to
-learners, regardless of the release and publishing status.
+You can hide content from learners in both instructor-paced and self-paced
+courses. Such content is never visible to learners, regardless of the release
+and publishing status.
 
 You might hide a unit from learners, for example, when that unit contains an
 answer to a problem in another unit of that subsection. After the problem's due
@@ -96,6 +96,12 @@ You could also hide a unit from learners if you wanted to use that unit to
 provide instructions or guidance meant only for the course team. Only course
 team members would see that unit in the course.
 
+.. note:: As a best practice, do not hide sections, subsections, or units that
+   contain graded content. When the platform performs grading for any learner,
+   the grading process does not include problems that a learner does not have
+   access to, in other words, any content that is hidden from that learner.
+   For more details, see :ref:`Hiding Graded Content`.
+
 You can hide content at different levels, as described in the following topics.
 
 * :ref:`Sections<Hide a Section from Students>`
@@ -104,11 +110,12 @@ You can hide content at different levels, as described in the following topics.
 
 .. note::
  When you make a previously hidden section or subsection visible to learners,
- some content in the section or subsection may remain hidden. If you have
+ some content in the section or subsection might remain hidden. If you have
  explicitly set a subsection or unit to be hidden from learners, this
  subsection or unit remains hidden even when you change the visibility of the
  parent section or subsection. Unpublished units remain unpublished, and
  changes to published units remain unpublished.
+
 
 .. _Hiding Graded Content:
 
@@ -116,11 +123,15 @@ You can hide content at different levels, as described in the following topics.
 Hiding Graded Content
 =====================
 
-If you hide a section, subsection, or unit that contains graded problems,
-grading is not affected. The hidden problems are still counted when the edX
-platform calculates grades. If a problem was visible at one time, and learners
-submitted answers for it, they still receive the credit they earned if you
-later hide the problem.
+Grading is affected if you hide a section, subsection, or unit that contains
+graded problems. When the platform performs grading for any learner, the grading
+process does not include problems that the learner does not have access to, in
+other words, any content that is hidden from that learner.
+
+.. note:: Grading is not affected for timed exams when you select the setting to
+   keep timed exam content hidden from learners even after the exam due date has
+   passed. For more information, see :ref:`Timed Exams`.
+
 
 .. _Content Groups:
 

--- a/en_us/shared/grading/graded_subsections.rst
+++ b/en_us/shared/grading/graded_subsections.rst
@@ -8,22 +8,19 @@ After you configure assignment types, as you are organizing your course, you
 set the assignment type for subsections that contain problems that are to be
 graded.
 
-Each subsection that contains problems to be graded can include only one
-assignment type.
+You can only set assignment types and due dates at the subsection level. You
+cannot set assignment types or due dates for entire sections or for individual
+units within subsections. Additionally, you can designate a subsection as one,
+and only one, of the assignment types you configured.
 
-.. note::
- You can only set assignment types and due dates at the subsection level. You
- cannot set assignment types or due dates for entire sections or for individual
- units within subsections. Additionally, you can designate a subsection as one,
- and only one, of the assignment types you configured.
+.. note:: You can create problems in Studio without specifying an assignment
+   type for the subsection. Scores for such problems are listed as "practice
+   scores" on the learner's **Progress** page and do not count toward the
+   learner's grade.
 
-For more information, see :ref:`Developing Course Subsections`.
-
-For instructions on designating a subsection as a graded assignment, see
-:ref:`Set the Assignment Type and Due Date for a Subsection`.
-
-For more information about how to designate a subsection as a timed exam, see
-:ref:`Timed Exams`.
+   Hidden sections, subsections, or units that contain graded content are not
+   included in grading and also do not count toward a learner's grade. For
+   more information, see :ref:`Hiding Graded Content`.
 
 Within a graded subsection, you create problems of the type designated for that
 subsection. You cannot not mix problems of different assignment types in the
@@ -34,10 +31,12 @@ specific topic, create two subsections. Set one subsection as the Homework
 assignment type and the other as the Lab assignment type. Both subsections can
 contain other content as well as the actual homework or lab problems.
 
-.. note::
- You can create problems in Studio without specifying that the subsection is an
- assignment type. However, such problems do not count toward a learner's grade.
+For more information about creating problems and developing subsections, see
+:ref:`Working with Problem Components` and :ref:`Developing Course
+Subsections`.
 
-For more information about creating problems, see :ref:`Working with Problem
-Components`.
+For more information about designating a subsection as a graded assignment,
+see :ref:`Set the Assignment Type and Due Date for a Subsection`.
 
+For more information about how to designate a subsection as a timed exam, see
+:ref:`Timed Exams`.


### PR DESCRIPTION
[DOC-2822](https://openedx.atlassian.net/browse/DOC-2822)
This PR corrects an inaccurate statement that hiding graded content does not affect a learner's grades. Adds a cross reference to the "Hiding Graded Content" topic from the section about graded subsections. Attempts to improve the flow of the graded subsection topic while adding this additional info and link (too many separate notes).

Further changes are to come that provide more details of grading behavior and how it is affected by visibility, but these will not be part this PR.

REVIEWERS:
- [x] @sstack22
- [x] @jaakana
- [x] @srpearce or @lamagnifica or @pdesjardins 
