### PR TITLE
Rewords specific references to Cypress

### DIFF
--- a/en_us/install_operations/source/configuration/ora2/ora2_uploads.rst
+++ b/en_us/install_operations/source/configuration/ora2/ora2_uploads.rst
@@ -9,9 +9,8 @@ Configuring ORA2 to Upload Files to Alternative Storage Systems
 By default, the Open Response Assessment (ORA2) application stores files that
 learners upload in an Amazon S3 bucket.
 
-With the Cypress release, you can configure ORA2 to store files in an alternate
-system. To have learners' files stored in a system other than Amazon S3, follow
-these steps.
+You can configure ORA2 to store files in an alternate system. To have learners'
+files stored in a system other than Amazon S3, follow these steps.
 
 #. In the ORA-2 repository, implement the ``BaseBackend`` class defined in the
    `base.py`_ file.
@@ -21,8 +20,8 @@ these steps.
    the storage system you intend to use.
 
 #. Configure ORA2 to use your alternative storage system by modifying the value
-   of ``backend_setting`` in `init file`_
-   to point to your implementation of ``BaseBackend``.
+   of ``backend_setting`` in `init file`_ to point to your implementation of
+   ``BaseBackend``.
 
 #. Add code to instantiate the new implementation to the ``get_backend()``
    function in the ``init.py`` file.
@@ -30,6 +29,3 @@ these steps.
 #. Configure ORA2 to use the alternative storage system by modifying the value
    of ``ORA2_FILEUPLOAD_BACKEND`` in the Django settings to point to your
    implementation of ``BaseBackend``.
-
-.. to do - used shared file with cypress release notes
-

--- a/en_us/install_operations/source/configuration/youtube_api.rst
+++ b/en_us/install_operations/source/configuration/youtube_api.rst
@@ -42,6 +42,10 @@ Install the YouTube API Key in Open edX
 After you obtain a YouTube API key, you must install that key into your
 Open edX installation. There are two different ways you can do this.
 
+.. contents::
+   :local:
+   :depth: 1
+
 Option 1: Ansible (recommended)
 ===============================
 
@@ -50,7 +54,8 @@ If you set your YouTube API key in Ansible's configuration file, then Ansible
 will make sure that the YouTube API key remains in place when you update Open
 edX.
 
-To set your YouTube API key in Ansible's configuration file, complete the following steps.
+To set your YouTube API key in Ansible's configuration file, follow these
+steps.
 
 #. Find the `configuration`_ repository on your Open edX server. If you are
    running devstack or fullstack, the directory is
@@ -69,7 +74,9 @@ To set your YouTube API key in Ansible's configuration file, complete the follow
 #. Save and close the file.
 
 #. Run Ansible so that it applies your YouTube API key to your Open edX
-   installation. If you are running the Open edX Cypress release, run the
+   installation.
+
+   For example, if you are running the Open edX Cypress release, run the
    following command.
 
    .. code-block:: bash


### PR DESCRIPTION
## [DOC-2705](https://openedx.atlassian.net/browse/DOC-2705)

Two files in the installation guide were written for the Cypress release and included specific references to that release. Reworded.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @nedbat
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check): @srpearce or @pdesjardins  
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
