### PR TITLE
Move Gen Info section of learner's guide to end

### DIFF
--- a/en_us/students/source/front_matter/change_log.rst
+++ b/en_us/students/source/front_matter/change_log.rst
@@ -2,27 +2,15 @@
 Change Log
 ############
 
-The edX documentation team no longer maintains a change log for each guide. For
-a weekly summary of platform changes, refer to the *EdX Release Notes* on the
-`docs.edx.org`_ website.
+As of 1 January 2016, the edX documentation team no longer maintains a change
+log for each guide. For a weekly summary of platform changes, refer to the *EdX
+Release Notes* on the `docs.edx.org`_ website.
 
-For information about changes made to the edX documentation set, the
-`edx-documentation`_ repository on GitHub provides a complete record.
+The `edx-documentation`_ repository on GitHub provides a complete record about
+changes made to the edX documentation set.
 
 .. include:: ../../../links/links.rst
 
-**********************
-2016
-**********************
-
-.. list-table::
-   :widths: 15 70
-   :header-rows: 1
-
-   * - Date
-     - Change
-   * - 18 January 2016
-     - Added the :ref:`SFD Self Paced` topic.
 
 **********************
 2015

--- a/en_us/students/source/front_matter/read_me.rst
+++ b/en_us/students/source/front_matter/read_me.rst
@@ -2,7 +2,7 @@
 Read Me
 *******
 
-The *EdX Guide for Students* is created using RST_ files and Sphinx_. You, the
+The *EdX Learner's Guide* is created using RST_ files and Sphinx_. You, the
 user community, can help update and revise this documentation project on
 GitHub::
 

--- a/en_us/students/source/index.rst
+++ b/en_us/students/source/index.rst
@@ -8,7 +8,6 @@ EdX Learner's Guide
    :numbered:
    :maxdepth: 2
 
-   front_matter/index
    SFD_introduction
    SFD_account
    sfd_dashboard_profile/index
@@ -16,7 +15,6 @@ EdX Learner's Guide
    SFD_enrolling
    SFD_credit_courses/index
    SFD_content_availability
-   SFD_licensing
    SFD_video_player
    SFD_bookmarks
    SFD_notes
@@ -30,3 +28,6 @@ EdX Learner's Guide
    sfd_discussions/index
    SFD_wiki
    SFD_mathformatting
+   SFD_licensing
+   front_matter/index
+


### PR DESCRIPTION
## [DOC-2993](https://openedx.atlassian.net/browse/DOC-2993)

This PR moves the "General Information" section of the learner's guide to the end. This information, which mentions GitHub and various other doc resources, isn't applicable to most learners and could cause confusion because it's the first thing the learner sees. Also moved the less-relevant "licensing" section to later in the doc. (NB: This doc could use a reorg! Will make a separate task for that.)
- [ ] doc review (sanity check): @lamagnifica or @pdesjardins 
