### PR TITLE
 Clarifying devstack and fullstack VM install instructions, in particular about VPN effects

### DIFF
--- a/en_us/shared/installation/troubleshooting_vm_installation.rst
+++ b/en_us/shared/installation/troubleshooting_vm_installation.rst
@@ -1,20 +1,30 @@
-In some cases, you see an error when you attempt to create an edX virtual
-machine (``vagrant up``). For example:
+In some cases, you might see a time out error when you attempt to create an edX
+virtual machine. Open edX virtual machines are devstack, fullstack, or
+analytics devstack installations.
 
-``mount.nfs: mount to NFS server '192.168.33.1:/path/to/edx-platform' failed: timed out, giving up``
+For example, you might see the following error message during a virtual machine
+installation.
 
-This error situation arises because Vagrant uses a host-only network in
-Virtualbox to communicate with your computer. If a network does not exist, one
-is created on ``vagrant up``. If this network is created with the VPN up, it
-will not work. You must recreate the network with the VPN down.
+.. code-block:: shell
 
-To resolve the error, follow these steps.
+    mount.nfs: mount to NFS server '192.168.33.1:/path/to/edx-platform' failed:
+    timed out, giving up
 
-#. Stop the VPN.
-#. Type ``vagrant halt``.
-#. Open Virtualbox.
-#. Navigate to **Preferences > Network > Host-only Networks** and remove the
-   most-recently-created host-only network.
-#. Type ``vagrant up``.
+This error happens because the Vagrant virtual machine software that is used by
+devstack and fullstack cannot create a host-only network while the host
+computer (for example, your laptop) is connected to a virtual private network
+(VPN). The Vagrant software can only create the network required by devstack
+and fullstack while your VPN software is disconnected. Be sure to disconnect
+your VPN before you attempt to install devstack or fullstack.
+
+To correct the error, follow these steps.
+
+#. Stop any VPNs that are active on the host computer.
+#. Enter ``vagrant halt`` on the command line from the installation directory
+   of your devstack or fullstack environment.
+#. Start the Oracle Virtualbox program if it is not running.
+#. In Virtualbox, choose **Preferences > Network > Host-only Networks** and
+   remove the host-only network that was most recently created.
+#. Enter ``vagrant up`` on the command line.
 
 .. include:: ../../../../links/links.rst


### PR DESCRIPTION
## [DOC-2633](https://openedx.atlassian.net/browse/DOC-2633)

I removed references to "the VPN", which were about the edX/MIT VPN, and made them more generally about VPNs and the Virtualbox networking configuration.
### Reviewers
- [x] Subject matter expert: @nedbat 
- [x] Doc team review (sanity check/copy edit/dev edit): @lamagnifica @srpearce @catong 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [x] http://draft-vm-install-vpn.readthedocs.io/en/latest/installation/devstack/troubleshooting_vm_installation.html
### Post-review
- [ ] Squash commits
