### PR TITLE
Update excluded RST filenames to match new release note filename convention

### DIFF
--- a/en_us/release_notes/source/conf.py
+++ b/en_us/release_notes/source/conf.py
@@ -15,6 +15,6 @@ html_favicon = '../../_themes/edx_theme/static/css/favicon.ico'
 project = u'EdX Release Notes'
 
 #remove directory when content is first added to it, and add to index
-exclude_patterns = ['links.rst', 'reusables/*', '20??/*/*20??.rst', 'coming_soon.rst']
+exclude_patterns = ['links.rst', 'reusables/*', '20??/*/*20??.rst', '20??/*/*20??-??-??.rst', 'coming_soon.rst']
 
 set_audience(PARTNER, COURSE_TEAMS)


### PR DESCRIPTION
## [DOC-3142](https://openedx.atlassian.net/browse/DOC-3142)

This is a follow-up PR for DOC-3142. The first PR changed the RST file name convention, but failed to ignore those files during the Sphinx build. This PR adds a regular expression to the `exclude_patterns` property for file names that use the pattern lms_2016-07-25.
### Date Needed (optional)

This is blocking the release notes project for the week of 7/25. A quick sanity check would be great!
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Doc team review (sanity check): @catong @lamagnifica @pdesjardins @srpearce
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
