### PR TITLE
DOC-2736: CA grade period does not apply to ORA

### DIFF
--- a/en_us/shared/grading/grace_period.rst
+++ b/en_us/shared/grading/grace_period.rst
@@ -6,10 +6,12 @@ Set the Grace Period
 *************************
 
 You can set a grace period that extends homework due dates for your learners.
+The grace period applies to the whole course; you cannot set different grace
+periods for individual assignments.
 
-.. note::
- The grace period applies to the whole course; you cannot set a grace period
- for individual assignments.
+.. note:: The grace period setting does not apply to open response assessments.
+   For details about setting the response date for an ORA assignment, see
+   :ref:`Specify Assignment Names and Dates <PA Specify Name and Dates>`.
 
-In the Grading page, under **Grading Rules & Policies**, enter a value in the
+On the Grading page, under **Grading Rules & Policies**, enter a value in the
 **Grace Period on Deadline** field. Enter the value in Hours:Minutes format.


### PR DESCRIPTION
## [DOC-2736](https://openedx.atlassian.net/browse/DOC-2736)

This PR adds a note to the topic about grace periods indicating that the grace period setting does not apply to ORA assignments, and adds a cross-ref to the topic about setting response dates for ORA assignments.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Requester/Subject matter expert: @sstack22 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica or @srpearce or @pdesjardins 

FYI @jaakana
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
