### PR TITLE
Fixes DOC-3060

### DIFF
--- a/en_us/olx/source/components/discussion-components.rst
+++ b/en_us/olx/source/components/discussion-components.rst
@@ -70,8 +70,9 @@ The ``discussion`` element contains no children.
    * - Attribute
      - Meaning
    * - ``display_name``
-     - The value that is displayed to students as the name of the discussion
-       component.
+     - Required. The value that is displayed to students as the name of the
+       discussion component. If you do not supply a ``display_name`` value,
+       "discussion" is supplied for you.
    * - ``discussion_category``
      - The name of the category for the inline discussion as shown in the main
        **Discussion** tab of the course.

--- a/en_us/olx/source/components/html-components.rst
+++ b/en_us/olx/source/components/html-components.rst
@@ -73,8 +73,9 @@ In this case, the ``html`` element contains no children.
    * - Attribute
      - Meaning
    * - ``display_name``
-     - The value that is displayed to students as the name of the HTML
-       component.
+     - Required. The value that is displayed to students as the name of the
+       HTML component. If you do not supply a ``display_name`` value, "html" is
+       supplied for you.
    * - ``file_name``
      - The name of the HTML file that contains the content for the HTML
        component, without the ``.HTML`` extension.

--- a/en_us/olx/source/components/video-components.rst
+++ b/en_us/olx/source/components/video-components.rst
@@ -16,7 +16,8 @@ verticals (which it calls units).
 Create the XML File for a Video Component
 **********************************************
 
-To add a video component to your course, add it to the course XML tree as follows.
+To add a video component to your course, add it to the course XML tree as
+follows.
 
 .. code-block:: xml
 
@@ -80,8 +81,9 @@ The ``source`` element contains the following attribute.
    * - Attribute
      - Meaning
    * - ``display_name``
-     - The value that is displayed to students as the name of the video
-       component.
+     - Required. The value that is displayed to students as the name of the
+       video component. If you do not supply a ``display_name`` value, "video"
+       is supplied for you.
    * - ``youtube``
      - The speed and ID pairings for the YouTube video source. The value can
        contain multiple speed:ID pairs, separated by commas.

--- a/en_us/olx/source/problem-xml/create_problem.rst
+++ b/en_us/olx/source/problem-xml/create_problem.rst
@@ -55,8 +55,11 @@ the LMS, and in Insights.
      Insights.
  :width: 800
 
-Unique, descriptive display names help you and your learners identify problems
-quickly and accurately.
+Each problem type supplies a default display name that identifies the type of
+problem component added. Changing the default to a unique, descriptive display
+name can help you and your learners identify different problems quickly and
+accurately. If you delete the default display name and do not enter your own
+identifying name, the platform supplies "problem" for you.
 
 For more information about metrics for your course's problem components, see
 `Using edX Insights`_.

--- a/en_us/shared/course_components/create_discussion.rst
+++ b/en_us/shared/course_components/create_discussion.rst
@@ -62,7 +62,13 @@ Create a Discussion Component
     :width: 600
 
    The value in the **Display Name** field identifies the discussion in the
-   course content. The values in the **Category** and **Subcategory** fields
+   course content. The default display name for new discussion components is
+   "Discussion".  Changing the default to a unique, descriptive display name
+   can help you and your learners identify different topics quickly and
+   accurately. If you delete the default display name and do not enter your own
+   identifying name, the platform supplies "discussion" for you.
+
+   The values in the **Category** and **Subcategory** fields
    are visible to learners in the list of discussion topics on the
    **Discussion** page.
 

--- a/en_us/shared/course_components/create_html_component.rst
+++ b/en_us/shared/course_components/create_html_component.rst
@@ -270,6 +270,12 @@ Create an HTML Component
    do so, select **Settings**, and then enter text in the **Display Name**
    field.
 
+   Each HTML template supplies a default display name. Changing the default to
+   a unique, descriptive display name can help you and your learners identify
+   course content quickly and accurately. If you delete the default display
+   name and do not enter your own identifying name, the platform supplies
+   "html" for you.
+
    To return to the visual editor, select **Editor**.
 
 #. Select **Save**.

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -216,8 +216,11 @@ the LMS, and in Insights.
      Insights.
  :width: 800
 
-Unique, descriptive display names help you and your learners identify problems
-quickly and accurately.
+Each problem type supplies a default display name that identifies the type of
+problem component added. Changing the default to a unique, descriptive display
+name can help you and your learners identify different problems quickly and
+accurately. If you delete the default display name and do not enter your own
+identifying name, the platform supplies "problem" for you.
 
 For more information about metrics for your course's problem components, see
 `Using edX Insights`_.

--- a/en_us/shared/course_components/create_video.rst
+++ b/en_us/shared/course_components/create_video.rst
@@ -308,6 +308,11 @@ To add a video and its transcript to your course, follow these steps.
    video. This name appears as a heading above the video in the LMS, and it
    identifies the video for you in Insights.
 
+   The default display name for new video components is "Video". Changing the
+   default to a unique, descriptive display name can help you and your learners
+   identify different videos quickly and accurately. If you delete this default
+   and do not enter an identifying name, the platform supplies "video" for you.
+
 #. In the **Default Video URL** field, enter the URL of the video. Example
    URLs follow.
 


### PR DESCRIPTION
## [DOC-3060](https://openedx.atlassian.net/browse/DOC-3060)

FEDX-198 enforced a default display name for all components added to a course.
### Date Needed

This released in June
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @clrux 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check): @srpearce  
- [ ] Product review: @sstack22 
- [ ] Partner support: 
- [ ] PM review: 

FYI: @mmacfarlane
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
