### PR TITLE
Adding a manifest file for the Google Android repo tool.

### DIFF
--- a/utilities/repo-manifest.xml
+++ b/utilities/repo-manifest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote  name="github"
+           fetch="https://github.com" />
+           
+  <default revision="master"
+           remote="github" />
+
+  <project name="edx/edx-documentation" remote="github" path="edx-documentation"/>
+  <project name="edx/edx-platform" remote="github" path="edx-platform"/>
+  <project name="edx/ecommerce" remote="github" path="ecommerce"/>
+  <project name="edx/course-discovery" remote="github" path="course-discovery"/>
+  <project name="edx/edx-certificates" remote="github" path="edx-certificates"/>
+  <project name="edx/api-manager" remote="github" path="api-manager"/>
+</manifest>
+
+<!-- Instructions
+
+This is a manifest file for the Google Android repo tool. It will clone 
+local copies of multiple git repositories, placing them in at fixed 
+relative file paths. For more information about the repo tool, see 
+http://source.android.com/source/developing.html.
+
+To use repo for edX repositories, change to an empty directory and invoke
+the following commands.
+
+curl https://storage.googleapis.com/git-repo-downloads/repo > repo
+chmod a+x repo
+./repo init -u https://github.com/edx/edx-documentation.git -m utilities/repo-manifest.xml
+./repo sync
+
+ -->


### PR DESCRIPTION
## [DOC-3009](https://openedx.atlassian.net/browse/DOC-3009)

This is a manifest file for the Google Android repo tool. It will clone local copies of multiple git repositories, placing them in at fixed relative file paths. For more information about the repo tool, see http://source.android.com/source/developing.html.

Adding this file gives us the option to write documents that share RST or other files among multiple repositories. The relative file paths between the local copies of the repositories are fixed by the manifest file. For example, the following relative file path would be valid from the edx-documentation/en_us/install_operations/source directory:

`../../../../course-discovery/docs/getting_started.rst`

I don't think this would be useful for publishing documentation on Read the Docs, but it gives us other options.

To use repo for edX repositories, change to an empty directory in a terminal and invoke
the following commands.

curl https://storage.googleapis.com/git-repo-downloads/repo > repo
chmod a+x repo
./repo init -u https://github.com/edx/edx-documentation.git -m utilities/repo-manifest.xml  # (This will only work after we merge the PR. Until then, replace the edx-documentation repo URL with https://github.com/pdesjardins/repo-combiner.git)
./repo sync
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @nedbat
- [x] Subject matter expert: @lamagnifica
- [ ] Subject matter expert: @srpearce 
- [ ] Subject matter expert: @catong 
- [ ] Subject matter expert: @jbarciauskas
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
