### PR TITLE
Removes sentence for reverted change

### DIFF
--- a/en_us/course_authors/source/video/video_course.rst
+++ b/en_us/course_authors/source/video/video_course.rst
@@ -129,11 +129,6 @@ Create or Obtain a Transcript
 To create or obtain a transcript in .srt format, you can work with a company
 that provides captioning services.
 
-The edX video player renders transcript files as plain text. EdX recommends
-that you create or obtain transcript files that use plain text only, and that
-do not include HTML markup, character entities such as ``&nbsp;``, or styling
-such as boldface or italics.
-
 To ensure quality and accuracy of transcripts, edX works with `3Play Media`_.
 To request a 3Play account at edX's discounted rate, contact your edX partner
 manager.

--- a/en_us/shared/course_components/create_preroll_video.rst
+++ b/en_us/shared/course_components/create_preroll_video.rst
@@ -97,13 +97,8 @@ the *Processing Video Files* guide.
 Prepare Pre-Roll Video Transcript Files
 *****************************************
 
-You must provide at least one transcript file for your pre-roll video. The edX
-video player renders transcript files as plain text. EdX recommends that you
-create or obtain transcript files that use plain text only, and that do not
-include HTML markup, character entities such as ``&nbsp;``, or styling
-such as boldface or italics.
-
-You can provide additional transcript files in multiple languages.
+You must provide at least one transcript file for your pre-roll video. You can
+provide additional transcript files in multiple languages.
 
 * If you have transcript files in more than one language, edX recommends that
   you include identifying `ISO 639-1 codes`_ in your transcript file names.

--- a/en_us/shared/course_components/create_video.rst
+++ b/en_us/shared/course_components/create_video.rst
@@ -173,11 +173,6 @@ that provides captioning services.
   `Cielo24 <http://www.cielo24.com/>`_. `YouTube <http://www.youtube.com/>`_
   also provides captioning services.
 
-The edX video player renders transcript files as plain text. EdX recommends
-that you create or obtain transcript files that use plain text only, and that
-do not include HTML markup, character entities such as ``&nbsp;``, or styling
-such as boldface or italics.
-
 When you upload an .srt file, a .txt file is created automatically. You can
 allow learners to download these transcript files. If you allow your learners
 to download transcripts, the video player includes a **Download transcript**


### PR DESCRIPTION
## [DOC-3086](https://openedx.atlassian.net/browse/DOC-3086)

AC-454 was reverted. Advice about obtaining transcripts in plain text is still valid, but the statement "The edX video player renders transcript files as plain text. " is no longer true.
### Date Needed

This PR was reverted last week (?) so doc change should catch up ASAP.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @sstack22 
- [x] Subject matter expert: @clrux 
- [ ] Doc team review (sanity check): @pdesjardins @catong @srpearce 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
