### PR TITLE
Adds advice to get plain text transcripts

### DIFF
--- a/en_us/course_authors/source/video/video_course.rst
+++ b/en_us/course_authors/source/video/video_course.rst
@@ -122,9 +122,16 @@ Create or Obtain a Transcript
 ======================================
 
 To create or obtain a transcript in .srt format, you can work with a company
-that provides captioning services. To ensure quality and accuracy of
-transcripts, edX works with `3Play Media`_. To request a 3Play account at
-edX's discounted rate, contact your edX partner manager.
+that provides captioning services.
+
+The edX video player renders transcript files as plain text. EdX recommends
+that you create or obtain transcript files that use plain text only, and that
+do not include HTML markup, character entities such as ``&nbsp;``, or styling
+such as boldface or italics.
+
+To ensure quality and accuracy of transcripts, edX works with `3Play Media`_.
+To request a 3Play account at edX's discounted rate, contact your edX partner
+manager.
 
 ===================================
 Associate a Transcript with a Video

--- a/en_us/shared/course_components/create_preroll_video.rst
+++ b/en_us/shared/course_components/create_preroll_video.rst
@@ -95,10 +95,15 @@ an identifying video ID. For more information, see `Upload Video Files`_ in
 the *Processing Video Files* guide.
 
 Prepare Pre-Roll Video Transcript Files
-**********************************************************
+*****************************************
 
-You must provide at least one transcript file for your pre-roll video. You
-can provide additional transcript files in multiple languages.
+You must provide at least one transcript file for your pre-roll video. The edX
+video player renders transcript files as plain text. EdX recommends that you
+create or obtain transcript files that use plain text only, and that do not
+include HTML markup, character entities such as ``&nbsp;``, or styling
+such as boldface or italics.
+
+You can provide additional transcript files in multiple languages.
 
 * If you have transcript files in more than one language, edX recommends that
   you include identifying `ISO 639-1 codes`_ in your transcript file names.
@@ -127,7 +132,7 @@ To prepare transcript files for a pre-roll video, follow these steps.
     edx_preroll_zh_HANS.srt
 
 Upload Pre-Roll Video Transcript Files
-**********************************************************
+***************************************
 
 To upload transcript files for a pre-roll video into Studio, follow these
 steps.

--- a/en_us/shared/course_components/create_video.rst
+++ b/en_us/shared/course_components/create_video.rst
@@ -174,6 +174,11 @@ that provides captioning services.
   `Cielo24 <http://www.cielo24.com/>`_. `YouTube <http://www.youtube.com/>`_
   also provides captioning services.
 
+The edX video player renders transcript files as plain text. EdX recommends
+that you create or obtain transcript files that use plain text only, and that
+do not include HTML markup, character entities such as ``&nbsp;``, or styling
+such as boldface or italics.
+
 When you upload an .srt file, a .txt file is created automatically. You can
 allow learners to download these transcript files. If you allow your learners
 to download transcripts, the video player includes a **Download transcript**


### PR DESCRIPTION
## [DOC-3045](https://openedx.atlassian.net/browse/DOC-3045)

Due to AC-454 rework. transcripts will now be stripped of markup and rendered as plain text only. Clayton has notified the transcript service (for partners) that we recommend that they should provide transcripts in plain text only. Add a note to this effect for course teams to inform other transcript services.
### Date Needed

20 June 2016
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @clrux 
- [ ] Subject matter expert: 
- [x] Doc team review (copy edit): @catong @srpearce @pdesjardins 
- [ ] Product review: 
- [ ] Partner support: 
- [ ] PM review: 

FYI: @cptvitamin 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
