### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Possible roles follow. The PR submitter checks the boxes after each reviewer fin
 
 - [ ] Subject matter expert: 
 - [ ] Subject matter expert: 
-- [ ] Doc team review (sanity check/copy edit/dev edit): 
+- [ ] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @pdesjardins @srpearce
 - [ ] Product review:
 - [ ] Partner support: 
 - [ ] PM review: 


### PR DESCRIPTION
## [DOC-3147](https://openedx.atlassian.net/browse/DOC-3147)

Adds all of the doc team as reviewers whenever a PR is opened.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check/copy edit/dev edit): @pdesjardins @srpearce @catong 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Post-review
- [ ] Squash commits
