### PR TITLE
Fixed WARNINGS encountered when publishing the doc set with Sphinx 1.3.5

### DIFF
--- a/en_us/course_catalog_api_user_guide/source/authentication/index.rst
+++ b/en_us/course_catalog_api_user_guide/source/authentication/index.rst
@@ -193,7 +193,7 @@ To get an access token for the edX API, follow these steps.
    The following example ``access_token`` value includes an access token
    string.
 
-   .. code-block:: json
+   .. code-block:: none
 
       "access_token": "4IHZlbCB2aXZlcnJhIGdyYXZpZGEsIHJpc3V.TG9yZW0gaXBzdW0gZG9
       sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRXRpYW0gdGluY2lk

--- a/en_us/course_catalog_api_user_guide/source/course_catalog/catalog.rst
+++ b/en_us/course_catalog_api_user_guide/source/course_catalog/catalog.rst
@@ -665,112 +665,123 @@ many courses.
 .. code-block:: json
 
     {
-        "count": 123,
-        "next": "https://api.edx.org/catalog/v1/catalogs/1/courses/?limit=20&offset=40",
-        "previous": "https://api.edx.org/catalog/v1/catalogs/1/courses/?limit=20&offset=0",
-        "results": [
-            {
-                "key": "example_course_key",
-                "title": "Title of the Course",
-                "short_description": "Short description of course content",
-                "full_description": "Longer, more detailed description of course content.",
-                "level_type": "Introductory",
-                "subjects": [
-                    {
-                        "name": "Name of subject"
-                    }
-                ],
-                "prerequisites": [],
-                "expected_learning_items": [],
-                "image": [
-                    {
-                        "src": "https://example.com/directory/course_image.jpg",
-                        "description": "Example image for the Example Title course",
-                        "height": "300",
-                        "width": "400"
-                     }
-                ],
-                "video": [
-                    {
-                        "src": "http://www.youtube.com/watch?v=abcdefghijk",
-                        "description": null,
-                        "image": null
-                    }
-                ],
-                "owners": [
-                    {
-                        "key": "example_institution_key",
-                        "name": "Example Institution",
-                        "description": null,
-                        "logo_image": [
-                            {
-                            "src": "https://example.com/directory/institution_logo.jpg",
-                            "description": null
-                            "height": "200",
-                            "width": "200"
-                            }
-                        ],
-                        "homepage_url": null
-                    }
-                ],
-                "sponsors": [],
-                "modified": "YYYY-MM-DDTHH:MM:SS.SSSSSSZ",
-                "course_runs": [
-                    {
-                        "course": "course_number",
-                        "key": "example_course_key",
-                        "title": "Title of the Course",
-                        "short_description": "Short description of course content",
-                        "full_description": "Longer, more detailed description of course content",
-                        "start": "YYYY-MM-DDTHH:MM:SSZ",
-                        "end": "YYYY-MM-DDTHH:MM:SSZ",
-                        "enrollment_start": "YYYY-MM-DDTHH:MM:SSZ",
-                        "enrollment_end": "YYYY-MM-DDTHH:MM:SSZ",
-                        "announcement": null,
-                        "image": [
-                            {
-                            "src": "https://example.com/directory/course_image.jpg",
-                            "description": null,
-                            "height": "200",
-                            "width": "300"
-                            },
-                        ]
-                        "video": null,
-                        "seats": [
-                            {
-                            "type": "credit",
-                            "price": "100.00",
-                            "currency": "USD",
-                            "upgrade_deadline": "YYYY-MM-DDTHH:MM:SSZ",
-                            "credit_provider": "example institution",
-                            "credit_hours": 3
-                            }
-                        ],
-                        "content_language": null,
-                        "transcript_languages": [],
-                        "instructors": [],
-                        "staff": [
-                            {
-                            "key": "staff_key",
-                            "name": "Staff Member Name",
-                            "title": "Staff Member Title",
-                            "bio": "Example staff member bio.",
-                            "profile_image": {
-                                "src": "https://example.com/image/staff_member_name.png",
-                                "description": null,
-                                "height": "150",
-                                "width": "150"
-                            }
-                        ],
-                        "pacing_type": "instructor_paced",
-                        "min_effort": null,
-                        "max_effort": null,
-                        "modified": "YYYY-MM-DDTHH:MM:SSZ"
-                    }
-                ],
-                "marketing_url": "https://example.org/url_for_marketing_materials"
-            }
-        ]
+       "count":123,
+       "next":"https://api.edx.org/catalog/v1/catalogs/1/courses/?limit=20&offset=40",
+       "previous":"https://api.edx.org/catalog/v1/catalogs/1/courses/?limit=20&offset=0",
+       "results":[
+          {
+             "key":"example_course_key",
+             "title":"Title of the Course",
+             "short_description":"Short description of course content",
+             "full_description":"Longer, more detailed description of course content.",
+             "level_type":"Introductory",
+             "subjects":[
+                {
+                   "name":"Name of subject"
+                }
+             ],
+             "prerequisites":[
+
+             ],
+             "expected_learning_items":[
+
+             ],
+             "image":[
+                {
+                   "src":"https://example.com/directory/course_image.jpg",
+                   "description":"Example image for the Example Title course",
+                   "height":"300",
+                   "width":"400"
+                }
+             ],
+             "video":[
+                {
+                   "src":"http://www.youtube.com/watch?v=abcdefghijk",
+                   "description":null,
+                   "image":null
+                }
+             ],
+             "owners":[
+                {
+                   "key":"example_institution_key",
+                   "name":"Example Institution",
+                   "description":null,
+                   "logo_image":[
+                      {
+                         "src":"https://example.com/directory/institution_logo.jpg",
+                         "description":null,
+                         "height":"200",
+                         "width":"200"
+                      }
+                   ],
+                   "homepage_url":null
+                }
+             ],
+             "sponsors":[
+
+             ],
+             "modified":"YYYY-MM-DDTHH:MM:SS.SSSSSSZ",
+             "course_runs":[
+                {
+                   "course":"course_number",
+                   "key":"example_course_key",
+                   "title":"Title of the Course",
+                   "short_description":"Short description of course content",
+                   "full_description":"Longer, more detailed description of course content",
+                   "start":"YYYY-MM-DDTHH:MM:SSZ",
+                   "end":"YYYY-MM-DDTHH:MM:SSZ",
+                   "enrollment_start":"YYYY-MM-DDTHH:MM:SSZ",
+                   "enrollment_end":"YYYY-MM-DDTHH:MM:SSZ",
+                   "announcement":null,
+                   "image":[
+                      {
+                         "src":"https://example.com/directory/course_image.jpg",
+                         "description":null,
+                         "height":"200",
+                         "width":"300"
+                      }
+                   ],
+                   "video":null,
+                   "seats":[
+                      {
+                         "type":"credit",
+                         "price":"100.00",
+                         "currency":"USD",
+                         "upgrade_deadline":"YYYY-MM-DDTHH:MM:SSZ",
+                         "credit_provider":"example institution",
+                         "credit_hours":3
+                      }
+                   ],
+                   "content_language":null,
+                   "transcript_languages":[
+
+                   ],
+                   "instructors":[
+
+                   ],
+                   "staff":[
+                      {
+                         "key":"staff_key",
+                         "name":"Staff Member Name",
+                         "title":"Staff Member Title",
+                         "bio":"Example staff member bio.",
+                         "profile_image":{
+                            "src":"https://example.com/image/staff_member_name.png",
+                            "description":null,
+                            "height":"150",
+                            "width":"150"
+                         }
+                      }
+                   ],
+                   "pacing_type":"instructor_paced",
+                   "min_effort":null,
+                   "max_effort":null,
+                   "modified":"YYYY-MM-DDTHH:MM:SSZ"
+                }
+             ],
+             "marketing_url":"https://example.org/url_for_marketing_materials"
+          }
+       ]
     }
 
 

--- a/en_us/data/source/internal_data_formats/course_structure.rst
+++ b/en_us/data/source/internal_data_formats/course_structure.rst
@@ -152,56 +152,58 @@ Course Data Sample
 
 .. code-block:: json
 
-   "i4x://edX/DemoX/course/1T2015": {
-      "category": "course",
-      "children": [
-        "i4x://edX/DemoX/chapter/1ff96c6155eb40c39140c656cdc2708b",
-        "i4x://edX/DemoX/chapter/00d4374f346b4744aa6f4708cdf46d53",
-        "i4x://edX/DemoX/chapter/abc5cf5203ee494faf73fa3f55b4485b",
-        "i4x://edX/DemoX/chapter/a783b6e59fe24917985a8aa29eeec150",
-        "i4x://edX/DemoX/chapter/0cdd0de7b1f740468381c265796f6f63"
-      ],
-      "metadata": {
-        "advertised_start": "4/15/2015",
-        "days_early_for_beta": 90.0,
-        "discussion_topics": {
-          "General": {
-            "id": "i4x-edX-DemoX-course-1T2015"
+   {
+       "i4x://edX/DemoX/course/1T2015":{
+          "category":"course",
+          "children":[
+             "i4x://edX/DemoX/chapter/1ff96c6155eb40c39140c656cdc2708b",
+             "i4x://edX/DemoX/chapter/00d4374f346b4744aa6f4708cdf46d53",
+             "i4x://edX/DemoX/chapter/abc5cf5203ee494faf73fa3f55b4485b",
+             "i4x://edX/DemoX/chapter/a783b6e59fe24917985a8aa29eeec150",
+             "i4x://edX/DemoX/chapter/0cdd0de7b1f740468381c265796f6f63"
+          ],
+          "metadata":{
+             "advertised_start":"4/15/2015",
+             "days_early_for_beta":90.0,
+             "discussion_topics":{
+                "General":{
+                   "id":"i4x-edX-DemoX-course-1T2015"
+                }
+             },
+             "display_name":"edX Demonstration Course",
+             "end":null,
+             "graceperiod":"18000 seconds",
+             "start":"2014-08-10T07:00:00Z",
+             "tabs":[
+                {
+                   "name":"Courseware",
+                   "type":"courseware"
+                },
+                {
+                   "name":"Course Info",
+                   "type":"course info"
+                },
+                {
+                   "name":"Discussion",
+                   "type":"discussion"
+                },
+                {
+                   "name":"edX Community",
+                   "type":"static_tab",
+                   "url_slug":"67e8a9e44dde4e97b2bd33a928b9099e"
+                },
+                {
+                   "name":"Progress",
+                   "type":"progress"
+                },
+                {
+                   "name":"Wiki",
+                   "type":"wiki"
+                }
+             ]
           }
-        },
-        "display_name": "edX Demonstration Course",
-        "end": null,
-        "graceperiod": "18000 seconds",
-        "start": "2014-08-10T07:00:00Z",
-        "tabs": [
-          {
-            "name": "Courseware",
-            "type": "courseware"
-          },
-          {
-            "name": "Course Info",
-            "type": "course info"
-          },
-          {
-            "name": "Discussion",
-            "type": "discussion"
-          },
-          {
-            "name": "edX Community",
-            "type": "static_tab",
-            "url_slug": "67e8a9e44dde4e97b2bd33a928b9099e"
-          }
-          {
-            "name": "Progress",
-            "type": "progress"
-          },
-          {
-            "name": "Wiki",
-            "type": "wiki"
-          }
-        ]
-      }
-    },
+       }
+    }
 
 
 .. _Course Building Block Data:
@@ -266,7 +268,7 @@ Course Building Block Data Sample
 ======================================
 
 
-.. code-block:: json
+.. code-block:: none
 
   "i4x://edX/DemoX/chapter/00d4374f346b4744aa6f4708cdf46d53": {
     "category": "chapter",
@@ -350,7 +352,7 @@ component.
 Course Component Data Sample
 ======================================
 
-.. code-block:: json
+.. code-block:: none
 
   "i4x://edX/DemoX/html/d3bd5215cf044056beb8e6f7f3e3afc4": {
     "category": "html",

--- a/en_us/data/source/internal_data_formats/discussion_data.rst
+++ b/en_us/data/source/internal_data_formats/discussion_data.rst
@@ -126,7 +126,7 @@ more readable is produced.
 Comment Document Example
 ----------------------------------------
 
-.. code-block:: json
+.. code-block:: none
 
  { "_id" : { "$oid" : "52e54fdd801eb74c33000070" }, "votes" : { "up" : [],
  "down" : [], "up_count" : 0, "down_count" : 0, "count" : 0, "point" : 0 },

--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -163,7 +163,7 @@ generic information necessary for user login and permissions.
 
 A sample of the heading row and a data row in the ``auth_user`` table follows.
 
-.. code-block:: json
+.. code-block:: none
 
     id  username  first_name  last_name  email  password  is_staff  is_active
     is_superuser  last_login  date_joined status  email_key  avatar_typ
@@ -366,7 +366,7 @@ themselves. Every row in this table corresponds to one row in ``auth_user``.
 A sample of the heading row and a data row in the ``auth_userprofile`` table
 follows.
 
-.. code-block:: json
+.. code-block:: none
 
     id  user_id name  language  location  meta  courseware  gender
     mailing_address year_of_birth level_of_education  goals allow_certificate
@@ -1523,7 +1523,7 @@ each subsection.
 A sample of the heading row and a data row in the ``courseware_studentmodule``
 table follows.
 
-.. code-block:: sql
+.. code-block:: none
 
     id  module_type module_id student_id  state grade created modified  max_grade done
     course_id

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -27,7 +27,7 @@ A sample event from an edX.log file follows. This sample was edited to remove
 personally identifiable information. Events are stored in JSON documents, which
 can be difficult to read before standard formatting is applied.
 
-.. code-block:: json
+.. code-block:: none
 
     {"agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)
     Chrome/30.0.1599.101 Safari/537.36", "context": {"course_id": "edx/AN101/2014_T1",

--- a/en_us/data/source/internal_data_formats/wiki_data.rst
+++ b/en_us/data/source/internal_data_formats/wiki_data.rst
@@ -36,7 +36,7 @@ Fields in the ``wiki_article`` File
 The header row of the ``wiki_article`` SQL file, and a row of sample data,
 follow.
 
-.. code-block:: json
+.. code-block:: none
 
     id  current_revision_id created modified  owner_id  group_id  group_read  group_write
     other_read  other_write
@@ -120,7 +120,7 @@ Fields in the ``wiki_articlerevision`` File
 The header row of the ``wiki_articlerevision`` SQL file, and a row of sample
 data, follow.
 
-.. code-block:: json
+.. code-block:: none
 
     id  revision_number user_message  automatic_log ip_address  user_id modified  created
     previous_revision_id  deleted locked  article_id  content title

--- a/en_us/data/source/rdx/rdx_data.rst
+++ b/en_us/data/source/rdx/rdx_data.rst
@@ -94,7 +94,7 @@ Replacement Example
 
 For example, a learner adds this post to a course discussion.
 
-.. code-block:: JSON
+.. code-block:: none
 
   Hi all,
     My name is Jonathan M. Doe (johndoe), and I'm excited to be in this
@@ -107,7 +107,7 @@ Assuming that the learner has values of "johndoe" in ``auth_user.username`` and
 "Jonathan Doe" in ``auth_userprofile.name``, the ``CommentThread.body`` in
 the RDX package appears as follows.
 
-.. code-block:: JSON
+.. code-block:: none
 
   Hi all,
     My name is <<FULLNAME>> M. <<FULLNAME>> (<<USERNAME>>), and I'm excited to
@@ -120,7 +120,7 @@ Another example follows, in which the learner's post does not include any
 values that the replacement method identifies or replaces. In this case, the
 ``CommentThread.body`` in the RDX package is identical to the original post.
 
-.. code-block:: JSON
+.. code-block:: none
 
   Hi everyone! My name is John, here's my info if you want to contact me!
     Email: johnmdoe (AT) gmail (DOT) com

--- a/en_us/developers/source/conventions/internationalization/i18n.rst
+++ b/en_us/developers/source/conventions/internationalization/i18n.rst
@@ -222,12 +222,14 @@ For more information on proper escaping, see :ref:`Safe Templates`.
 JavaScript Files
 ================
 
-.. highlight:: javascript
+.. highlight:: html
 
 To internationalize JavaScript, the HTML template (base.html) must first load
 a special JavaScript library, and Django must be configured to serve it. ::
 
     <script type="text/javascript" src="jsi18n/"></script>
+
+.. highlight:: javascript
 
 Then, in JavaScript files (`*.js`)::
 
@@ -614,7 +616,7 @@ Mako template. ::
 When the string is rendered in French, it will produce the following invalid
 JavaScript.
 
-.. code-block:: javascript
+.. code-block:: none
 
     <script>
     var feeling = 'Je t'aime.';
@@ -623,7 +625,7 @@ JavaScript.
 Avoid this issue by following the best practices detailed in :ref:`Safe
 Templates`. Here is the same example with proper escaping.
 
-.. code-block:: javascript
+.. code-block:: mako
 
     <%!
     from django.utils.translation import ugettext as _
@@ -637,7 +639,7 @@ Templates`. Here is the same example with proper escaping.
 
 The code with proper escaping produces the following JavaScript-escaped code.
 
-.. code-block:: javascript
+.. code-block:: html
 
     <script>
     var feeling = 'Je t\u0027aime.';

--- a/en_us/developers/source/conventions/safe_templates.rst
+++ b/en_us/developers/source/conventions/safe_templates.rst
@@ -572,7 +572,7 @@ JavaScript context.
 Here is an example of how to import and use ``js_escaped_string`` and
 ``dump_js_escaped_json`` in the context of JavaScript in a Mako template.
 
-.. code-block:: mako
+.. code-block:: none
 
     <%namespace name='static' file='static_content.html'/>
     <%!

--- a/en_us/developers/source/extending_platform/javascript.rst
+++ b/en_us/developers/source/extending_platform/javascript.rst
@@ -140,7 +140,7 @@ attribute of the ``jsinput`` element for the problem.
 
 For example:
 
-.. code-block::  xml
+.. code-block::  none
 
     <customresponse cfn="vglcfn">
         <jsinput get_statefn="JSObject.getState"
@@ -164,7 +164,7 @@ attribute of the ``jsinput`` element for the problem.
 
 For example:
 
-.. code-block::  xml
+.. code-block::  none
 
     <customresponse cfn="vglcfn">
         <jsinput set_statefn="JSObject.setState"
@@ -189,7 +189,7 @@ attribute of the ``jsinput`` element for the problem.
 
 For example:
 
-.. code-block::  xml
+.. code-block::  none
 
     <customresponse cfn="vglcfn">
         <jsinput gradefn="JSObject.getGrade"

--- a/en_us/developers/source/user_interface_development.rst
+++ b/en_us/developers/source/user_interface_development.rst
@@ -101,7 +101,7 @@ your Sass files at the top of your main Mako file. The following example
 declares files that are configured with the names ``style- learner-dashboard``
 and ``style-learner-dashboard-rtl``.
 
-.. code-block:: html
+.. code-block:: mako
 
     <%! main_css = "style-learner-dashboard" %>
 

--- a/en_us/olx/source/components/video-components.rst
+++ b/en_us/olx/source/components/video-components.rst
@@ -25,7 +25,7 @@ follows.
     youtube="1.00:o2pLltkrhGM"
     url_name="Introduction_Lecture"
     display_name="Introduction Lecture"
-    youtube_id_1_0="o2pLltkrhGM"
+    youtube_id_1_0="o2pLltkrhGM">
   </video>
 
 If you prefer to place the video component in its own file, you create an XML

--- a/en_us/olx/source/organizing-course/course-xml-file.rst
+++ b/en_us/olx/source/organizing-course/course-xml-file.rst
@@ -66,13 +66,13 @@ An example of the contents of a ``course.xml`` file follows.
 The attributes of the ``course`` element are used to construct URLs in the
 course.  The following course URL shows where these values are used.
 
-.. code-block:: html
+.. code-block:: none
 
   http://my-edx-server.org/courses/<@org value>/<@course value>/<@url_name value>/info
 
 For example:
 
-.. code-block:: html
+.. code-block:: none
 
   http://my-edx-server.org/courses/edX/DemoX/Demo_Course/info
 
@@ -189,7 +189,7 @@ For example, the course can contain a sequential in this format.
 
 The ``sequential`` element contains one or more child ``vertical`` elements.
 
-The ``veritical`` element references a vertical, or unit, in the course.
+The ``vertical`` element references a vertical, or unit, in the course.
 
 The following example shows a chapter with a sequential that has three
 verticals, or units.
@@ -199,9 +199,9 @@ verticals, or units.
     <course>
         <chapter url_name="exam_review">
             <sequential display_name="Simulations" url_name="simulations">
-                <vertical display_name: "Unit 1" url_name="Lesson_1_Unit_1">
+                <vertical display_name="Unit 1" url_name="Lesson_1_Unit_1">
                     . . . .
-                <vertical display_name: "Unit 2" url_name="Lesson_1_Unit_2">
+                <vertical display_name="Unit 2" url_name="Lesson_1_Unit_2">
                     . . . .
             </sequential>
         </chapter>

--- a/en_us/olx/source/problem-xml/create_problem.rst
+++ b/en_us/olx/source/problem-xml/create_problem.rst
@@ -68,7 +68,7 @@ With OLX, you set the display name as an attribute of the ``problem`` element.
 
 .. code-block:: xml
 
-  <problem display_name="Geography Homework" . . . >
+  <problem display_name="Geography Homework"></problem>
 
 
 ==============================
@@ -91,7 +91,7 @@ element.
 
 .. code-block:: xml
 
-  <problem max_attempts="3" . . . >
+  <problem max_attempts="3"></problem>
 
 
 .. _Problem Weight:
@@ -122,7 +122,7 @@ With OLX, you set a different component weight as an attribute of the
 
 .. code-block:: xml
 
-  <problem weight="2.0" . . . >
+  <problem weight="2.0"></problem>
 
 Computing Scores
 ****************
@@ -260,7 +260,7 @@ element.
 
 .. code-block:: xml
 
-  <problem rerandomize="always" . . . >
+  <problem rerandomize="always"></problem>
 
 
 
@@ -333,7 +333,7 @@ With OLX, you set the show answer preference as an attribute of the
 
 .. code-block:: xml
 
-  <problem showanswer="correct_or_past_due"  . . . >
+  <problem showanswer="correct_or_past_due"></problem>
 
 .. _Show Reset Button:
 
@@ -358,7 +358,7 @@ With OLX, you set the show reset button preference as an attribute of the
 
 .. code-block:: xml
 
-  <problem show_reset_button="true"  . . . >
+  <problem show_reset_button="true"></problem>
 
 .. include:: ../../../shared/exercises_tools/Section_adding_hints.rst
 

--- a/en_us/open_edx_course_authors/source/manage_live_course/manage_course_fees.rst
+++ b/en_us/open_edx_course_authors/source/manage_live_course/manage_course_fees.rst
@@ -63,7 +63,7 @@ configuration code in your Open edX environment.
 
 * Add the following code to the lms.env.json file.
 
-  .. code-block:: json
+  .. code-block:: none
 
     ...
     "FEATURES": {
@@ -76,7 +76,7 @@ configuration code in your Open edX environment.
 
 * Add the following code to the lms.auth.json file.
 
-  .. code-block:: json
+  .. code-block:: none
 
     ...
         "CC_PROCESSOR": {

--- a/en_us/shared/course_features/content_experiments/content_experiments_configure.rst
+++ b/en_us/shared/course_features/content_experiments/content_experiments_configure.rst
@@ -36,7 +36,7 @@ To enable content experiments in your course, you add ``split_test`` to the
    For example, the text in the **Advanced Module List** field may resemble
    the following:
 
-   .. code-block:: json
+   .. code-block:: none
 
      [
        "lti_consumer",

--- a/en_us/shared/course_features/content_experiments/subsection_content_experiments_policies.rst
+++ b/en_us/shared/course_features/content_experiments/subsection_content_experiments_policies.rst
@@ -32,7 +32,7 @@ Example: One Group Configuration
 The following code shows an example JSON object that defines a group
 configuration with two learner segments.
 
-.. code-block:: json
+.. code-block:: none
 
     "user_partitions": [{"id": 0,
                        "name": "Name of the group configuration",
@@ -64,7 +64,7 @@ The following code shows an example JSON object that defines two group
 configurations. The first group configuration divides learners into two
 experiment groups, and the second divides learners into three experiment groups.
 
-.. code-block:: json
+.. code-block:: none
 
     "user_partitions": [{"id": 0,
                          "name": "Name of Group Configuration 1",

--- a/en_us/shared/exercises_tools/custom_python.rst
+++ b/en_us/shared/exercises_tools/custom_python.rst
@@ -431,7 +431,7 @@ The following code shows the configuration of this problem.
 
   def give_partial_credit(expect, ans):
     ans = float(ans)
-    if ans > 100 or ans < 0:
+    if ans &gt; 100 or ans &lt; 0:
         # Assign a score of zero if the answer is less than zero or over 100.
         ans = 0
     grade = ans/100

--- a/en_us/shared/student_progress/course_answers.rst
+++ b/en_us/shared/student_progress/course_answers.rst
@@ -82,7 +82,7 @@ The first interaction, shown at the bottom of the Submission History, records
 when the server delivered the problem component to the browser for the learner
 to view.
 
-.. code-block:: json
+.. code-block:: none
 
   #1: 2015-09-04 08:34:53+00:00 (America/New_York time)
 
@@ -102,7 +102,7 @@ The next interaction shown as you scroll up from the bottom records when the
 learner selected **Check** in the browser to submit an answer. Note that this
 record does not contain the actual answer submitted.
 
-.. code-block:: json
+.. code-block:: none
 
   #2: 2015-09-04 08:35:03+00:00 (America/New_York time)
 
@@ -125,7 +125,7 @@ after the learner submitted the answer. This record includes
 ``student_answers`` with the submitted answer value, along with ``attempts``,
 ``correctness``, and other values.
 
-.. code-block:: json
+.. code-block:: none
 
   #3: 2015-09-03 18:15:10+00:00 (America/New_York time)
 
@@ -171,7 +171,7 @@ differences between values in this record and in record 3, including the
 reported ``Score`` and the values for ``student_answers``, ``attempts``, and
 ``correctness``.
 
-.. code-block:: json
+.. code-block:: none
 
   #5: 2015-09-03 18:15:17+00:00 (America/New_York time)
 

--- a/en_us/xblock-tutorial/source/getting_started/setup_sdk.rst
+++ b/en_us/xblock-tutorial/source/getting_started/setup_sdk.rst
@@ -4,7 +4,7 @@
 Set Up the XBlock Software Development Kit
 ###########################################
 
-Before you continue, make sure that you are familiar with the subjects in the 
+Before you continue, make sure that you are familiar with the subjects in the
 :ref:`Install XBlock Prerequisites` section.
 
 When you have installed all prerequisites, you are ready to set up the `XBlock
@@ -23,13 +23,13 @@ work, including a virtual environment, the XBlock SDK, and the XBlocks you
 develop.
 
 #. At the command prompt, run the following command to create the directory.
-   
+
    .. code-block:: bash
 
       $ mkdir xblock_development
 
 #. Change directories to the ``xblock_development`` directory.
-   
+
    .. code-block:: bash
 
       $ cd xblock_development
@@ -48,7 +48,7 @@ Then create the virtual environment in your ``xblock_development`` directory.
 
 #. At the command prompt in ``xblock_development``, run the following
    command to create the virtual environment.
-   
+
    .. code-block:: bash
 
       $ virtualenv venv
@@ -56,14 +56,14 @@ Then create the virtual environment in your ``xblock_development`` directory.
 #. Run the following command to activate the virtual environment.
 
    .. code-block:: bash
-  
+
       $ source venv/bin/activate
 
    When the virtual environment is activated, the command prompt shows the name
    of the virtual directory in parentheses.
 
-   .. code-block:: bash
-     
+   .. code-block:: none
+
       (venv) $
 
 .. include:: ../reusable/clone_sdk.rst

--- a/en_us/xblock-tutorial/source/reusable/create_db.rst
+++ b/en_us/xblock-tutorial/source/reusable/create_db.rst
@@ -8,20 +8,20 @@ database.
 #. In the ``xblock_development`` directory, run the following command to create
    the database.
 
-   .. code-block:: bash
+   .. code-block:: none
 
       (venv) $ python xblock-sdk/manage.py syncdb
 
 #. You are prompted to indicate whether or not to create a Django superuser.
 
-   .. code-block:: bash
+   .. code-block:: none
 
       You just installed Django's auth system, which means you don't have any
       superusers defined. Would you like to create one now? (yes/no):
 
 #. Enter ``no``.
 
-   .. code-block:: bash
+   .. code-block:: none
 
       (venv) $ python no
 

--- a/en_us/xblock-tutorial/source/reusable/create_xblock.rst
+++ b/en_us/xblock-tutorial/source/reusable/create_xblock.rst
@@ -8,8 +8,8 @@ follow these steps at a command prompt.
 #. In the ``xblock_development`` directory, which contains the ``venv`` and
    ``xblock-sdk`` directories, run the following command to create the skeleton
    files for the XBlock.
-   
-   .. code-block:: bash
+
+   .. code-block:: none
 
       (venv) $ xblock-sdk/bin/workbench-make-xblock
 
@@ -17,7 +17,7 @@ follow these steps at a command prompt.
    and a class name. Follow the guidelines in the command window to determine
    the names that you want to use.
 
-   .. code-block:: bash
+   .. code-block:: none
 
       You will be prompted for two pieces of information:
 
@@ -37,14 +37,14 @@ follow these steps at a command prompt.
 
 #. At the command prompt, enter the Short Name you selected for your XBlock.
 
-   .. code-block:: bash
-  
+   .. code-block:: none
+
       $ Short name: myxblock
 
 #. At the command prompt, enter the Class name you selected for your XBlock.
 
-   .. code-block:: bash
-  
+   .. code-block:: none
+
       $ Class name: MyXBlock
 
 The skeleton files for the XBlock are created in the ``myxblock`` directory.

--- a/en_us/xblock-tutorial/source/reusable/install_xblock.rst
+++ b/en_us/xblock-tutorial/source/reusable/install_xblock.rst
@@ -2,11 +2,11 @@
 Install the XBlock
 ******************
 
-After you create the XBlock, you install it in the XBlock SDK. 
+After you create the XBlock, you install it in the XBlock SDK.
 
 In the ``xblock_development`` directory, use ``pip`` to install your XBlock.
 
-   .. code-block:: bash
+   .. code-block:: none
 
       (venv) $ pip install -e myxblock
 

--- a/en_us/xblock-tutorial/source/reusable/run_server.rst
+++ b/en_us/xblock-tutorial/source/reusable/run_server.rst
@@ -2,12 +2,12 @@
 Run the XBlock SDK Server
 **************************
 
-To see the web interface of the XBlock SDK, you must run the SDK server. 
+To see the web interface of the XBlock SDK, you must run the SDK server.
 
 In the ``xblock_development`` directory, run the following command to start the
 server.
 
-   .. code-block:: bash
+   .. code-block:: none
 
       (venv) $ python xblock-sdk/manage.py runserver
 
@@ -32,7 +32,7 @@ Get Help for the XBlock SDK Server
 To get help for the XBlock SDK ``runserver`` command, run the following
 command.
 
-   .. code-block:: bash
+   .. code-block:: none
 
       (venv) $ python xblock-sdk/manage.py help
 


### PR DESCRIPTION
## [DOC-3160](https://openedx.atlassian.net/browse/DOC-3160)

Fixed WARNINGS encountered when publishing the doc set with Sphinx 1.3.5 (as Read the Docs does). All warnings were because of syntax highlighting in code examples. In some cases the fix was to correct the syntax of code examples, so Sphinx could parse them. In many cases, the fix was to change the syntax highlighting language to none.

After these changes merge, the doc team should be able to standardize our Sphinx versions on v1.3.5 an no one will see spurious warnings.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check): @catong @lamagnifica @srpearce
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
