### PR TITLE
Emphasized warnings about the deprecated drag and drop problem type.

### DIFF
--- a/en_us/shared/exercises_tools/drag_and_drop_deprecated.rst
+++ b/en_us/shared/exercises_tools/drag_and_drop_deprecated.rst
@@ -4,14 +4,6 @@
 Drag and Drop Problem (Deprecated)
 ##################################
 
-.. note:: EdX offers provisional support for this problem type.
-
-In drag and drop problems, learners respond to a question by dragging text or
-objects to a specific location on an image.
-
-.. image:: ../../../shared/images/DragAndDropProblem.png
- :alt: Image of a drag and drop problem
-
 .. note::
     This drag and drop problem type has been replaced by a newer
     drag and drop problem type. The newer drag and drop problem type includes
@@ -19,13 +11,13 @@ objects to a specific location on an image.
     development. For more information about the replacement drag and
     drop problem type, see :ref:`drag_and_drop_problem`.
 
-.. note::
+.. warning::
 
- * **Drag and drop problems are not accessible for learners with some
-   disabilities, and they do not work correctly on mobile phones.** If you use
-   this kind of problem, make sure that you include an alternative for
-   learners who cannot access drag and drop problems, or leave these problems
-   ungraded.
+ * **This deprecated drag and drop problem type is not accessible for learners
+   with some disabilities, and it does not work correctly on mobile phones and
+   other devices that use touch screen interfaces.** If you use this kind of
+   problem, make sure that you include an alternative for learners who cannot
+   access drag and drop problems, or leave these problems ungraded.
 
    For more information about creating accessible content, see
    :ref:`Accessibility Best Practices for Course Content Development`.
@@ -34,6 +26,14 @@ objects to a specific location on an image.
    default, the **Show Answer** option is set to **Never**. If you change this
    option in the problem component, a **Show Answer** button appears in the
    LMS, but the button does not work.
+
+.. note:: EdX offers provisional support for this problem type.
+
+In drag and drop problems, learners respond to a question by dragging text or
+objects to a specific location on an image.
+
+.. image:: ../../../shared/images/DragAndDropProblem.png
+ :alt: Image of a drag and drop problem
 
 *********************************
 Creating a Drag and Drop Problem


### PR DESCRIPTION
## [DOC-3033](https://openedx.atlassian.net/browse/DOC-3033)

I moved the notes about accessibility and mobile device problems to the top of the doc section for the deprecated drag and drop problem type. I also changed the note to a warning. I moved the note about the new drag and drop problem type to the top of the page just below the new warning.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @catong @srpearce 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
