### PR TITLE
DOC-3072: Remove landing page from SF TOC

### DIFF
--- a/en_us/open_edx_students/source/conf.py
+++ b/en_us/open_edx_students/source/conf.py
@@ -13,6 +13,8 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'Open edX Learner\'s Guide'
 
+exclude_patterns = ['links.rst', 'reusables/*', 'SFD_mathformatting.rst']
+
 tags.add('Open_edX')
 product = 'Open_edX'
 set_audience(OPENEDX, LEARNERS)

--- a/en_us/open_edx_students/source/index.rst
+++ b/en_us/open_edx_students/source/index.rst
@@ -27,5 +27,4 @@ Open edX Learner's Guide
    SFD_ORA
    SFD_wiki
    SFD_licensing
-   SFD_mathformatting
    front_matter/index

--- a/en_us/students/source/conf.py
+++ b/en_us/students/source/conf.py
@@ -13,6 +13,7 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 
 project = u'EdX Learner\'s Guide'
 
+exclude_patterns = ['links.rst', 'reusables/*', 'SFD_mathformatting.rst']
 
 tags.add('Partners')
 product = 'Partners'

--- a/en_us/students/source/index.rst
+++ b/en_us/students/source/index.rst
@@ -28,6 +28,6 @@ EdX Learner's Guide
    SFD_ORA
    SFD_wiki
    SFD_licensing
-   SFD_mathformatting
+
    front_matter/index
 


### PR DESCRIPTION
## [DOC-3072](https://openedx.atlassian.net/browse/DOC-3072)

The redirect topic SFD_mathformatting is included in the TOCs of both Learner's Guides. This is a landing page topic that should remain in the HTML output but should not be visible in the TOC.

Removes SFD_mathformatting.rst from the index.rst files and adds the filename to the exclude patterns in conf.py so that no errors are generated upon building the guides.
### Reviewers
- [x] Doc team sanity check: @lamagnifica @srpearce @pdesjardins 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
