### PR TITLE
Add a script to generate source files for new release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+release-note:
+	./utilities/add-upcoming-release-notes-file.sh

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ EdX Documentation
 ###################
 
 The edx-documentation repository contains source files for most of the
-documentation for edX partners and the Open edX community. This repo is managed
-by the edX Documentation team.
+documentation for edX partners and the Open edX community. This repository is
+managed by the edX Documentation team.
 
 * API documentation that includes docstrings from code files is stored in the
   repository of that module.
@@ -110,3 +110,70 @@ HTTP server also monitors the project and detects any changes. When you save a
 change to a file, the server rebuilds the HTML and refreshes your browser
 automatically. In this way you can rapidly see how changes you make will be
 rendered as HTML.
+
+================================
+Adding Release Notes
+================================
+
+The edX documentation team compiles release notes to describe changes to the
+Open edX platform and how they affect learners, course teams, installers, and
+other end-users. You can contribute release notes for upcoming releases.
+
+Release notes are set up as a collection of ReStructured Text (.rst) files.
+There is one file for each of several categories:
+
+* Analytics
+* Documentation
+* LMS
+* Mobile
+* Open edX
+* Studio
+* The edx.org website
+
+To add a release notes item, you determine the category for the item, run the
+``utilities/add-upcoming-release-notes-file.sh`` shell script to determine or
+create the .rst file for that category, and then enter the item in the .rst
+file. You then submit a pull request for your .rst file. The documentation team
+copy edits the file and includes it in the index file for the week's release
+notes.
+
+Full instructions follow.
+
+Add a Release Notes Item
+************************
+
+To add a release notes item, follow these steps.
+
+1. Change to the edx-documentation directory.
+
+2. Create a new branch.
+
+3. On your branch, run either of the following commands.
+
+   .. code-block:: shell
+
+     $ ./utilities/add-upcoming-release-notes-file.sh
+
+     $ make release-note
+
+4. At the prompt, enter the category that you want, and then press Enter.
+
+   The script returns a message with the name and location of the .rst file
+   where you will add your item. If the file does not already exist, the script
+   creates the file. The script does not overwrite an existing release notes
+   source file for the next upcoming release.
+
+   For example, the file might have the following name.
+
+   ``/edx-documentation/en_us/release_notes/source/2016/lms/lms_2016-07-25.rst``
+
+5. In a text editor, open the file and follow the inline instructions to add
+   your note.
+
+6. Save, commit, and push your changes.
+
+7. Open a PR for your branch and resolve any merge conflicts.
+
+   The doc team is tagged automatically when you open your PR and will complete
+   any necessary copy editing. The doc team will also include the new files in
+   the release notes index.

--- a/utilities/add-upcoming-release-notes-file.sh
+++ b/utilities/add-upcoming-release-notes-file.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# Create a new RST file to hold a release note for the upcoming release, 
+# if it doesn't already exist.
+#
+# Invoke this script from the command line. It does not matter which 
+# directory you invoke it from.
+#
+#    ./add-upcoming-release-notes-file.sh
+#
+
+# These are the categories of release notes. If we add a new category,
+# for example, certificates, add a label to this list.
+NOTE_CATEGORIES="analytics documentation lms mobile openedx studio website"
+
+# Relative path from the utilities directory to the release notes source
+RELEASE_NOTES_SOURCE_PATH="../en_us/release_notes/source/"
+SCRIPT_DIRECTORY=`dirname ${0}`
+
+# Temporarily change to the script directory, so we can use relative paths.
+pushd ${SCRIPT_DIRECTORY}
+
+# Gather some information about file paths, for labeling.
+ABSOLUTE_SCRIPT_DIRECTORY="`pwd | sed 's%/utilities%%'`"
+ABSOLUTE_RELEASE_NOTES_SOURCE_PATH=`echo ${RELEASE_NOTES_SOURCE_PATH} | sed "s%..%${ABSOLUTE_SCRIPT_DIRECTORY}%"`
+
+# Explain what the script is doing.
+echo ""
+echo "Hello, writer! This script adds a new RST documentation source file to hold release notes for the upcoming release. It will not overwrite existing files."
+
+# Find out which release notes category the new note fits in.
+
+echo ""
+echo "These are the categories for release notes. Choose a category based on the audience who needs the note. If the note you are writing does not fit in any of the categories, contact the edX documentation team (docs@edx.org)."
+echo ""
+
+for POSSIBLE_CATEGORY in ${NOTE_CATEGORIES}
+do
+    echo "    ${POSSIBLE_CATEGORY}"
+done
+
+echo ""
+echo "Enter the category that you are adding a note to."
+
+read NOTE_CATEGORY
+
+for POSSIBLE_CATEGORY in ${NOTE_CATEGORIES}
+do
+    if [[ ${NOTE_CATEGORY} == ${POSSIBLE_CATEGORY} ]]
+    then
+        NOTE_CATEGORY_VALID="true"
+    fi
+done
+
+if [[ ${NOTE_CATEGORY_VALID} != "true" ]]
+then
+    echo ""
+    echo "${NOTE_CATEGORY} is not a valid category."
+    exit 1
+fi
+
+# Determine the date of the upcoming Monday.
+
+POSSIBLE_UPCOMING_MONDAY_OFFSET=0
+
+while [[ -z ${UPCOMING_MONDAY_DATE} ]]
+do
+    
+    POSSIBLE_UPCOMING_MONDAY_DAY_OF_WEEK=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%a`
+    
+    if [[ ${POSSIBLE_UPCOMING_MONDAY_DAY_OF_WEEK} == "Mon" ]]
+    then
+        # This is where we set the date string format.
+        UPCOMING_MONDAY_DATE=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%Y-%m-%d`
+        UPCOMING_MONDAY_YEAR=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%Y`
+    else
+        POSSIBLE_UPCOMING_MONDAY_OFFSET=`expr ${POSSIBLE_UPCOMING_MONDAY_OFFSET} + 1`
+    fi
+done
+
+# Add a new RST file for the upcoming date, in the release note category directory.
+
+NEW_NOTE_FILE_NAME="${UPCOMING_MONDAY_YEAR}/${NOTE_CATEGORY}/${NOTE_CATEGORY}_${UPCOMING_MONDAY_DATE}.rst"
+
+if [[ -e "${RELEASE_NOTES_SOURCE_PATH}/${NEW_NOTE_FILE_NAME}" ]]
+then
+    echo ""
+    echo "The source file for that category already exists. Add your note to:"
+    echo ""
+    echo "    ${ABSOLUTE_RELEASE_NOTES_SOURCE_PATH}${NEW_NOTE_FILE_NAME}"
+    echo ""
+else
+    echo ""
+    echo "Creating the source file for that category. Add your note to:"
+    echo ""
+    echo "    ${ABSOLUTE_RELEASE_NOTES_SOURCE_PATH}${NEW_NOTE_FILE_NAME}"
+    echo ""
+    
+    # If the year and/or category directory isn't present, create it.
+    if [[ ! -e "${RELEASE_NOTES_SOURCE_PATH}${UPCOMING_MONDAY_YEAR}/${NOTE_CATEGORY}" ]]
+    then
+        mkdir -p ${RELEASE_NOTES_SOURCE_PATH}${UPCOMING_MONDAY_YEAR}/${NOTE_CATEGORY}
+    fi
+    
+    # Define a function that writes comments to the new note source file.
+    write_note_comment () {
+        echo ".. ${1}" >> ${RELEASE_NOTES_SOURCE_PATH}${NEW_NOTE_FILE_NAME}
+    }
+    
+    # Add a comment to the top of the new RST file.
+    
+    write_note_comment "Add release notes for the ${NOTE_CATEGORY} audience in RST format here."
+    write_note_comment "The edX documentation team will include this file in the index "
+    write_note_comment "file for the upcoming release. If you add more than one note, format the"
+    write_note_comment "notes as a bulleted list by preceding each note with an asterisk."
+    write_note_comment
+    write_note_comment "If your release note change is associated with a JIRA item, add the"
+    write_note_comment "JIRA ticket number at the end of your item."
+    write_note_comment
+    write_note_comment "For example:"
+    write_note_comment
+    write_note_comment "To improve the experience of learners who use screen readers, the"
+    write_note_comment "learner dashboard now provides additional, course specific context for"
+    write_note_comment "each of the Upgrade to Verified or View XSeries Details options that"
+    write_note_comment "appear on this page. (:jira:\`ECOM-4269\`, :jira:\`ECOM-4270\`)"
+    write_note_comment
+
+    
+fi
+
+popd
+
+exit 0


### PR DESCRIPTION
## [DOC-3142](https://openedx.atlassian.net/browse/DOC-3142)

This script adds an RST source file to the release notes source directory so that a contributor can easily add a release note. The script figures out the "week of" date for the next weekly release (naively, it doesn't try to predict skipped releases for holidays) and adds an empty file. The intention is that the documentation team member who is compiling release notes will include any files contributed this way in the index files later on.

This PR was prompted by a discussion @rlucioni convened, about developers contributing release notes. The script makes it easier to consistently conform to our file naming conventions.

Note that the date format used by the script is YYYY-MM-DD, which I prefer because it orders nicely in directories. @lamagnifica suggested choosing a format other than the one we've been using for release note naming. It would be easy to alter the format, if anyone feels strongly.

Example file name:

  2016/documentation/documentation_2016-07-18.rst

To test:
- Clone this branch.
- In a command-line terminal, change to the edx-documentation/utilities directory.
- Invoke ./add-upcoming-release-notes-file.sh.
- Run "git status" to see what new RST files are in your source directory.
- Open the new files in your RST editor.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @rlucioni 
- [ ] Subject matter expert: @lamagnifica 
- [x] Subject matter expert: @srpearce 
- [x] Subject matter expert: @catong 
### Post-review
- [ ] Squash commits
