### PR TITLE
Add status message to 5-30 release notes for prod rollback

### DIFF
--- a/en_us/release_notes/source/2016/05-30-2016.rst
+++ b/en_us/release_notes/source/2016/05-30-2016.rst
@@ -1,6 +1,6 @@
-####################
-Week of 30 May 2016
-####################
+################################################
+Week of 30 May 2016 (Status: Not Yet Released)
+################################################
 
 The following information summarizes what is new in the edX platform this week.
 

--- a/en_us/release_notes/source/2016/lms/lms_0509_2016.rst
+++ b/en_us/release_notes/source/2016/lms/lms_0509_2016.rst
@@ -1,3 +1,3 @@
 The cohort management section of the instructor dashboard now displays status
 information to help course teams determine whether the feature is enabled and
-working properly. (:jira:`TNL-4393`)
+working correctly. (:jira:`TNL-4393`)


### PR DESCRIPTION
Changing gh-pages back to 25 May and adding a note to current release page.

This PR also adds a change I thought I'd made before (adding a JIRA ticket number) - technology gremlins are running amok, as I made that change before but it's not showing up on readthedocs, but it does show up on the latest version of master, so I had to make a different change to get it to show up...).

@lamagnifica @catong or @pdesjardins, can I get thumbs, please? 
