### PR TITLE
Updated custom proctoring rules section based on review input from an earlier PR

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
@@ -65,11 +65,11 @@ monitoring the test environment and screen activity as the learner takes the
 exam.
 
 For more information about the technical requirements for taking a proctored
-exam, and edX's :ref:`Online Proctoring Rules <Online Proctoring Rules>`, see
+exam, and edX's :ref:`online proctoring rules <Online Proctoring Rules>`, see
 :ref:`Preparing Learners for Proctored Exams`.
 
-.. note:: Course staff should familiarize themselves with edX's :ref:`Online
-   Proctoring Rules <Online Proctoring Rules>`, which reflect our proctoring
+.. note:: Course staff should familiarize themselves with edX's :ref:`online
+   proctoring rules <Online Proctoring Rules>`, which reflect our proctoring
    software partner's "Closed Book Exam" rules. These strict rules prohibit
    learners from using any tools during the exam, including pencil and
    paper, calculators, or reference books.
@@ -91,10 +91,10 @@ Proctored Exam Session Results
 
 When learners complete a proctored exam, either by submitting their answers or
 when the time expires for the exam, the proctoring session data is uploaded to
-the third party proctoring service provider. This data is reviewed for
-adherence to :ref:`Online Proctoring Rules <Online Proctoring Rules>`, and
-when the review is complete, a result is returned for each learner who took
-the exam as a proctored exam.
+the third party proctoring service provider. A team of reviewers examines the
+data to determine whether the learner complied with the :ref:`Online Proctoring
+Rules <Online Proctoring Rules>`. When the review is complete, the proctoring
+service returns the results for each learner.
 
 Before proctoring session results are available, learners see a **Pending**
 result. After their proctoring sessions are available, learners can receive
@@ -191,8 +191,8 @@ grading policy of your course, and make it clear what the requirements are for
 earning credit.
 
 Explain what proctored exams are, and provide learners with links to the
-Learner's Guide topics about proctored exams, and to edX's :ref:`Online
-Proctoring Rules <Online Proctoring Rules>`.
+Learner's Guide topics about proctored exams, and to edX's :ref:`online
+proctoring rules <Online Proctoring Rules>`.
 
 .. note:: Course staff should familiarize themselves with edX's :ref:`Online
    Proctoring Rules <Online Proctoring Rules>`, which reflect our proctoring
@@ -223,7 +223,7 @@ Exam`.
    as that process is completed.
 
 The following list represents only some of the requirements listed in the
-:ref:`Online Proctoring Rules <Online Proctoring Rules>`.
+:ref:`online proctoring rules <Online Proctoring Rules>`.
 
 * System and environment checks that learners are asked to perform for the
   proctoring session include taking a photo of a government-issued photo ID,
@@ -393,14 +393,16 @@ regardless of their enrollment track.
 Specifying Exam Rules and Exceptions
 ====================================
 
-You can provide custom rules and rule exceptions to the team of reviewers who
-determine whether learners' exam attempts conform to the rules for proctored
-exams. If your course allows learners to use tools and techniques that are
-prohibited by the default rules for proctored exams, you must describe the
-exceptions to the reviewers.
+The team of reviewers who examine exam attempt records determine whether
+learners complied with the :ref:`Online Proctoring Rules <Online Proctoring
+Rules>`. By default, the team of reviewers uses the standard set of rules for
+taking proctored exams.
 
-For more information about the default rules for proctored exams, see
-:ref:`Online Proctoring Rules <Online Proctoring Rules>`.
+You can provide custom rules and rule exceptions if the content of an exam
+requires them. If your course allows learners to use tools and techniques that
+the default rules for proctored exams prohibit, you must provide information
+about these rules and exceptions both to your learners and to the team of
+reviewers.
 
 To specify custom proctored exam rules and rule exceptions, follow these steps.
 
@@ -435,7 +437,7 @@ Responding to Learners' Concerns about Proctored Exams
 **********************************************************
 
 In addition to questions that can be answered in the FAQs on edx.org, or by the
-:ref:`Online Proctoring Rules <Online Proctoring Rules>`, situations might
+:ref:`online proctoring rules <Online Proctoring Rules>`, situations might
 arise that require an action by edX Support.
 
 .. contents::


### PR DESCRIPTION
## [DOC-2570](https://openedx.atlassian.net/browse/DOC-2570)

Edited a section that was flagged in https://github.com/edx/edx-documentation/pull/762 but that I didn't respond to before merging. Poor form! Some of the sections mentioned in the review input were subsequently edited in a separate PR. I didn't edit them further, because I thought the new wording addressed the input.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check/copy edit/dev edit):  @srpearce 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
