### PR TITLE
Add note about what to do when there are two sets of captions

### DIFF
--- a/en_us/course_authors/source/video/video_course.rst
+++ b/en_us/course_authors/source/video/video_course.rst
@@ -40,7 +40,7 @@ Copy the Video ID
     the file must be Ready on the **Video Uploads** page.
 
 You can also download a report of all uploaded videos on the **Video Uploads**
-page: click **Download available encodings (.csv)**. The report includes the
+page: select **Download available encodings (.csv)**. The report includes the
 video ID for every uploaded file.
 
 .. to come: how to download a CSV
@@ -66,32 +66,34 @@ components in the other.
 #. From the **Content** menu select **Outline**. The **Course Outline** page
    opens.
 
-#. Select or add a unit, and then click **Video** to add a video component.
+#. Select or add a unit, and then select **Video** to add a video component.
 
-   To edit an existing video component, locate the video component window and
-   then click **Edit**. The Editing: Video popup opens to the Basic tab.
+   To edit an existing video component, locate the video component window, and
+   then select **Edit**. The Editing: Video dialog box opens to the **Basic**
+   tab.
 
-#. For the **Component Display Name**, enter the identifying name that you
-   want learners to see for this video.
+#. For the **Component Display Name**, enter the identifying name that you want
+   learners to see for this video.
 
-#. At the top of the Editing: Video popup click **Advanced**. Additional fields
-   appear below the **Component Display Name** and **Default Timed Transcript**
-   fields.
+#. Select the **Advanced** tab for the Editing: Video dialog box.
 
-#. Scroll down to the **Video ID** field and paste in the ID of the video
-   file that you want to play. See :ref:`Copy the edX Video ID`.
+   Additional fields appear below the **Component Display Name** and **Default
+   Timed Transcript** fields.
 
-   When you supply a valid video ID in this field, you associate your
-   video component with files on YouTube and AWS that are optimized for
-   viewing with different devices and bandwidths. You do not need to add
-   values to the **Default Video URL**, **Video File URLs**, or the **YouTube
-   ID** fields. If those fields already have values, the URLs that are
-   associated with this video ID override them.
+#. For the **Video ID**, paste in the ID of the video file that you want
+   to play. See :ref:`Copy the edX Video ID`.
 
-6. Set the **Video Download Allowed** field to **True** or **False** to define
-   whether learners can download this video.
+   When you supply a valid video ID in this field, you associate your video
+   component with files on YouTube and AWS that are optimized for viewing with
+   different devices and bandwidths. You do not need to add values to the
+   **Default Video URL**, **Video File URLs**, or **YouTube ID** fields. The
+   URLs that are associated with the video ID override any existing values in
+   those fields.
 
-#. Click **Save**. The referenced video appears in the video component.
+#. Set **Video Download Allowed** to **True** or **False** to define whether
+   learners can download this video.
+
+#. Select **Save**. The referenced video appears in the video component.
 
    .. note:: For the video to appear, a destination URL must be available for
     at least one of the formats and host sites that are the result of the edX
@@ -111,11 +113,12 @@ who speak other languages.
 
 Timed transcripts in the SubRip Text (.srt) format are recommended. A
 transcript in the .srt format appears next to its associated video and
-automatically scrolls as the video plays. A learner can click a word in the
+automatically scrolls as the video plays. A learner can select a word in the
 transcript to jump to the point in the video where that word is spoken.
 
 This section briefly describes the procedures that course teams follow to add
-transcripts to their videos. For more information, see the :ref:`Create Transcript` section in this guide.
+transcripts to their videos. For more information, see the :ref:`Create
+Transcript` section in this guide.
 
 ======================================
 Create or Obtain a Transcript
@@ -159,18 +162,28 @@ To associate a transcript with a video, follow these steps.
 
 #. Locate the video component window and select **Edit**.
 
-#. To upload an .srt file from your computer: In the **Default Timed
-   Transcript** field select **Upload New Transcript**, and then select the
-   .srt file from your computer.
+#. Next, either you upload an .srt file or you import YouTube subtitles or
+   captions.
 
-   To import YouTube subtitles or captions: In the **Default Timed
-   Transcript** field select **Import from YouTube**.
+   * To upload an .srt file from your computer: For the **Default Timed
+     Transcript** select **Upload New Transcript**, and then select the
+     .srt file from your computer.
+
+   * To import YouTube subtitles or captions: For the **Default Timed
+     Transcript** select **Import from YouTube**.
 
 #. Select **Save**.
 
 To test the transcript with the video, select the **Show transcript** (") icon
 in the video player's control bar. The transcript file scrolls while the video
-file plays.
+file plays. You can also test the transcript by selecting the **CC** icon.
+
+.. note:: In some cases, two sets of captions can appear when you select
+  **CC**. This situation can occur if YouTube is the host service for the video
+  and your YouTube account settings for playback are set to always show
+  captions. As a result, YouTube and your course might both provide captions
+  for the video. To correct this problem, select **CC** again or change your
+  YouTube account setting.
 
 ============================
 Enable Transcript Downloads

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -1154,7 +1154,7 @@ events of this type as for the :ref:`play_video` events.
 ``edx.video.closed_captions.hidden``
 *************************************************************
 
-When a user toggles **Closed Captions** to suppress display of the overlay captioning, the
+When a user toggles **CC** to suppress display of the overlay captioning, the
 browser or mobile app emits an ``edx.video.closed_captions.hidden`` event.
 
 **Event Source**: Browser or Mobile
@@ -1183,7 +1183,7 @@ events of this type as for the :ref:`play_video` events.
 ``edx.video.closed_captions.shown``
 ************************************************************
 
-When a user toggles **Closed Captions** to display the closed captions, the browser or
+When a user toggles **CC** to display the closed captions, the browser or
 mobile app emits an ``edx.video.closed_captions.shown`` event.
 
 **Event Source**: Browser or Mobile

--- a/en_us/shared/course_components/create_video.rst
+++ b/en_us/shared/course_components/create_video.rst
@@ -46,8 +46,8 @@ Video Length
 
 Keep videos as short as possible.
 
-Learners are much less likely to finish watching a video if it is more than
-5-10 minutes long.
+Learners are more likely to finish watching a video if it is no more than 5-10
+minutes long.
 
 ====================
 Video Accessibility
@@ -67,8 +67,8 @@ files, including YouTube videos and videos that are hosted in other locations.
 You can allow learners to download videos by selecting the **Video Download
 Allowed** option for your video components.
 
-For more information about posting
-videos to hosting sites other than YouTube, see :ref:`Post the Video Online`.
+For more information about posting videos to hosting sites other than YouTube,
+see :ref:`Post the Video Online`.
 
 For more information about options that you can set when you create a video
 component, see :ref:`Video Advanced Options` under :ref:`Create a Video
@@ -84,11 +84,10 @@ Your videos can contain whatever content you want to include in the course. The
 `Creating Videos`_ section of `edX101 Overview of Creating an edX Course`_ has
 some helpful pointers for creating good video content.
 
-When you create videos, follow `Richard Mayer's 12 Principles
-<http://hartford.edu/academics/faculty/
-fcld/data/documentation/technology/presentation/powerpoint/12_principles_mult
-imedia.pdf>`_. The principles in this document are based on extensive
-experimental research of student learning.
+When you create videos, follow Richard E. Mayer's `12 Principles of Multimedia
+Learning <http://hartford.edu/academics/faculty/fcld/data/documentation/technology/presentation/powerpoint/12_principles_multimedia.pdf>`_. The
+principles in this document are based on extensive experimental research of
+student learning.
 
 .. _Compression Specifications:
 
@@ -162,7 +161,7 @@ automatically scrolls as the video plays, and learners can select a line in the
 transcript to jump to the point in the video where that word is spoken.
 
 Learners can also choose to show the transcript file as overlaid closed
-captions for the video by selecting the **Closed caption** (CC) icon in the
+captions for the video by selecting the **CC** icon in the
 video player's control bar.
 
 To create or obtain a transcript in .srt format, you can work with a company
@@ -323,14 +322,15 @@ To add a video and its transcript to your course, follow these steps.
       http://www.youtube.com/watch?v=OEoXaMPEzfM
       https://s3.amazonaws.com/edx-course-videos/edx-edx101/EDXSPCPJSP13-G030300.mp4
 
-.. note:: To be sure that all learners can access a video, you can
-    create multiple versions that use different encodings or hosting services.
-    After you post different versions on the Internet, you add each URL below
-    the default video URL. **These URLs cannot be YouTube URLs**. To add a URL
-    for another version, select **Add URLs for additional versions**. The first
-    listed video that is compatible with the learner's computer plays.
+   .. note:: To be sure that all learners can access a video, you can
+      create multiple versions that use different encodings or hosting
+      services. After you post different versions on the Internet, you add each
+      URL below the default video URL. **These URLs cannot be YouTube URLs**.
+      To add a URL for another version, select **Add URLs for additional
+      versions**. The first listed video that is compatible with the learner's
+      computer plays.
 
-5. Next to **Default Timed Transcript**, select an option.
+#. Next to **Default Timed Transcript**, select an option.
 
    * If edX already has a transcript for this video, Studio automatically
      finds the transcript and associates the transcript with the video. This
@@ -367,7 +367,7 @@ To add a video and its transcript to your course, follow these steps.
         * If your transcript uses the .sjson format, do not use this field.
           For more information, see :ref:`Steps for sjson files`.
 
-6. Optionally, select **Advanced** to set more options for the video. For a
+#. Optionally, select **Advanced** to set more options for the video. For a
    description of each option, see :ref:`Video Advanced Options`.
 
 #. Select **Save.**

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -129,8 +129,9 @@ C
 **Closed Captions**
 
   The spoken part of the transcript for a video file, which is overlaid on the
-  video as it plays. You can move closed captions to different areas on the
-  video screen by dragging and dropping them.
+  video as it plays. To show or hide closed captions, you select the **CC**
+  icon. You can move closed captions to different areas on the video screen by
+  dragging and dropping them.
 
   For more information, see :ref:`learners:Video Player`.
 

--- a/en_us/shared/students/SFD_video_player.rst
+++ b/en_us/shared/students/SFD_video_player.rst
@@ -46,10 +46,17 @@ by an explanation of each option or control on the video player.
    window by selecting this control. To return to default mode, press ESC on
    your keyboard or select this control again.
 
-8. **Closed caption**: You can show an overlaid transcript of the audio portion
-   of the file by selecting this control. If you show the captions, you can
-   move them to different areas on the video screen by dragging and dropping
-   them. To hide the captions, select this control again.
+8. **Show or hide closed captioning**: You can show an overlaid transcript of
+   the audio portion of the file by selecting this control. If you show the
+   captions, you can move them to different areas on the video screen by
+   dragging and dropping them. To hide the captions, select this control again.
+
+   .. note:: In some cases, two sets of captions can appear when you select
+    **CC**. This situation can occur if YouTube is the host service for the
+    video and your YouTube account settings for playback are set to always show
+    captions. As a result, YouTube and your course might both provide captions
+    for the video. To correct this problem, select **CC** again or change your
+    YouTube account setting.
 
 9. **Show transcript**: You can show a complete, scrolling transcript of the
    audio portion of the file to the right of the video by selecting this


### PR DESCRIPTION
## [DOC-2989](https://openedx.atlassian.net/browse/DOC-2989)

Anyone who uses the video player can end up in a situation where two sets of captions appear. This adds a note to that effect to the learner guide (to which course teams are directed) and to the video processing section that applies to edx.org courses only.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @jaakana
- [ ] Subject matter expert: 
- [x] Doc team review (copy edit): @catong @pdesjardins @srpearce 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @clrux 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment
- [x] Squash commits
