### PR TITLE
DOC-3049 Clear up shared file use and add mobile refs to getting started topics

### DIFF
--- a/en_us/course_authors/source/getting_started/accounts.rst
+++ b/en_us/course_authors/source/getting_started/accounts.rst
@@ -4,21 +4,19 @@
 Getting Started with edX
 #############################
 
-The following topics provide an introduction to edX and instructions for
-getting started on edX websites.
+The following topics provide an introduction to edx.org and edX Edge, and describe steps for getting started on edX websites.
 
 .. contents::
  :local:
  :depth: 1
 
 This information is intended for course teams. The *EdX Learner's Guide* also
-includes information about creating an account and the edX Demo course. You
-might want to share course- or institution-specific details about the
-registration process, such as password policies or the use of campus
+includes information about creating and activating accounts and about the edX
+Demo course. You might want to share course- or institution-specific details
+about the registration process, such as password policies or the use of campus
 credentials, in your communications with prospective students.
 
-For information about enrolling students in a course, see
-:ref:`enroll_student`.
+For information about enrolling learners in a course, see :ref:`enroll_student`.
 
 .. _edX.org and edX Edge:
 
@@ -40,7 +38,8 @@ different.
 * Edge, at edge.edx.org, is a more private site. Courses on Edge are not
   published on edx.org. Any member of a partner course team can create and
   publish courses, including test courses, on Edge without receiving approval
-  from edX or a partner institution.
+  from edX or a partner institution. You can also host small private online
+  courses (SPOCs) on Edge.
 
   However, Edge does not have a course catalog, and courses cannot be found
   through search engines such as Google. Only learners whom you explicitly
@@ -48,7 +47,6 @@ different.
   Edge. Note that you can invite an unlimited number of learners to participate
   in an Edge course.
 
-  EdX Edge also hosts small private online courses (SPOCs).
 
 .. _Create an Account:
 
@@ -56,17 +54,16 @@ different.
 Create and Activate an Account
 *******************************
 
-.. note::
-  All user accounts on Edge and edx.org are separate. If you want to use both
-  edx.org and Edge, you must complete the account registration process on both
-  sites.
+.. note::  The user accounts on edx.org and edX Edge are separate. To access or
+   create courses on both websites, you must complete the account registration
+   process on each of the two sites.
 
-When you create an edx.org or edX Edge account, you associate an email
-address with your edX account. EdX strongly recommends that you use your
-organizational email address or select an existing account (such as a campus
-account) that is set up to use your organizational email address.
+   When you create an edx.org or edX Edge account, you associate an email
+   address with your edX account. EdX strongly recommends that you use your
+   organizational email address or select an existing account (such as a campus
+   account) that is set up to use your organizational email address.
 
-.. include:: ../../../shared/students/Section_register_account.rst
+.. include:: ../../../shared/getting_started/create_activate_account.rst
 
 You can only access the **Account Settings** page from the LMS. You cannot
 access this page from Studio.

--- a/en_us/shared/getting_started/create_activate_account.rst
+++ b/en_us/shared/getting_started/create_activate_account.rst
@@ -1,5 +1,4 @@
-You create, or register, an edx.org or edX Edge account on the registration
-page for edx.org or edX Edge. You can create an account in different ways.
+You can create an account for edx.org or edX Edge in different ways.
 
 * You can create an entirely new edx.org or edX Edge account.
 * You can use an existing social media account, such as a Facebook or Google
@@ -14,10 +13,10 @@ page for edx.org or edX Edge. You can create an account in different ways.
   your accounts, you sign in to your edX.org or edX Edge account automatically
   whenever you sign in to the external account.
 
-Creating an edX.org or edX Edge account has two steps.
+Creating an account for edx.org or edX Edge has two steps.
 
-#. :ref:`Create the account <edX Create an Account>` on the edX.org or edX Edge
-   website.
+#. :ref:`Create an account <edX Create an Account>` on the edX.org or edX Edge
+   website, or from the edX mobile app (for edX.org accounts only).
 #. :ref:`Activate the account <edX Activate an Account>` by using an email
    message that you receive automatically after your account is created.
 
@@ -27,20 +26,21 @@ Creating an edX.org or edX Edge account has two steps.
 Create an Account
 ==================
 
-You create, or register, an edx.org or Edge account on the account registration
-page.
+You create, or register, an edx.org or edX Edge account on the account
+registration page. For edx.org, you can also register from the edX mobile app.
 
 To register an account on edx.org or edX Edge, follow these steps.
 
 .. note::
   When you register an account, you specify a username that will represent you
   throughout the edx.org or edX Edge site. Course team members and other
-  learners only see your username. You cannot change your username after you
+  learners see only your username. You cannot change your username after you
   create your account. EdX recommends that you select your username carefully.
 
 #. Go to the edx.org or edX Edge registration page.
 
-   * For edx.org, go to https://courses.edx.org/register.
+   * For edx.org, go to https://courses.edx.org/register or open the edX
+     mobile app.
    * For edX Edge, go to https://edge.edx.org/register.
    * If you received an email invitation for a course, follow the instructions
      in the email message to go to the correct registration page.

--- a/en_us/shared/students/SFD_introduction.rst
+++ b/en_us/shared/students/SFD_introduction.rst
@@ -5,9 +5,9 @@ Welcome!
 #################
 
 Welcome to online learning with edX! At edX, we are glad to welcome new
-learners to the `edx.org`_ website, and to all of the other websites
-that use the Open edX platform to deliver courses around the world. We hope
-that you are as excited about online learning as we are.
+learners to the `edx.org`_ website or to the edX mobile app, as well as to all
+of the other websites that use the Open edX platform to deliver courses around
+the world. We hope that you are as excited about online learning as we are.
 
 The purpose of this guide is to help with your transition to online learning.
 The guide answers common questions about topics like getting started in an

--- a/en_us/students/source/SFD_account.rst
+++ b/en_us/students/source/SFD_account.rst
@@ -30,16 +30,16 @@ EdX hosts courses on the `edx.org`_ and `edX Edge`_ websites.
   account on Edge unless you have received an invitation to enroll in an Edge
   course.
 
-.. note::
- The user accounts on edx.org and edX Edge are separate. If you take courses on
- both websites, you must complete the account registration process on both
- sites.
+.. note::  The user accounts on edx.org and edX Edge are separate. If you take
+   courses on both websites, you must complete the account registration
+   process on each of the two sites.
 
 ********************************
 Create and Activate an Account
 ********************************
 
-.. include:: ../../shared/students/Section_register_account.rst
+.. include:: ../../shared/getting_started/create_activate_account.rst
+
 
 ******************************
 The edX Demo Course

--- a/en_us/students/source/SFD_enrolling.rst
+++ b/en_us/students/source/SFD_enrolling.rst
@@ -35,8 +35,7 @@ To enroll in a course, follow these steps.
 
 #. On the edX home page, select the course that you want to take.
 
-#. When the About page for the course opens, select **Enroll Now** in the
-   upper right corner of the page.
+#. On the About page for the course, select **Enroll Now**.
 
    * If the course offers only an audit track, you are enrolled in the course
      after you select **Enroll Now**.
@@ -58,17 +57,18 @@ To enroll in a course, follow these steps.
      After you submit a payment for a verified certificate, you can view that
      payment at any time. For more information, see :ref:`View Order History`.
 
-#. After you enroll in the course, your dashboard opens automatically. When
-   your dashboard opens, verify that the new course appears in your list of
-   courses.
+#. After you enroll in the course, on the website, your dashboard opens with
+   the new course added to your list of courses. In the mobile app, the new
+   course opens.
 
-If you select **View Course** on your dashboard, the **Home** page for
-the course opens. If the course has already started, you can select the
+On the website, select **View Course** on your dashboard to open the **Home**
+page for the course. If the course has already started, you can select the
 **Course** page to access released course materials.
 
 .. note:: Course instructors occasionally enroll learners directly in a
  course. If this is the case, you receive an email that contains a link to the
  course. Select the link to enroll in the course.
+
 
 ****************************
 Change Your Course Track
@@ -79,6 +79,9 @@ to earn a verified certificate. Or you might enroll in the verified certificate
 track for a course, but then decide that you want to audit the course instead.
 If the course has recently started, you might be able to change your course
 track.
+
+.. note:: Currently you can only upgrade to the verified track for courses on
+   the edx.org website.
 
 ====================================================
 Change to the Verified Certificate Track


### PR DESCRIPTION
## [DOC-3049](https://openedx.atlassian.net/browse/DOC-3049)

1) The shared include file is used by both the edX Learner's Guide and the (Partner) Building and Running Course guide. Move the shared into shared/getting_started so that it's out of the student subdirectories.
2) Add mentions of mobile app to the getting started, create account, and enrolling sections where applicable.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @srpearce @pdesjardins 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
