### PR TITLE
import safe filter before use message

### DIFF
--- a/en_us/developers/source/conventions/safe_templates.rst
+++ b/en_us/developers/source/conventions/safe_templates.rst
@@ -1218,9 +1218,17 @@ context, so you must use one of the following safe filters.
 
 .. code-block:: mako
 
-    ## DO this
+    <%!
+    from openedx.core.djangolib.js_utils import dump_js_escaped_json
+    %>
+    ...
     ${x | n, dump_js_escaped_json}
+
     ## or
+    <%!
+    from openedx.core.djangolib.js_utils import js_escaped_string
+    %>
+    ...
     ${x | n, js_escaped_string}
 
     ## or DO this sparingly


### PR DESCRIPTION
It will be better to include an import the safe filter before using it, to avoid confusion and misstep.
### Reviewer
- [ ] @robrap 
- [ ] @catong 
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
