### PR TITLE
Added the course-catalog-api-guide project to the list of RTD project…

### DIFF
--- a/utilities/build-rtd-documents.sh
+++ b/utilities/build-rtd-documents.sh
@@ -18,19 +18,25 @@
 # C1MQH7NLG944:~ peterdesjardins$ ./build-rtd-documents.sh
 
 
-DOC_IDS="edx \
-         edx-partner-course-staff \
-         edx-insights \
-         devdata \
-         edx-guide-for-students \
-         edx-installing-configuring-and-running \
-         open-edx-building-and-running-a-course \
-         open-edx-learner-guide \
-         edx-developer-guide \
-         edx-open-learning-xml \
-         xblock-tutorial \
-         edx-release-notes
-         "
+if [ -z ${1} ]
+then
+   DOC_IDS="edx
+            edx-partner-course-staff
+            edx-insights
+            devdata
+            edx-guide-for-students
+            edx-installing-configuring-and-running
+            open-edx-building-and-running-a-course
+            open-edx-learner-guide
+            edx-developer-guide
+            edx-open-learning-xml
+            xblock-tutorial
+            edx-release-notes
+            course-catalog-api-guide
+            "
+else
+   DOC_IDS=${1}
+fi
          
 # xblock - Removed this project because it is failing local builds
 # edx-platform-api - Removed from list because of its separate repo


### PR DESCRIPTION
## [DOC-2980](https://openedx.atlassian.net/browse/DOC-2980)

Added the course-catalog-api-guide project to the list of RTD projects in the doc build script. Also added an option to pass a doc ID in as a command line argument, to make rebuilding doc drafts quicker.
### Reviewers
- [x] Subject matter expert: @nedbat 
- [x] Doc team review (sanity check): @lamagnifica @catong @srpearce 
### Post-review
- [ ] Squash commits
