### PR TITLE
Problems, exercises, and tools

### DIFF
--- a/en_us/course_authors/source/exercises_tools/index.rst
+++ b/en_us/course_authors/source/exercises_tools/index.rst
@@ -1,17 +1,18 @@
 .. _Exercises and Tools Index:
 
 ############################
-Creating Exercises and Tools
+Adding Exercises and Tools
 ############################
 
-Use the topics in this section to understand how to add exercises and
-tools to your course.
+Use the topics in this section to understand how to add exercises and tools to
+your course, including the various problem types that you can add using the
+:ref:`problem component<Working with Problem Components>`.
 
-For information on how to develop your course content in the Studio Outline
+For information about how to develop your course content in the Studio Outline
 page, see :ref:`Developing Your Course Index`.
 
-For information on building specific course component types, see :ref:`Course
-Components Index`.
+For information about building specific course component types, see
+:ref:`Course Components Index`.
 
 
 .. toctree::

--- a/en_us/open_edx_course_authors/source/exercises_tools/index.rst
+++ b/en_us/open_edx_course_authors/source/exercises_tools/index.rst
@@ -1,17 +1,18 @@
 .. _Exercises and Tools Index:
 
 ############################
-Creating Exercises and Tools
+Adding Exercises and Tools
 ############################
 
-Use the topics in this section to understand how to add exercises and
-tools to your course.
+Use the topics in this section to understand how to add exercises and tools to
+your course, including the various problem types that you can add using the
+:ref:`problem component<Working with Problem Components>`.
 
-For information on how to develop your course content in the Studio Outline
+For information about how to develop your course content in the Studio Outline
 page, see :ref:`Developing Your Course Index`.
 
-For information on building specific course component types, see :ref:`Course
-Components Index`.
+For information about building specific course component types, see
+:ref:`Course Components Index`.
 
 
 .. toctree::

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -4,34 +4,56 @@
 Working with Problem Components
 ################################
 
-This section covers the basics of problem components: what they look like to
-you and your learners, and the options that every problem component has.
+This section introduces the core set of problem types that course teams can add
+to any course by using the problem component. It also describes editing options
+and settings for problem components.
 
 .. contents::
  :local:
  :depth: 1
 
-For more information about individual problem types, see :ref:`Create
-Exercises`.
+For information about specific problem types, and the other exercises and tools
+that you can add to your course, see :ref:`Create Exercises`.
 
-******************************
-Overview
-******************************
+.. _Adding a Problem:
 
-The problem component allows you to add interactive, automatically
-graded exercises to your course content. You can create many different
-types of problems in Studio.
+****************
+Adding a Problem
+****************
 
-******************************
-Graded Problems
-******************************
+To add interactive problems to a course in Studio, In the course outline in
+Studio, at the :ref:`unit<The Unit Workflow>` level, you select **Problem**.
+You then choose the type of problem that you want to add from a list of
+**Common Problem Types** or **Advanced** problem types.
 
-All problems receive a point score, but, by default, problems do not count
-toward a learner's grade.
+The common problem types include relatively straightforward CAPA problems such
+as multiple choice and text or numeric input. The advanced problem types can be
+more complex to set up, such as math expression input, peer assessment, or
+custom JavaScript problems.
 
-To have problems to count toward the grade, change the assignment type of the
-subsection that contains the problems. For more information, see :ref:`Set the
-Assignment Type and Due Date for a Subsection`.
+The common and advanced problem types that the problem component lists are the
+core set of problems that every course team can include in a course. You can
+also enable more exercises and tools for use in your course. For more
+information, see :ref:`Enable Additional Exercises and Tools`.
+
+=====================================
+Adding Graded or Ungraded Problems
+=====================================
+
+When you :ref:`establish the grading policy<Grading Index>` for your course,
+you define the assignment types that count toward learners' grades: for
+example, homework, labs, midterm, final, and ungraded. You specify
+one of these assignment types for each of the subsections in your course.
+
+As you develop your course, you can add problem components to a unit in any
+subsection. The problem components that you add automatically inherit the
+assignment type that is defined at the subsection level. For example, all of
+the problem components that you add to a unit in an ungraded subsection are
+ungraded, all of the problem components that you add to a unit in the midterm
+subsection are graded, and so on.
+
+For more information, see :ref:`Set the Assignment Type and Due Date for a
+Subsection`.
 
 .. _Problem Learner View:
 
@@ -39,100 +61,133 @@ Assignment Type and Due Date for a Subsection`.
 
 .. _Problem Studio View:
 
-************************************
-The Studio View of a Problem
-************************************
+*****************************
+Editing a Problem in Studio
+*****************************
 
-The information that you specify for every problem component is saved in OLX
-(Open Learning XML), edX's XML standard. However, for many problem components
-Studio offers two different editing interfaces: the simple editor and the
-advanced editor.
+When you select **Problem** and choose one of the problem types, Studio adds an
+example problem of that type to the unit. To replace the example with your own
+problem, you select **Edit** to open the example problem in an editor.
 
-*  The simple editor allows you to edit problems visually, and you use
-   markdown-style formatting indicators to identify elements such as the
-   question and the correct answer. You do not need to know XML or OLX (open
-   learning XML) to use this editor.
+The editing interface that opens depends on the type of problem you choose.
 
-*  The advanced editor presents problems with their OLX markup elements and
-   attributes. You can edit problems in the advanced editor as well.
+* For common problem types, the :ref:`simple editor<Simple Editor>` opens. In
+  this editor, you use Markdown-style formatting indicators to identify the
+  elements of the problem, such as the prompt and the correct and incorrect
+  answer options.
+
+* For advanced problem types (with the exception of :ref:`peer assessment<Open
+  Response Assessments 2>`), the :ref:`advanced editor<Advanced Editor>` opens.
+  In this editor you use OLX (open learning XML) tags, elements, and attributes
+  to identify the elements of the problem.
+
+  For peer assessment problem types, you define the problem elements and
+  options by using a graphical user interface. For more information, see
+  :ref:`PA Create an ORA Assignment`.
 
 You can switch from the simple editor to the advanced editor at any time by
-selecting **Advanced Editor** from the simple editor's toolbar. However, after
-you save a problem in the advanced editor, you cannot open it again in the
-simple editor.
+selecting **Advanced Editor** from the simple editor's toolbar.
+
+.. note:: After you save a problem in the advanced editor, you cannot open it
+ again in the simple editor.
 
 .. _Simple Editor:
 
-=================
+==================
 The Simple Editor
-=================
+==================
 
-When you add one of these standard CAPA (computer assisted personalized
-approach) problem types, the simple editor opens with a preformatted example
-problem.
+When you edit one of the :ref:`common problem types<Adding a Problem>`, the
+simple editor opens with an example problem that you can use as a template for
+adding Markdown formatting.
 
-.. change to ...preformatted template.
+*  :ref:`Checkbox` and Checkboxes with Hints and Feedback
 
-*  :ref:`Checkbox`
+*  :ref:`Dropdown` and Dropdown with Hints and Feedback
 
-*  :ref:`Dropdown`
+*  :ref:`Multiple Choice` and Multiple Choice with Hints and Feedback
 
-*  :ref:`Multiple Choice`
+*  :ref:`Numerical Input` and Numerical Input with Hints and Feedback
 
-*  :ref:`Numerical Input`
+*  :ref:`Text Input` and Text Input with Hints and Feedback
 
-*  :ref:`Text Input`
+Blank common problems do not provide an example problem, but they also open in
+the simple editor by default.
 
-The following image shows an example multiple choice problem in the simple
+==========================
+Adding Markdown Formatting
+==========================
+
+The following image shows a multiple choice problem in the simple
 editor.
 
 .. image:: ../../../shared/images/MultipleChoice_SimpleEditor.png
- :alt: An example multiple choice problem in the simple editor with numbered
-     callouts that demonstrate the markdown formatting.
+ :alt: An example multiple choice problem in the simple editor, with numbered
+   callouts for each formatting option.
  :width: 600
 
 The simple editor includes a toolbar with options that provide the required
-formatting for different types of problems. When you select an option from the
-toolbar, formatted sample text appears in the simple editor. Alternatively,
-you can apply formatting to your own text by selecting the text and then one
-of the toolbar options.
+Markdown formatting for different types of problems. When you select an option
+from the toolbar, formatted sample text appears in the simple editor.
+Alternatively, you can apply formatting to your own text by selecting the text
+and then one of the toolbar options.
 
-Descriptions of the toolbar options follow.
+Descriptions of the Markdown formatting that you use in the simple editor
+follow.
 
-#. **Heading**: Formats text as a title or heading.
+#. **Heading**: Identifies a title or heading by adding a
+   series of equals signs (``=``) below it on the next line.
 
-#. **Multiple Choice**: Identifies text as an answer option for a multiple
-   choice problem.
+#. **Multiple Choice**: Identifies an answer option for a multiple choice
+   problem by adding a pair of parentheses (``( )``) before it. To identify the
+   correct answer option, you insert an ``x`` within the parentheses:
+   (``(x)``).
 
-#. **Checkboxes**: Identifies text as an answer option for a checkboxes
-   problem.
+#. **Checkboxes**: Identifies an answer option for a checkboxes problem by
+   adding a pair of brackets (``[ ]``) before it. To identify the correct
+   answer option or options, you insert an ``x`` within the brackets:
+   (``[x]``).
 
-#. **Text Input**: Identifies text as the correct answer for a text input
-   problem.
+#. **Text Input**: Identifies the correct answer for a text input problem by
+   adding an equals sign (``=``) before the answer value on the same line.
 
-#. **Numerical Input**: Identifies the correct answer, with an optional
-   tolerance, for a numerical input problem.
+#. **Numerical Input**: Identifies the correct answer for a numerical input
+   problem by adding an equals sign (``=``) before the answer value on the same
+   line.
 
-#. **Dropdown**: Identifies a comma-separated list as correct and incorrect
-   answer options for a dropdown problem.
+#. **Dropdown**: Identifies a comma-separated list of values as the set of
+   answer options for a dropdown problem by adding two pairs of brackets (``[[
+   ]]``) around the list. To identify the correct answer option, you add
+   parentheses (``( )``) around that option.
 
-#. **Explanation**: Formats text as an explanation that appears after learners
-   select **Show Answer**.
+#. **Explanation**: Identifies the explanation for the
+   correct answer by adding an ``[explanation]`` tag to the lines before and
+   after the text. An explanation appears only after learners select **Show
+   Answer**. You define when the **Show Answer** option is available to
+   learners by using the :ref:`Show Answer` setting.
 
-#. Opens the problem in the advanced editor.
+#. **Advanced Editor** link: Opens the problem in the :ref:`advanced
+   editor<Advanced Editor>`, which shows the OLX markup for the problem.
 
-#. Opens a list of formatting hints.
+#. **Question Mark** icon: Opens a list of formatting hints.
 
-#. **Accessible Label**: Identifies the part of the problem text that is the
-   specific question that learners will answer by selecting the options that
-   follow, or by entering a text or numeric response. The toolbar does not have
-   an option that provides this formatting, so you type two angle brackets on
-   either side of the question text pointing inward. For example, ``>>Is this
-   the question text?<<``.
+#. **Accessible Label**: Identifies the prompt, or question, that learners need
+   to answer. The toolbar does not have an option that provides this
+   formatting, so you add two pairs of inward-pointing angle brackets (``>>
+   <<``) around the question text. For example, ``>>Is this the question?<<``.
+
+.. Optionally, you can add guidance that helps learners answer the question as
+   part of the accessible label. For example, when you add a checkbox problem
+   that is only correct when learners select three of the answer options, you
+   might include the tip "Be sure to select all that apply." To add this
+   description, you include it after the question within the angle brackets,
+   and then you separate the question and the description by inserting a pair
+   of pipe symbols (``||``) between them. For example, ``>>Which of the
+   following choices is correct? ||Be sure to select all that apply.<<``.
 
    * Screen readers read all of the text that you supply for the problem, and
-     then repeat the text that you identify with this formatting immediately
-     before reading the answer choices for the problem.
+     then repeat the text that is identified as the accessible label
+     immediately before reading the answer choices for the problem.
 
    * The :ref:`Student_Answer_Distribution` report uses the text with this
      formatting to identify each problem.
@@ -142,72 +197,66 @@ Descriptions of the toolbar options follow.
 
 .. _Advanced Editor:
 
-===================
+====================
 The Advanced Editor
-===================
+====================
 
-The advanced editor shows the OLX markup for a problem. Templates for some
-problem types, such as math expression input, open directly in the advanced
-editor.
+The advanced editor is an XML editor that shows the OLX markup for a problem.
+The following advanced problem types open in the advanced editor.
 
-The following image shows the multiple choice problem above in the advanced
-editor instead of the simple editor.
+* :ref:`Circuit Schematic Builder`
+
+* :ref:`Custom JavaScript Display and Grading<Custom JavaScript>`
+
+* :ref:`Custom Python-Evaluated Input<Write Your Own Grader>`
+
+* :ref:`Drag and Drop<drag_and_drop_problem>`
+
+* :ref:`Image Mapped Input`
+
+* :ref:`Math Expression Input`
+
+* :ref:`Problem with Adaptive Hint`
+
+Blank advanced problems do not provide an example problem, but they also open
+in the advanced editor by default.
+
+The following image shows the OLX markup in the advanced editor for the same
+example multiple choice problem that is shown in the simple editor above.
 
 .. image:: ../../../shared/images/MultipleChoice_AdvancedEditor.png
- :alt: An image of a problem in the advanced editor.
+ :alt: An example multiple choice problem in the advanced editor.
  :width: 600
 
-The following problem templates open in the advanced editor.
-
-* :ref:`Circuit Schematic Builder` In circuit schematic problems, learners
-  create and modify circuits on an interactive grid and submit computer-
-  generated analyses of the circuits for grading.
-
-* :ref:`Custom JavaScript` With custom JavaScript problems, you can create a
-  custom problem or tool that uses JavaScript and add it directly into Studio.
-
-* :ref:`Drag and Drop` Drag and drop problems require learners to drag text or
-  objects to a specific location on an image.
-
-* :ref:`Image Mapped Input` Image mapped input problems require learners to
-  select a specific location on an image.
-
-* :ref:`Math Expression Input` Math expression input problems require learners
-  to enter a mathematical expression as text, such as e=m\*c^2.
-
-* :ref:`Problem with Adaptive Hint` These problems can give learners feedback
-  or hints based on their responses. Problems with adaptive hints can be text
-  input or multiple choice problems.
-
-* :ref:`Problem Written in LaTeX` This problem type allows you to convert
-  problems that you previously wrote in LaTeX into the edX format. Note that
-  this problem type is a prototype, and is not supported.
-
-* :ref:`Write Your Own Grader` Custom Python-evaluated input (also called
-  "write-your-own-grader" problems evaluate learners' responses using an
-  embedded Python script that you create. These problems can be of any type.
+For more information about the OLX markup to use for a problem, see the topic
+that describes that problem type.
 
 .. _Problem Settings:
 
-******************
-Problem Settings
-******************
+****************************************
+Defining Settings for Problem Components
+****************************************
 
-In addition to the text of the problem, problems that you create using a
-problem component have the following settings. To access these settings you
-select **Settings** in the component editor.
+In addition to the text of the problem and its Markdown formatting or OLX
+markup, you define the following settings for problem components. To access
+these settings, you edit the problem and then select **Settings**.
 
 .. contents::
   :local:
   :depth: 1
 
+If you do not edit these settings, default values are supplied for your
+problems.
+
 ===============
 Display Name
 ===============
 
-This setting indicates the name of your problem. This name appears as a heading
-above the problem in the LMS, and it identifies the problem for you in
-Insights.
+This required setting provides an identifying name for the problem. The display
+name appears as a heading above the problem in the LMS, and it identifies the
+problem for you in Insights. Be sure to add unique, descriptive display names
+so that you, and your learners, can identify specific problems quickly and
+accurately.
 
 The following illustration shows the display name of a problem in Studio, in
 the LMS, and in Insights.
@@ -217,35 +266,35 @@ the LMS, and in Insights.
      Insights.
  :width: 800
 
-Unique, descriptive display names help you and your learners identify problems
-quickly and accurately. If you delete the default display name and do not enter
-your own identifying name, the platform supplies "problem" for you.
-
-
 For more information about metrics for your course's problem components, see
 `Using edX Insights`_.
 
-==============================
+=================
 Maximum Attempts
-==============================
+=================
 
-This setting specifies the number of times that a learner is allowed to attempt
-answering a problem. By default, the course-wide **Maximum Attempts**
-advanced setting is null, meaning that the maximum number of attempts for
-problems is unlimited. If the course-wide **Maximum Attempts** setting is
-changed to a specific number, the **Maximum Attempts** setting for individual
-problems defaults to that number, and cannot be set to unlimited.
+This setting specifies the number of times that a learner is allowed to try to
+answer this problem correctly. You can define a different **Maximum Attempts**
+value for each problem.
 
-.. note:: edX recommends setting **Maximum Attempts** to either unlimited or a
-   very large number. Unlimited attempts allow for mastery learning and
-   encourages risk taking and experimentation, both of which lead to improved
-   learning outcomes. Allowing for unlimited attempts might be impossible in
-   some courses, such as those where grading is primarily based on multiple
-   choice problems.
+A course-wide **Maximum Attempts** setting defines the default value for this
+problem-specific setting. Initially, the value for the course-wide setting is
+null, meaning that learners can try to answer problems an unlimited number of
+times. You can change the course-wide default by selecting **Settings** and
+then **Advanced Settings**. Note that if you change the course-wide default
+from null to a specific number, you can no longer change the problem-specific
+**Maximum Attempts** value to unlimited.
 
-.. note:: Only problems that have a **Maximum Attempts** setting of 1 or
-   higher are included in the answer distribution computations used in edX
-   Insights and the Student Answer Distribution report.
+Only problems that have a **Maximum Attempts** setting of 1 or higher are
+included in the answer distribution computations used in edX Insights and the
+Student Answer Distribution report.
+
+.. note:: EdX recommends setting **Maximum Attempts** to unlimited or a
+   large number when possible. Problems that allow unlimited attempts encourage
+   risk taking and experimentation, both of which lead to improved learning
+   outcomes. However, allowing for unlimited attempts might not be feasible in
+   some courses, such as those that use primarily multiple choice or dropdown
+   problems in graded subsections.
 
 .. _Problem Weight:
 
@@ -253,25 +302,30 @@ problems defaults to that number, and cannot be set to unlimited.
 Problem Weight
 ==============================
 
-.. note:: The LMS stores scores for all problems, but
-  scores only count toward a learner's final grade if they are in a subsection
-  that is graded.
+.. note:: The LMS scores all problems. However, only scores for problem
+  components that are in graded subsections count toward a learner's final
+  grade.
 
-This setting specifies the total number of points possible for the
-problem. The problem weight appears next to the problem's display name.
+This setting specifies the total number of points possible for the problem. In
+the LMS, the problem weight appears near the problem's display name.
 
 .. image:: ../../../shared/images/ProblemWeight_DD.png
- :alt: An image of a problem from a learner's point of view, with the possible
+ :alt: A problem component with three questions, with the possible
        number of points, 3, circled.
  :width: 500
 
-By default, each response field, or "answer space", in a problem component is
-worth one point. Any problem component can have multiple response fields. For
-example, the problem component above contains one dropdown problem that has
-three separate questions, and also has three response fields.
+By default, each response field, or answer space, in a problem component is
+worth one point. You increase or decrease the number of points for a problem
+component by setting its **Problem Weight**.
 
-You can increase or decrease the weight for a problem component by entering a
-**Problem Weight**.
+In the example shown above, a single problem component includes three separate
+questions. To respond to these questions, learners select answer options from
+three separate dropdown lists, the response fields for this problem. By
+default, learners receive one point for each question that they answer
+correctly.
+
+For information about how to define a problem that includes more than one
+question, see :ref:`Multiple Problems in One Component`.
 
 Computing Scores
 ****************
@@ -296,7 +350,7 @@ The following are some examples of computing scores.
 
 *Example 1*
 
-A problem's **Weight** setting is left blank. The problem has two
+A problem's **Problem Weight** setting is left blank. The problem has two
 response fields. Because the problem has two response fields, the
 maximum score is 2.0 points.
 
@@ -324,10 +378,10 @@ answers, the learner's score is 0.5 out of 2 points.
 Randomization
 ===============
 
-.. note:: The **Randomization** setting serves a different purpose from
- "problem randomization". The **Randomization** setting affects how numeric
+.. note:: This **Randomization** setting serves a different purpose from
+ "problem randomization". This **Randomization** setting affects how numeric
  values are randomized within a single problem and requires the inclusion of a
- Python script. Problem randomization offers different problems or problem
+ Python script. Problem randomization presents different problems or problem
  versions to different learners. For more information, see :ref:`Problem
  Randomization`.
 
@@ -372,8 +426,8 @@ in *Using edX Insights*.
 
 .. important:: Whenever you choose an option other than **Never** for a
  problem, the computations for the Answer Distribution report and edX Insights
- include up to 20 variants for the problem, even if the problem was not
- actually configured to include randomly generated values. This can make data
+ include up to 20 variants for the problem, **even if the problem was not
+ actually configured to include randomly generated values**. This can make data
  collected for problems that cannot include randomly generated values,
  (including, but not limited to, all multiple choice, checkboxes, dropdown, and
  text input problems), extremely difficult to interpret.
@@ -408,8 +462,7 @@ You can choose the following options for the **Randomization** setting.
 Show Answer
 ===============
 
-This setting defines when learners are shown the answers to a problem and has
-the following options.
+This setting adds a **Show Answer** option to the problem. The following options define when the answer is shown to learners.
 
 .. list-table::
    :widths: 15 70
@@ -445,7 +498,7 @@ the following options.
    * - **Past Due**
      - Show the answer after the due date for the problem has passed.
    * - **Never**
-     - Never show the answer. In this case, a **Show Answer** button does not
+     - Never show the answer. In this case, the **Show Answer** option does not
        appear next to the problem in Studio or in the LMS.
 
 .. _Show Reset Button:
@@ -454,7 +507,7 @@ the following options.
 Show Reset Button
 =================
 
-This setting defines whether a **Reset** button is visible on the problem.
+This setting defines whether a **Reset** option is available for the problem.
 
 Learners can select **Reset** to clear any input that has not yet been
 submitted, and try again to answer the problem.
@@ -464,10 +517,10 @@ submission and, if the problem contains randomized variables and randomization
 is set to **On Reset**, changes the values in the problem.
 
 If the number of Maximum Attempts that was set for this problem has been
-reached, the **Reset** button is not visible.
+reached, the **Reset** option is not visible.
 
 This problem-level setting overrides the course-level **Show Reset Button for
-Problems** setting.
+Problems** advanced setting.
 
 .. _Timer Between Attempts:
 
@@ -487,6 +540,88 @@ sees a message below the problem indicating the remaining wait time. The format
 of the message is, "You must wait at least {n} seconds between submissions. {n}
 seconds remaining."
 
+.. _Multiple Problems in One Component:
+
+***************************************************
+Including Multiple Questions in One Component
+***************************************************
+
+In some cases, you might want to design an assessment that combines multiple
+questions in a single problem component. For example, you might want learners
+to demonstrate mastery of a concept by providing the correct responses to
+several questions, and only giving them credit for problem if all of the
+answers are correct.
+
+Another example involves learners who have slow or intermittent internet
+connections. When every problem appears on a separately loaded web page, these
+learners can find the amount of time it takes to complete an assignment or exam
+discouraging. For these learners, grouping several questions together can
+promote increased engagement with course assignments.
+
+When you add multiple questions to a single problem component, the settings
+that you define, including the display name and whether to show the **Reset**
+button, apply to all of the questions in that component. The answers to all of
+the questions are submitted when learners select **Check**, and the correct
+answers for all of the questions appear when learners select **Show Answer**.
+By default, learners receive one point for each question they answer correcty.
+For more information about changing the default problem weight and other
+settings, see :ref:`Problem Settings`.
+
+.. important:: To assure that the data collected for learner interactions with
+  your problem components is complete and accurate, include a maximum of 10
+  questions in a single problem component.
+
+================================================
+Adding Multiple Questions to a Problem Component
+================================================
+
+To design an assignment that includes several questions, you add one problem
+component and then edit it to add all of the questions, one after the other, in
+that component. Be sure to identify the text of every question or prompt with
+the appropriate Markdown characters (``>> <<``) or OLX markup, and include all
+of the other required elements for each question you include.
+
+.. info about the question separator markdown/up will go here; see if the OLX markup is always the label= attribute
+
+The questions that you include can all have the same problem type, such as a
+series of text input questions, or you can include questions that use different
+problem types, such as both numerical input and math expression input.
+
+.. note::
+  You cannot use a :ref:`Custom JavaScript` in a problem component that
+  contains more than one question. Each custom JavaScript problem must be in
+  its own component.
+
+.. include:: ../../../shared/exercises_tools/Section_adding_hints.rst
+
+.. include:: ../../../shared/exercises_tools/Section_partial_credit.rst
+
+.. include:: ../../../shared/exercises_tools/Section_adding_tooltip.rst
+
+.. _Problem Randomization:
+
+***********************************
+Problem Randomization
+***********************************
+
+Presenting different learners with different problems or with different
+versions of the same problem is referred to as "problem randomization".
+
+You can provide different learners with different problems by using randomized
+content blocks, which randomly draw problems from pools of problems stored in
+content libraries. For more information, see :ref:`Randomized Content Blocks`.
+
+.. note:: Problem randomization is different from the **Randomization** setting
+   that you define in Studio. Problem randomization presents different problems
+   or problem versions to different learners, while the **Randomization**
+   setting controls when a Python script randomizes the variables within a
+   single problem. For more information about the **Randomization** setting,
+   see :ref:`Randomization`.
+
+.. _Create Randomized Problems:
+
+Creating randomized problems by exporting your course and editing some of your
+course's XML files is no longer supported.
 
 .. _Modifying a Released Problem:
 
@@ -500,7 +635,7 @@ Modifying a Released Problem
 
 After a learner submits a response to a problem, the LMS stores that response,
 the score that the learner received, and the maximum score for the problem. For
-problems with a **Maximum Attempts** setting greater than one, the LMS updates
+problems with a **Maximum Attempts** setting greater than 1, the LMS updates
 these values each time the learner submits a new response to a problem.
 However, if you change a problem or its attributes, existing learner
 information for that problem is not automatically updated.
@@ -531,121 +666,15 @@ to submit a new response and be regraded. Note that both options require you to
 ask your learners to go back and resubmit answers to a problem.
 
 *  In the problem component that you changed, increase the number of attempts
-   for the problem, then ask all your learners to redo the problem.
+   for the problem, and then ask all of your learners to redo the problem.
 
-*  Delete the entire problem component in Studio and create a new Problem
-   component with the content and settings that you want, then ask all your
-   learners to complete the new problem. (If the revisions you must make are
-   minor, duplicate the problem component before you delete it and revise the
-   copy.)
+*  Delete the entire problem component in Studio and replace it with a new
+   problem component that has the content and settings that you want. Then ask
+   all of your learners to complete the new problem. (If the revisions you must
+   make are minor, you might want to duplicate the problem component before you
+   delete it, and then revise the copy.)
 
 For information about how to review and adjust learner grades in the LMS, see
-:ref:`Grades`.
-
-.. _Multiple Problems in One Component:
-
-***********************************
-Multiple Problems in One Component
-***********************************
-
-You might want to create a problem that has more than one response type. For
-example, you might want to create a numerical input problem and then include a
-multiple choice problem about that numerical input problem. Or, you might
-want a learner to be able to check the answers to many problems at one time. To
-do this, you can include multiple problems inside a single problem component.
-The problems can be different types.
-
-.. note::
-  You cannot use a :ref:`Custom JavaScript` in a component that contains more
-  than one problem. Each custom JavaScript problem must be in its own
-  component.
-
-To create multiple problems in one component, create a new Blank Advanced
-problem component, and then add the OLX  for each problem in the component
-editor. You only need to include the OLX  for the problem and its answers. You
-do not have to include the code for other elements, such as the **Check**
-button.
-
-Elements such as the **Check**, **Show Answer**, and **Reset** buttons, as well
-as the settings that you select for the problem component, apply to all of the
-problems in that component. Thus, if you set the maximum number of attempts to
-3, the learner has three attempts to answer the entire set of problems in the
-component as a whole rather than three attempts to answer each problem
-individually. If a learner selects **Check**, the LMS scores all of the
-problems in the component at once. If a learner selects **Show Answer**, the
-answers for all the problems in the component appear.
-
-.. include:: ../../../shared/exercises_tools/Section_adding_hints.rst
-
-.. include:: ../../../shared/exercises_tools/Section_partial_credit.rst
-
-
-.. _Problem Randomization:
-
-***********************************
-Problem Randomization
-***********************************
-
-Presenting different learners with different problems or with different
-versions of the same problem is referred to as "problem randomization".
-
-You can provide different learners with different problems by using randomized
-content blocks, which randomly draw problems from pools of problems stored in
-content libraries. For more information, see :ref:`Randomized Content Blocks`.
-
-.. note:: Problem randomization is different from the **Randomization** setting
-   in Studio. Problem randomization offers different problems or problem
-   versions to different learners, whereas the **Randomization** setting
-   controls when a Python script randomizes the variables within a single
-   problem. For more information about the **Randomization** setting, see
-   :ref:`Randomization`.
-
-
-
-============================================
-Course Outline Terminology in Exported Files
-============================================
-
-Sections, subsections, units, and components have different names in the
-**Course Outline** view and in the list of files that you will see after you
-export your course and open the OLX files for editing. The following table
-lists the names of these elements in the **Course Outline** view and in a list
-of files.
-
-.. list-table::
-   :widths: 15 15
-   :header-rows: 0
-
-   * - Course Outline View
-     - File List
-   * - Section
-     - Chapter
-   * - Subsection
-     - Sequential
-   * - Unit
-     - Vertical
-   * - Component
-     - Discussion, HTML, problem, or video
-
-For example, when you want to find a specific section in your course, look in
-the **Chapter** directory when you open the list of files that your course
-contains. To find a unit, look in the **Vertical** directory.
-
-.. _Create Randomized Problems:
-
-==========================
-Create Randomized Problems
-==========================
-
-.. note:: Creating randomized problems by exporting your course and editing
-   some of your course's OLX files is no longer supported.
-
-You can provide different learners with different problems by using randomized
-content blocks, which randomly draw problems from pools of problems stored in
-content libraries. For more information, see
-:ref:`partnercoursestaff:Randomized Content Blocks`.
-
-
-.. include:: ../../../shared/exercises_tools/Section_adding_tooltip.rst
+:ref:`Adjust_grades`.
 
 .. include:: ../../../links/links.rst

--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -1,26 +1,26 @@
 .. _Create Exercises:
 
-############################
-Exercises and Tools
-############################
+###############################
+Problems, Exercises, and Tools
+###############################
 
-You can add a wide variety of different types of exercises and tools to your
-course outline. By default, a core set of exercises is available for you to add
-to your course. There are also numerous additional exercises and tools that you
-can review and add to your course.
+You can add a wide variety of different types of problems, exercises, and tools
+to your course outline. By default, a core set of :ref:`problem types<Working
+with Problem Components>` is available for you to include in your course. You
+have the option to expand the initial set of core problem types by enabling
+additional exercises and tools.
 
 .. contents::
   :local:
   :depth: 2
 
-************************************
-Levels of Support for Tools
-************************************
+******************
+Levels of Support
+******************
 
-The level of support that edX provides for each tool varies. The description
-of each exercise and tool in the following sections indicates the level of
-support designated for each tool: full, provisional, or no support. This table
-provides the definition for each level of support.
+The level of support that edX provides for each problem, exercise, or tool
+varies. The levels of support are categorized as full, provisional, or no
+support. This table provides the definition for each level of support.
 
 .. list-table::
    :widths: 25 60
@@ -47,42 +47,42 @@ provides the definition for each level of support.
        requirements, such as testing, accessibility, internationalization, and
        documentation.
 
-************************************
-Introduction to Exercises and Tools
-************************************
+**************************************************************
+Enhancing Your Course with Additional Exercises and Tools
+**************************************************************
 
 "Exercises and tools" is a general way to refer to the robust variety of
-content that you can integrate into an online course. You create the graded and
-ungraded assessments in your course with different exercises or problem types,
-while various tools deliver different types of course content. Software
-developers use the XBlock component architecture to contribute new exercises
-and tools to the Open edX platform and provide new and varied options for
-reaching learners.
+content that you can integrate into an online course. Software developers use
+the XBlock component architecture to contribute new exercises and tools to the
+Open edX platform and provide new and varied options for reaching learners.
+Exercises enhance the core set of problem types by challenging learners to
+complete graded and ungraded assessments. Tools deliver a variety of other
+types of course content.
 
-* You might need to explicitly enable an exercise or tool that you want to use
-  in your course. For more information, see :ref:`Enable Additional Exercises
-  and Tools`.
+* To use an exercise or tool in your course beyond the core set of problem
+  types, you must explicitly enable that exercise or tool. For more
+  information, see :ref:`Enable Additional Exercises and Tools`.
 
-* After you enable an exercise or tool for use with your course, when you add a
-  component to a unit, that exercise or tool might be listed as one of the
-  **Advanced**, **HTML**, or **Problem** options.
+* After you enable an exercise or tool for use in your course, you might need
+  to select **Advanced**, **HTML**, or **Problem** on the unit page in order to
+  add content of that type to your course.
 
-The topics in this section describe different exercises and tools. Information
-about how to enable specific exercises and tools is provided, followed by
-examples and step-by-step instructions for how you use Studio to add components
-to your course. For many of the exercises and tools, when you add a component
-Studio presents a template for you to use as a starting point for your work.
-XML examples and descriptions of the attributes, tags, and elements that you
-can use in an XML editor are also provided.
+The topics in this section describe different problems, exercises, and tools.
+Information about how to enable specific exercises and tools is provided, along
+with examples and step-by-step instructions for how you use Studio to add
+components to your course. For many of the exercises and tools, when you add a
+component Studio presents a template for you to use as a starting point for
+your work. OLX examples and descriptions of the attributes, tags, and elements
+that you can use in the advanced editor are also provided.
 
 .. _General Exercises and Tools:
 
-****************************
-General Exercises and Tools
-****************************
+*******************************
+General-Use Exercises and Tools
+*******************************
 
-Exercises and tools with a wide range of uses are listed alphabetically in this
-table.
+Exercises and tools that have a wide range of uses are listed alphabetically in
+this table.
 
 .. only:: Open_edX
 
@@ -99,25 +99,23 @@ table.
      - Description
      - Support
    * - :ref:`Annotation`
-     - Annotation problems ask learners to respond to questions about a
-       specific block of text. The question appears above the text when the
-       learner moves the cursor to the highlighted text so that learners can
-       think about the question as they read.
+     - Learners respond to questions about a specific block of text. The
+       question appears above the text so that learners can think about the
+       question as they read.
      - Provisional support
    * - :ref:`Calculator`
-     - The calculator tool is available for every course through the course
-       advanced settings. When the calculator tool is enabled, it appears on
-       every unit page. Learners can enter input that includes Greek
-       letters, trigonometric functions, and scientific or ``e`` notation in
-       addition to common operators.
+     - Learners can enter input that includes Greek letters, trigonometric
+       functions, and scientific or ``e`` notation in addition to common
+       operators. The calculator tool is available for every course through the
+       course advanced settings. When the calculator tool is enabled, it
+       appears on every unit page.
      - Provisional support
    * - :ref:`completion`
-     - This tool allows learners to mark sections of course content as
-       completed. It helps learners to track their progress through sections of
-       the course (including for ungraded activities such as reading text,
-       watching video, or participating in course discussions), and gives them
-       a way to indicate to both themselves and course staff that they
-       completed the required activities.
+     - Learners mark sections of course content as completed. This tool helps
+       learners track their progress through sections of the course (including
+       ungraded activities such as reading text, watching videos, or
+       participating in course discussions), and gives them a way to indicate
+       to both themselves and course staff that they completed an activity.
      - Full support
    * - :ref:`Conditional Module`
      - You can create a conditional module to control versions of content that
@@ -127,9 +125,9 @@ table.
      - Provisional support
    * - :ref:`Custom JavaScript`
      - Custom JavaScript display and grading problems (also called custom
-       JavaScript problems or JS input problems) allow you to create a
-       custom problem or tool that uses JavaScript and then add the problem or
-       tool directly into Studio.
+       JavaScript problems or JS input problems) allow you to create a custom
+       problem or tool that uses JavaScript and then add the problem or tool
+       directly into Studio.
      - Full support
    * - :ref:`External Grader`
      - An external grader is a service that receives learner responses to a
@@ -140,19 +138,18 @@ table.
        submit complex code.
      - Provisional support
    * - :ref:`Google Calendar Tool`
-     - You can embed a Google calendar in your course so that learners see the
-       calendar in the course body. You can use a Google calendar to share quiz
-       dates, office hours, or other schedules of interest to learners.
+     - Learners see a Google calendar embedded in your course. You can use a
+       Google calendar to share quiz dates, office hours, or other schedules of
+       interest to learners.
      - Full support
    * - :ref:`Google Drive Files Tool`
-     - You can embed a Google Drive file, such as a document, spreadsheet, or
-       image, in your course so that learners see the file in the course body.
+     - Learners see a Google Drive file, such as a document, spreadsheet, or
+       image, embedded in your course.
      - Full support
    * - :ref:`Google Instant Hangout`
-     - You can add the ability for learners to participate in instant hangouts
-       directly from your course. With instant hangouts, learners can interact
-       through live video and voice, share screens and watch videos together,
-       and collaborate on documents.
+     - Learners participate in instant hangouts directly in your course. With
+       instant hangouts, learners can interact through live video and voice,
+       share screens and watch videos together, and collaborate on documents.
      - Provisional support
    * - :ref:`IFrame`
      - With the iframe tool, you can integrate ungraded exercises and tools
@@ -167,10 +164,9 @@ table.
        learners can experience them directly in the course body.
      - Full support
    * - :ref:`Open Response Assessments 2`
-     - In open response assessments, learners receive feedback on written
-       responses of varying lengths as well as image files that the learners
-       upload. Open response assessments include self assessment and peer
-       assessment.
+     - Learners receive feedback on responses that they submit, and give
+       feedback to other course participants. Open response assessments include
+       self assessment, peer assessment, and optionally, staff assessment.
      - Full support
    * - :ref:`Oppia Exploration Tool`
      - You can embed Oppia explorations in your course so that learners can
@@ -198,8 +194,8 @@ table.
        problems can be text input or multiple choice problems.
      - Provisional support
    * - :ref:`Problem Written in LaTeX`
-     - If you have a problem that is already written in LaTeX, you can use
-       this problem type to easily convert your code into XML.
+     - If you have a problem that is already written in LaTeX, you can use this
+       problem type to convert your code into XML.
      - No support
    * - :ref:`Qualtrics Survey`
      - You can import surveys that you have created in Qualtrics. The survey
@@ -207,10 +203,10 @@ table.
      - Full support
    * - :ref:`RecommenderXBlock`
      - RecommenderXBlock can hold a list of resources for misconception
-       remediation, additional reading, and so on. This tool allows the
-       course team and learners to work together to maintain the list of
-       resources. For example, team members and learners can suggest new
-       resources, vote for useful ones, or flag abuse and spam.
+       remediation, additional reading, and so on. This tool allows the course
+       team and learners to work together to maintain the list of resources.
+       For example, team members and learners can suggest new resources, vote
+       for useful ones, or flag abuse and spam.
      - Full support
    * - :ref:`Survey Tool`
      - You can include surveys in your course to collect learner responses to
@@ -222,13 +218,13 @@ table.
        punctuation marks.
      - Full support; mobile-ready
    * - :ref:`Word Cloud`
-     - Word clouds arrange text that learners enter - for example, in response
-       to a question - into a colorful graphic that learners can see.
+     - Word clouds arrange text that learners enter in response to a question
+       into a colorful graphic.
      - Provisional support
    * - :ref:`Write Your Own Grader`
      - In custom Python-evaluated input (also called "write-your-own-grader")
        problems, the grader uses a Python script that you create and embed in
-       the problem to evaluates a learner's response or provide hints. These
+       the problem to evaluate a learner's response or provide hints. These
        problems can be any type.
      - Provisional support
 
@@ -247,30 +243,27 @@ this table.
      - Description
      - Support
    * - :ref:`drag_and_drop_problem`
-     - In drag and drop problems, learners respond to a question by dragging
-       text or objects to a specific location on an image.
+     - Learners respond to a question by dragging text or objects to a specific
+       location on an image.
      - Full support; mobile-ready
    * - :ref:`Full Screen Image`
-     - The full screen image tool allows a learner to enlarge an image in the
-       whole browser window. This is useful when the image contains a large
-       amount of detail and text that is easier to view in context when
-       enlarged.
+     - Learners can enlarge an image in the entire browser window. This tool is
+       useful for detailed images that are easier to view when enlarged.
      - Full support
    * - :ref:`Image Mapped Input`
-     - In an image mapped input problem, learners click inside a defined area
-       in an image. You define this area by including coordinates in the body
-       of the problem.
+     - Learners answer prompts by selecting a defined area in an image. You
+       define the area by including coordinates in the body of the problem.
      - Provisional support
    * - :ref:`Zooming Image`
-     - Zooming images allow you to enlarge sections of an image so that
-       learners can see the section in detail.
+     - Learners can view sections of an image in detail. You specify the
+       sections in an image that can be enlarged.
      - Full support
 
-************************************
-Multiple Choice Exercises and Tools
-************************************
+**************************************
+Multiple Choice Problems and Exercises
+**************************************
 
-Exercises and tools that provide ways for learners to select from
+Problems and exercises that provide ways for learners to select from
 several options are listed alphabetically in this table.
 
 .. list-table::
@@ -281,37 +274,32 @@ several options are listed alphabetically in this table.
      - Description
      - Support
    * - :ref:`Checkbox`
-     - In checkbox problems, the learner selects one or more options from a
-       list of possible answers. The learner must select all the options that
-       apply to answer the problem correctly.
+     - Learners select one or more options from a set of possible answers. The
+       learner must select all the options that apply to answer the problem
+       correctly.
      - Full support; mobile-ready
    * - :ref:`Dropdown`
-     - Dropdown problems allow the learner to choose from a collection of
-       answer options, presented as a dropdown list. Unlike multiple choice
-       problems, whose answers are always visible directly below the question,
-       dropdown problems don't show answer choices until the learner clicks the
-       dropdown arrow.
+     - Learners choose one answer from a set of possible answers, which are
+       presented in a dropdown list after the learner selects the dropdown
+       arrow.
      - Full support; mobile-ready
    * - :ref:`Multiple Choice`
-     - In multiple choice problems, learners select one option from a list of
-       answer options. Unlike with dropdown problems, whose answer choices
-       don't appear until the learner clicks the drop-down arrow, answer
-       choices for multiple choice problems are always visible directly below
-       the question.
+     - Learners select one answer from a set of possible answers, which are
+       visible directly below the question.
      - Full support; mobile-ready
    * - :ref:`Multiple Choice and Numerical Input`
-     - You can create a problem that combines a multiple choice and numerical
-       input problems. Students not only select a response from options that
-       you provide, but also provide more specific information, if necessary.
+     - Learners not only choose one answer from a set of possible options, they
+       are also prompted to provide more specific information, if necessary.
      - Provisional support; mobile-ready
 
 
-********************************
-STEM Exercises and Tools
-********************************
+***********************************
+STEM Problems, Exercises, and Tools
+***********************************
 
-Exercises and tools that are most suitable for use in science, technology,
-engineering, or math courses are listed alphabetically in this table.
+Problems, exercises, and tools that are most suitable for use in science,
+technology, engineering, or math courses are listed alphabetically in this
+table.
 
 .. list-table::
    :widths: 25 60 20
@@ -321,56 +309,51 @@ engineering, or math courses are listed alphabetically in this table.
      - Description
      - Support
    * - :ref:`Chemical Equation`
-     - Chemical equation problems allow the learner to enter text that
-       represents a chemical equation into a text box. The grader evaluates the
-       learner's response by using a Python script that you create and embed in
-       the problem.
+     - Learners enter a value that represents a chemical equation into a text
+       box. The grader uses Python script that you create and embed in the
+       problem to evaluate learner responses.
      - Full support
    * - :ref:`Circuit Schematic Builder`
-     - In circuit schematic builder problems, learners can arrange circuit
-       elements such as voltage sources, capacitors, resistors, and MOSFETs on
-       an interactive grid. They then submit a DC, AC, or transient analysis of
-       their circuit to the system for grading.
+     - Learners arrange circuit elements such as voltage sources, capacitors,
+       resistors, and MOSFETs on an interactive grid. They then submit a DC,
+       AC, or transient analysis of their circuits to the system for grading.
      - Provisional support
    * - :ref:`Gene Explorer`
      - The gene explorer (GeneX) simulates the transcription, splicing,
        processing, and translation of a small hypothetical eukaryotic gene.
-       GeneX allows learners to make specific mutations in a gene sequence, and
-       it then calculates and displays the effects of the mutations on the mRNA
-       and protein.
+       Learners make specific mutations in a gene sequence, and this tool
+       calculates and displays the effects of the mutations on the mRNA and
+       protein.
      - Provisional support
    * - :ref:`Math Expression Input`
-     - The more complex of Studio's two types of math problems. In math
-       expression input problems, learners enter mathematical expressions to
-       answer a question. These problems can include unknown variables and more
-       complex symbolic expressions. You can specify a correct answer either
-       explicitly or by using a Python script.
+     - Learners enter mathematical expressions to answer a question. These
+       problems can include unknown variables and more complex symbolic
+       expressions. You can specify a correct answer either explicitly or by
+       using a Python script.
      - Full support; mobile-ready
    * - :ref:`Molecule Editor`
-     - The molecule editor allows learners to draw molecules that follow the
-       rules for covalent bond formation and formal charge, even if the
-       molecules are chemically impossible, are unstable, or do not exist in
-       living systems.
+     - Learners draw molecules that follow the rules for covalent bond
+       formation and formal charge, even if the molecules are chemically
+       impossible, are unstable, or do not exist in living systems.
      - No support
    * - :ref:`Molecule Viewer`
-     - The molecule viewer allows you to create three-dimensional
-       representations of molecules for learners to view.
+     - Learners view three-dimensional representations of molecules that you
+       create.
      - No support
    * - :ref:`Numerical Input`
-     - The simpler of Studio's two types of math problems. In numerical input
-       problems, learners enter numbers or specific and relatively simple
-       mathematical expressions to answer a question. These problems only allow
-       integers and a few select constants. You can specify a margin of error,
-       and you can specify a correct answer either explicitly or by using a
-       Python script.
+     - Learners enter numbers or specific and relatively simple mathematical
+       expressions to answer a question. These problems allow only integers and
+       a few select constants. You can specify a margin of error, and you can
+       specify a correct answer either explicitly or by using a Python script.
      - Full support; mobile-ready
    * - :ref:`Periodic Table`
-     - An interactive periodic table of the elements shows detailed information
-       about each element as the learner moves the mouse over the element.
+     - An interactive periodic table of the elements that shows detailed
+       information about each element when learners move the pointer over each
+       element.
      - No support
    * - :ref:`Protein Builder`
-     - The Protex protein builder asks learners to create specified protein
-       shapes by stringing together amino acids.
+     - Learners create specified protein shapes by stringing together amino
+       acids.
      - No support
 
 

--- a/en_us/shared/exercises_tools/enable_exercises_tools.rst
+++ b/en_us/shared/exercises_tools/enable_exercises_tools.rst
@@ -1,15 +1,24 @@
 .. _Enable Additional Exercises and Tools:
 
 #########################################
-Enable Additional Exercises and Tools
+Enabling Additional Exercises and Tools
 #########################################
 
-Studio offers the same set of core exercises and tools for every course. You
-can expand the default set by enabling additional exercises and tools. After
-you enable an exercise or tool in Studio, you can add components of that type
-to your course.
+Studio includes a default set of core problem types that can be added to any
+course, including CAPA problems like text input, multiple choice, and math
+expression input. To add these problem types to a course, you select
+**Problem** on the unit page.
 
-To enable additional exercises and tools, follow these steps.
+You can expand the types of content you include in your course by enabling
+additional exercises and tools. After you enable an exercise or tool for use
+with your course, when you add a component to a unit, that type of content
+might be listed as one of the **Advanced**, **HTML**, or **Problem** options
+
+******************************************
+Enable an Exercise or Tool for Your Course
+******************************************
+
+To enable an advanced exercise or tool, follow these steps.
 
 #. In Studio, select **Settings**, and then **Advanced Settings**.
 
@@ -55,5 +64,6 @@ To enable additional exercises and tools, follow these steps.
    Studio checks the syntax of your entry and reformats your entry to add line
    feeds and indentation. A message lets you know whether your changes were
    saved successfully.
+
 
 

--- a/en_us/shared/releasing_course/export_import_course.rst
+++ b/en_us/shared/releasing_course/export_import_course.rst
@@ -64,6 +64,40 @@ To export your course, follow these steps.
 When the export completes you can then access the .tar.gz file on your
 computer.
 
+**********************************************
+Course Outline Terminology in Exported Files
+**********************************************
+
+Sections, subsections, units, and components have different names in the Studio
+**Course Outline** view and in the list of files that you see after you
+export your course and open the .xml files for editing. The following table
+lists the names of these elements in the **Course Outline** view and in a list
+of files.
+
+.. list-table::
+   :widths: 15 15
+   :header-rows: 0
+
+   * - Course Outline View
+     - File List
+   * - Section
+     - Chapter
+   * - Subsection
+     - Sequential
+   * - Unit
+     - Vertical
+   * - Component
+     - Discussion, HTML, problem, or video
+
+For example, if you want to find a specific section in your course when you
+open the list of files that your course contains, look in the **Chapter**
+directory. To find a unit, look in the **Vertical** directory.
+
+   .. only:: Partners
+
+     For more information, see :ref:`data:course_structure` in the **EdX
+     Research Guide**.
+
 .. _Import a Course:
 
 ***************

--- a/en_us/shared/student_progress/Section_course_student.rst
+++ b/en_us/shared/student_progress/Section_course_student.rst
@@ -30,7 +30,7 @@ Reported Problem Types
 **********************
 
 To measure problem-related activity, the learner engagement report includes
-data for capa problems. That is, the report includes data for problems for
+data for CAPA problems. That is, the report includes data for problems for
 which learners can select **Check**, including these problem types.
 
  * Checkboxes

--- a/en_us/shared/student_progress/course_answers.rst
+++ b/en_us/shared/student_progress/course_answers.rst
@@ -71,7 +71,7 @@ completed both in the browser and on the server. These records appear with the
 most recent interaction at the top of the Submission History Viewer, followed
 by each previous interaction.
 
-This topic provides an example submission history for a capa problem with
+This topic provides an example submission history for a CAPA problem with
 guidelines that can help you interpret a submission history. The number and
 complexity of the records that appear in this report vary based on the type of
 problem and the settings and features defined.
@@ -219,7 +219,7 @@ submitted for a problem by every learner, follow these steps.
 
 #. Select **Instructor**, and then select **Data Download**.
 
-#. In the **Reports** section, enter the **Problem location** . For capa
+#. In the **Reports** section, enter the **Problem location** . For CAPA
    problems, you can use the **Staff Debug Info** option to :ref:`find this
    identifier<find_URL>` for a problem.
 
@@ -244,7 +244,7 @@ learner's most recently submitted answer.
 
 When you open the report, the value in the **State** column appears on a single
 line. This value is a record in JSON format. An example record for a text input
-capa problem follows.
+CAPA problem follows.
 
 ``{"correct_map": {"e58b639b86db44ca89652b30ea566830_2_1": {"hint": "", "hintmode": null, "correctness": "correct", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}}, "input_state": {"e58b639b86db44ca89652b30ea566830_2_1": {}}, "last_submission_time": "2015-10-26T17:32:20Z", "attempts": 3, "seed": 1, "done": true, "student_answers": {"e58b639b86db44ca89652b30ea566830_2_1": "choice_2"}}``
 
@@ -280,12 +280,12 @@ You can use a JSON "pretty print" tool or script to make the value in the
   }
 
 When you add line breaks and spacing to the value in the **State** column for
-this capa problem, it becomes possible to recognize its similarity to the
+this CAPA problem, it becomes possible to recognize its similarity to the
 server problem check records in the Submission History. For more information,
 see :ref:`Interpret a Student Submission History`.
 
 A **State** value that appears as follows indicates a learner who has viewed a
-capa problem, but not yet submitted an answer.
+CAPA problem, but not yet submitted an answer.
 
   ``{"seed": 1, "input_state": {"e58b639b86db44ca89652b30ea566830_2_1": {}}}``
 

--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -128,9 +128,9 @@ enrolled in your course, follow these steps.
 
 .. _Interpret the Grade Report:
 
-==========================
-Interpret the Grade Report
-==========================
+=============================
+Interpreting the Grade Report
+=============================
 
 A grade report for your course is a time-stamped .csv file that identifies
 each enrolled learner by ID, email address, and username, and provides a
@@ -278,9 +278,9 @@ currently enrolled in your course, follow these steps.
 
 .. _Interpret the Problem Grade Report:
 
-====================================
-Interpret the Problem Grade Report
-====================================
+======================================
+Interpreting the Problem Grade Report
+======================================
 
 A problem grade report for your course is a time-stamped .csv file that
 identifies each enrolled learner by ID, email address, and username, and
@@ -425,7 +425,7 @@ To view the **Progress** page for a learner, follow these steps.
           score achieved for each problem in the first course subsection.
 
 =============================================
-Interpret the Learner Progress Page
+Interpreting the Learner Progress Page
 =============================================
 
 The chart of a learner's scores on the **Progress** page and the rows of data
@@ -507,7 +507,7 @@ while point scores from ungraded sections are called "Practice Scores".
 .. _Adjust_grades:
 
 ***********************************
-Adjust Grades
+Adjusting Grades
 ***********************************
 
 If you modify a problem or its settings after learners have attempted to answer


### PR DESCRIPTION
## [DOC-3159](https://openedx.atlassian.net/browse/DOC-3159)

Doc team, especially @catong , please expedite.

Prepares for a11y changes to capa problems (first tranche).
- revises how we introduce the problem types added by the problem component (core set, available to all course teams by deffault) vs. the exercises and tools that can be enabled, and that are then added using the HTML, Advanced, or problem components.
- streamlines the simple vs. advanced editor default 
- makes CAPA uppercase
- revises how you include multiple questions in a problem
- removes repetitive info on problem randomization
- moves a topic on course outline terminology differences to a (potentially) more relevant place in the import-export section

Additional changes in the topics for each of the CAPA problem types, particularly the "common" ones, to come in a follow on PR.
### Reviewers

Possible roles follow. PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Doc team review (dev edit): @catong @srpearce @pdesjardins 

FYI: @sstack22 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add description to release notes task as a comment
- [ ] Squash commits
