### PR TITLE
DOC: Reorder TOC in SF guide

### DIFF
--- a/en_us/open_edx_students/source/index.rst
+++ b/en_us/open_edx_students/source/index.rst
@@ -10,21 +10,21 @@ Open edX Learner's Guide
 
    SFD_introduction
    sfd_dashboard_profile/index
+   SFD_mobile
    SFD_check_progress
    SFD_certificates
    SFD_self_paced
+   SFD_course_search
+   SFD_prerequisites
    SFD_content_availability
    SFD_video_player
    sfd_discussions/index
-   SFD_course_search
-   SFD_bookmarks
-   SFD_notes
-   SFD_google_docs
-   SFD_teams
-   SFD_mobile
-   SFD_prerequisites
    completing_assignments/index
    SFD_ORA
+   SFD_google_docs
+   SFD_teams
+   SFD_bookmarks
+   SFD_notes
    SFD_wiki
    SFD_licensing
    front_matter/index

--- a/en_us/shared/students/SFD_mobile.rst
+++ b/en_us/shared/students/SFD_mobile.rst
@@ -1,10 +1,10 @@
 .. _SFD Mobile:
 
-########################
-Using an edX Mobile App
-########################
+###############################
+If You Use the edX Mobile App
+###############################
 
-This topic answers questions about how to use an edX mobile app on an Android
+This topic answers questions about how to use the edX mobile app on an Android
 smartphone or an iPhone to take edX courses.
 
 .. contents::

--- a/en_us/students/source/index.rst
+++ b/en_us/students/source/index.rst
@@ -11,6 +11,7 @@ EdX Learner's Guide
    SFD_introduction
    SFD_account
    sfd_dashboard_profile/index
+   SFD_mobile
    SFD_enrolling
    SFD_check_progress
    SFD_certificates
@@ -19,15 +20,13 @@ EdX Learner's Guide
    SFD_content_availability
    SFD_video_player
    sfd_discussions/index
-   SFD_bookmarks
-   SFD_notes
-   SFD_google_docs
-   SFD_teams
-   SFD_mobile
    completing_assignments/index
    SFD_ORA
+   SFD_google_docs
+   SFD_teams
+   SFD_bookmarks
+   SFD_notes
    SFD_wiki
    SFD_licensing
-
    front_matter/index
 


### PR DESCRIPTION
This PR makes changes to the order of sections in the Learner's Guide TOCs without changing any underlying file structure.
- move Mobile section to follow Getting Started
- move the "completing different types of assignments" to follow "understanding course content availability"
- group the assignment type, tools after "completing assignments": ORA, google files, calendar, teams
- group the "action" types after the assignment & tool types: watch videos, bookmark, add notes.
### Reviewers
- [x] @pdesjardins 
- [x] @lamagnifica 
- [x] @srpearce 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
