### PR TITLE
Doc: Add missing anchor

### DIFF
--- a/en_us/shared/getting_started/dashboard_settings_profile.rst
+++ b/en_us/shared/getting_started/dashboard_settings_profile.rst
@@ -420,6 +420,7 @@ To view or change this information, follow these steps.
 
 EdX saves your changes automatically.
 
+.. _Link Accounts:
 
 ==========================================
 Link or Unlink a Social Media Account


### PR DESCRIPTION
Fixes broken link issue in getting_started/create_activate_account.rst
