### PR TITLE
DOC-2956 Learners can add time zone in acct settings

### DIFF
--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -69,15 +69,16 @@ more information about subsection visibility settings, see :ref:`Hide a
 Subsection from Students`.
 
 
-.. note:: Release dates and times that you set in Studio are in Coordinated
-   Universal Time (UTC). You might want to verify that you have specified the
-   time that you intend by using a time zone converter such as `Time and Date
-   Time Zone Converter <http://www.timeanddate.com/worldclock/converter.html>`_.
+.. note:: Release dates and times that you set are in Coordinated Universal Time
+   (UTC). You might want to verify that you have specified the time that you
+   intend by using a time zone converter such as `Time and Date Time Zone
+   Converter <http://www.timeanddate.com/worldclock/converter.html>`_.
 
    Learners who have specified a time zone in their account settings see
-   course dates and times converted to their local time zone. Learners who
+   course dates and times converted to their specified time zone. Learners who
    have not specified a time zone in their account settings see course dates
    and times in UTC.
+
 
 ************************************************
 Release Statuses of Subsections

--- a/en_us/shared/getting_started/dashboard_settings_profile.rst
+++ b/en_us/shared/getting_started/dashboard_settings_profile.rst
@@ -21,7 +21,7 @@ course or browsing the course catalog.
 
 * Your :ref:`dashboard<SFD Learner Dashboard>` gives you access to course
   information, such as start and end dates, email settings, and certificates.
-  To access your dashboard, select your usernameon on any edX page.
+  To access your dashboard, select your username on on any edX page.
 
 * On your :ref:`profile page<SFD Profile Page>`, you can create a profile that
   includes an image and biographical information. To access your profile,
@@ -29,11 +29,13 @@ course or browsing the course catalog.
   **Profile**.
 
 * The :ref:`Account Settings<SFD Account Settings>` page allows you to change
-  settings such as your email address, education level, and country or region,
-  and to link your edX account to a social media or organization account. You
-  can also view a summary of any purchases you have made. To access the
-  **Account Settings** page, select the arrow next to your username on any edX
+  settings such as your email address, education level, country or region, and
+  to set the :ref:`time zone<Time Zones>` that you want course dates to display
+  in. You can link your edX account to a social media or organization account,
+  and view a summary of any purchases you have made. To access your account
+  settings at any time, select the arrow next to your username on any edX
   page, and then select **Account**.
+
 
 .. _SFD Learner Dashboard:
 
@@ -172,7 +174,6 @@ Find or Change Course Information
     In the right pane, a **Program Certificates** list shows the names of
     programs for which you have earned certificates. For more information about
     the program, or to view the certificate, select the name of the program.
-
 
 .. _SFD Profile Page:
 
@@ -321,21 +322,24 @@ username on the **Active Threads** page, and the learner's profile page.
       that learner's active threads page in the course discussions, and an
       image of the learner's profile
 
+
 .. _SFD Account Settings:
 
 ****************************************
 Exploring the Account Settings Page
 ****************************************
 
-Your **Account Settings** page has three tabs.
+Your Account Settings page has three tabs.
 
-* The **Account Settings** tab includes basic, required information, such as
-  your username, as well as optional information, such as the level of
-  education you have completed.
-* The **Linked Accounts** tab lists social media and other accounts that you
-  can connect to your edX account.
-* The **Order History** tab lists information about payments you have made,
-  such as the fee for a verified certificate.
+* The **Account Settings** tab includes basic, required information, such as your
+  username, as well as optional information, such as the level of education
+  you have completed.
+
+* The **Linked Accounts** tab lists social media and other accounts that you can
+  connect to your edX account.
+
+* The **Order History** tab lists information about payments you have made, such
+  as the fee for a verified certificate.
 
 You can view this information at any time. You can also add or change some of
 this information.
@@ -368,6 +372,11 @@ is required for every account on edX.
 
 * **Country or Region**: The country or region that you live in.
 
+* **Time Zone**: Your local time zone. If specified, course due dates and
+  times are displayed using this time zone. If you do not specify a time
+  zone, course dates and times are displayed in Coordinated Universal Time
+  (UTC).
+
 To view or change this information, follow these steps.
 
 .. note:: You cannot change your edX username.
@@ -393,7 +402,6 @@ information.
 
 * **Education Completed**: The highest level of education that you have
   completed.
-
 * **Gender**: The gender you identify as.
 
 * **Year of Birth**: The year that you were born.
@@ -412,7 +420,6 @@ To view or change this information, follow these steps.
 
 EdX saves your changes automatically.
 
-.. _Link Accounts:
 
 ==========================================
 Link or Unlink a Social Media Account
@@ -427,13 +434,14 @@ To link your edX account with another account, follow these steps.
 #. On any edX page, select the arrow next to your username, and then select
    **Account**.
 
-#. On the **Account Settings** page, select the **Linked Accounts** tab.
+#. On the **Account Settings** page, select **Linked Accounts**.
 
-#. Under **Linked Accounts**, select **Link Your Account** under the name of
-   the account that you want to link to your edX account.
+#. On the **Linked Accounts** page, select **Link Your Account** under the
+   name of the account that you want to link to your edX account.
 
-   If you want to unlink your edX account from another social media account,
-   select **Unlink This Account** under that account name.
+   To unlink your edX account from a social media account, select **Unlink This
+   Account** under that account name.
+
 
 .. _View Order History:
 

--- a/en_us/shared/students/SFD_introduction.rst
+++ b/en_us/shared/students/SFD_introduction.rst
@@ -81,11 +81,16 @@ A Note about Time Zones
 ************************
 
 The dates and times that new materials are released, and when homework
-assignments and exams are due, are included throughout your course. It is
-important to be aware that edX lists all times in Coordinated Universal Time
-(UTC). When you see a time in your course, edX recommends that you use a time
-zone converter to convert the UTC time to your local time. You can use any
-converter that you want, including one of the following time zone converters.
+assignments and exams are due, are shown throughout your course.
+
+In your account settings, you can specify your local time zone so that any
+course dates and times are displayed in your local time.
+
+.. Important:: If you do not specify a time zone in your account settings, edX
+   lists all times in Coordinated Universal Time (UTC). You can use a time
+   zone converter to convert UTC time to your local time. You can use any
+   converter that you want, including one of the following time zone
+   converters.
 
 * `Time and Date Time Zone Converter`_
 


### PR DESCRIPTION
[DOC-2956](https://openedx.atlassian.net/browse/DOC-2956)/TNL-4594
This PR updates student as well as course team documentation to reflect the option of specifying a time zone in account settings. Learners who specify a local time zone in account settings see course dates and times in their local time zone. Learners who don't specify a time zone continue to see course dates and times in UTC. No impact in Studio, where course teams set dates/times in UTC, but they should be aware that not all learners see dates/times in UTC.

REVIEWERS:
- [x] Subject matter expert: @kevinjkim 
- [x] Subject matter expert: @jcdyer 
- [x] Product: @sstack22
- [x] Doc team @pdesjardins or @srpearce or @lamagnifica 

FYI @jaakana 
