### PR TITLE
DOC-3081 - corrected scientific notation format in the edX learner's …

### DIFF
--- a/en_us/shared/students/completing_assignments/SFD_mathformatting.rst
+++ b/en_us/shared/students/completing_assignments/SFD_mathformatting.rst
@@ -159,7 +159,7 @@ expressions:
 
 To indicate ``-440,000``, you can enter either of the following expressions:
 
-* ``-4.4^5``
+* ``-4.4*10^5``
 * ``-4.4e5``
 
 The following table shows how to enter numbers with metric affixes, with


### PR DESCRIPTION
## [DOC-3081](https://openedx.atlassian.net/browse/DOC-3081)

There is an error at the notation of -44000 on this page which should NOT be written as 4.4^5 but 4.4*10^5 

This is fix for issue [Incorrect scientific notation format in the edX learner's guide](https://openedx.atlassian.net/browse/DOC-3081)
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check/copy edit/dev edit): @pdesjardins
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

…guide
