### PR TITLE
Add enable enrollment code ecommerce create_or_update_site command option.

### DIFF
--- a/en_us/install_operations/source/ecommerce/create_products/create_enrollment_codes.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_enrollment_codes.rst
@@ -1,0 +1,60 @@
+.. _Enable and Create Enrollment Codes:
+
+#####################################
+Enable and Create Enrollment Codes
+#####################################
+
+.. note::
+  The enrollment codes in this topic are not related to the enrollment codes in
+  the :ref:`Create and Manage Coupons` topic.
+
+Enrollment codes allow users to purchase bulk enrollments for a course.
+
+************************
+Enable Enrollment Codes
+************************
+
+You must enable enrollment codes in the E-Commerce service and in individual
+courses.
+
+#. To enable enrollment codes in the E-Commerce service, run the site
+   configuration command together with the following option.
+
+   ::
+
+     ``--enable-enrollment-codes=True``
+
+   For more information, see :ref:`Add Another Site Partner and Site
+   Configuration`.
+
+#. To enable enrollment codes in individual courses, follow these steps.
+
+   #. Follow step 1 through step 5 in :ref:`Create Course Seats` to access and
+      select options on the **Add New Course** page. Do not select **Create
+      Course** after you complete step 5.
+   #. Select **Include Enrollment Code**.
+   #. Select **Create Course**.
+
+After you select **Create Course**, enrollment codes are enabled for that
+course.
+
+************************
+Create Enrollment Codes
+************************
+
+#. Go to the enrollment page for the course.
+#. On the enrollment page, select **Buy enrollment**. Do not select **Enroll in
+   the course**.
+
+   The basket page opens.
+
+#. For **Number of Enrollment Codes**, enter the number of enrollment codes
+   that you want. Each enrollment code is for one course seat.
+#. Select **Purchase**.
+
+After you select **Purchase**, you receive an e-mail message that contains a
+link to a .csv file. The .csv file lists the enrollment codes.
+
+
+
+.. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/ecommerce/create_products/create_products_overview.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_products_overview.rst
@@ -4,8 +4,8 @@
 Creating Products Overview
 ###########################
 
-The edX platform offers two types of products. You create both products in
-E-Commerce web pages that are similar to the Django administration panel.
+The edX platform offers several types of products. You create these products in
+E-Commerce web pages.
 
 * Course seats represent enrollment types. Each course seat has an associated
   set of attributes, such as price and certificate availability. The edX code
@@ -15,6 +15,8 @@ E-Commerce web pages that are similar to the Django administration panel.
 * Coupons allow users to offer learners a discount, either percentage or fixed
   amount, off a course enrollment. For more information, see :ref:`Create and
   Manage Coupons`.
+
+* Enrollment codes allow users to purchase bulk enrollments for a course.
 
 ******************************
 Prepare to Create a Product

--- a/en_us/install_operations/source/ecommerce/create_products/index.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/index.rst
@@ -15,5 +15,6 @@ information, see the following topics.
    create_products_overview
    create_course_seats
    create_coupons
+   create_enrollment_codes
 
 .. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -228,6 +228,11 @@ this command.
      - Yes
      - Address from which email messages are sent.
      - ``--from-email=notifications@example.com``
+   * - ``--enable-enrollment-codes``
+     - No
+     - Indication that specifies whether enrollment codes for seats can be
+       created.
+     - ``--enable-enrollment-codes=True``
 
 
 To add another site, use the appropriate settings module for your environment


### PR DESCRIPTION
The work in https://github.com/edx/ecommerce/pull/859 will add an additional option for the `create_or_update_site` option in ecommerce, which will allow or deny creating enrollment codes.

The work is still in progress so we can't merge this before merging that PR.
### Reviewers
- [ ] Doc team review (sanity check/copy edit/dev edit): @srpearce 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
