### PR TITLE
Updates all readme files with new guidance for contributing

### DIFF
--- a/en_us/course_authors/source/front_matter/read_me.rst
+++ b/en_us/course_authors/source/front_matter/read_me.rst
@@ -2,13 +2,14 @@
 Read Me
 *******
 
-The edX *Building and Running an edX Course* guide is created
-using RST_ files and Sphinx_. You, the user community, can help update and revise this documentation project on GitHub::
+The edX *Building and Running an edX Course* guide is created using RST_ files
+and Sphinx_. You, the user community, can help update and revise this
+documentation project on GitHub.
 
-  https://github.com/edx/edx-documentation/tree/master/en_us/course_authors/source
+https://github.com/edx/edx-documentation/tree/master/en_us/course_authors/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub Flow`_.
-All pull requests need approval from edX. For more information, contact edX at docs@edx.org.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/data/source/front_matter/read_me.rst
+++ b/en_us/data/source/front_matter/read_me.rst
@@ -4,12 +4,12 @@ Read Me
 
 The *edX Research Guide* is created using RST_ files and Sphinx_. You, the
 user community, can help update and revise this documentation project on
-GitHub::
+GitHub.
 
-  https://github.com/edx/edx-platform/docs/en_us/data/source
+https://github.com/edx/edx-documentation/tree/master/en_us/data/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub Flow`_.
-All pull requests need approval from edX. For more information, contact edX at `docs@edx.org`_.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/developers/source/front_matter/read_me.rst
+++ b/en_us/developers/source/front_matter/read_me.rst
@@ -4,12 +4,12 @@ Read Me
 
 The *edX Developer Documentation* is created using RST_ files and Sphinx_.
 You, the user community, can help update and revise this documentation project
-on GitHub::
+on GitHub.
 
-  https://github.com/edx/edx-platform/docs/en_us/data/source
+https://github.com/edx/edx-documentation/tree/master/en_us/developers/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub Flow`_.
-All pull requests need approval from edX. For more information, contact edX at `docs@edx.org`_.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/front_matter/read_me.rst
+++ b/en_us/install_operations/source/front_matter/read_me.rst
@@ -4,11 +4,12 @@ Read Me
 
 The *Installing and Configuring the Open edX Platform* documentation is created
 using RST_ files and Sphinx_. As a member of the community, you can help update
-and revise this documentation project on GitHub:
+and revise this documentation project on GitHub.
 
-  ``https://github.com/edx/edx-documentation/tree/master/en_us/install_operations/source``
+https://github.com/edx/edx-documentation/tree/master/en_us/install_operations/source
 
-To suggest a revision, follow the `GitHub Flow`_: fork the project, make
-changes in your fork, and submit a pull request back to the original project.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -78,6 +78,8 @@
 
 .. _GitHub: http://github.com
 
+.. _Contribute to edX Documentation: https://github.com/edx/edx-documentation#contribute-to-edx-documentation
+
 .. _edx-documentation/shared: https://github.com/edx/edx-documentation/blob/master/shared/conf.py
 
 .. _edx-analytics-configuration: https://github.com/edx/edx-analytics-configuration

--- a/en_us/olx/source/front_matter/read_me.rst
+++ b/en_us/olx/source/front_matter/read_me.rst
@@ -4,18 +4,16 @@ Read Me
 
 The *edX Open Learning XML Guide* provides the information you need to build an
 edX course through OLX (open learning XML) and supporting files, without using
-edX Studio.  This document is an Alpha version. We will continue to make
-significant updates to improve your ability to build XML-based courses.
+edX Studio.
 
 This documentation is created using RST_ files and Sphinx_. You, the
 user community, can help update and revise this documentation project on
-GitHub::
+GitHub.
 
-  https://github.com/edx/edx-platform/docs/en_us/olx/source
+https://github.com/edx/edx-documentation/tree/master/en_us/olx/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub Flow`_.
-
-All pull requests need approval from edX. For more information, contact edX at `docs@edx.org`_.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/open_edx_course_authors/source/front_matter/read_me.rst
+++ b/en_us/open_edx_course_authors/source/front_matter/read_me.rst
@@ -4,15 +4,12 @@ Read Me
 
 The edX *Building and Running an Open edX Course* guide is created using RST_
 files and Sphinx_. You, the user community, can help update and revise this
-documentation project on GitHub::
+documentation project on GitHub.
 
-  https://github.com/edx/edx-documentation/tree/master/en_us/open_edx_course_authors/source
+https://github.com/edx/edx-documentation/tree/master/en_us/open_edx_course_authors/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub
-Flow`_.
-
-All pull requests need approval from edX. For more information, contact edX at
-docs@edx.org.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/open_edx_release_notes/source/front_matter/read_me.rst
+++ b/en_us/open_edx_release_notes/source/front_matter/read_me.rst
@@ -3,13 +3,12 @@ Read Me
 *******
 
 This document is created using RST_ files and Sphinx_. You, the user community,
-can help update and revise this documentation project on GitHub::
+can help update and revise this documentation project on GitHub.
 
-  https://github.com/edx/edx-platform/tree/master/docs/en_us/open_edx_release_notes/source
+https://github.com/edx/edx-documentation/tree/master/en_us/open_edx_release_notes/source
 
-To suggest a revision, you can fork the project, make changes in your fork, and
-submit a pull request back to the original project: this is known as the
-`GitHub Flow`_. All pull requests need approval from edX. For more information,
-contact edX at docs@edx.org.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/open_edx_students/source/front_matter/read_me.rst
+++ b/en_us/open_edx_students/source/front_matter/read_me.rst
@@ -4,15 +4,12 @@ Read Me
 
 The *Open edX Learner's Guide* is created using RST_ files and Sphinx_. You,
 the user community, can help update and revise this documentation project on
-GitHub::
+GitHub.
 
-  https://github.com/edx/edx-platform/docs/en_us/open_edx_students/source
+https://github.com/edx/edx-documentation/tree/master/en_us/open_edx_students/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub
-Flow`_.
-
-All pull requests need approval from edX. For more information, contact edX at
-`docs@edx.org`_.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/release_notes/source/front_matter/read_me.rst
+++ b/en_us/release_notes/source/front_matter/read_me.rst
@@ -3,13 +3,12 @@ Read Me
 ##########
 
 This document is created using RST_ files and Sphinx_. You, the user community,
-can help update and revise this documentation project on GitHub::
+can help update and revise this documentation project on GitHub.
 
-  https://github.com/edx/edx-documentation/tree/master/en_us/release_notes/source
+https://github.com/edx/edx-documentation/tree/master/en_us/release_notes/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub
-Flow`_. All pull requests need approval from edX. For more information, contact
-edX at docs@edx.org.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/release_notes_2014/source/front_matter/read_me.rst
+++ b/en_us/release_notes_2014/source/front_matter/read_me.rst
@@ -3,9 +3,9 @@ Read Me
 ##########
 
 This document is created using RST_ files and Sphinx_. You, the user community,
-can help update and revise this documentation project on GitHub::
+can help update and revise this documentation project on GitHub.
 
-  https://github.com/edx/edx-documentation/tree/master/en_us/release_notes/source
+https://github.com/edx/edx-documentation/tree/master/en_us/release_notes/source
 
 To suggest a revision, fork the project, make changes in your fork, and submit
 a pull request back to the original project: this is known as the `GitHub

--- a/en_us/students/source/front_matter/read_me.rst
+++ b/en_us/students/source/front_matter/read_me.rst
@@ -4,15 +4,12 @@ Read Me
 
 The *EdX Learner's Guide* is created using RST_ files and Sphinx_. You, the
 user community, can help update and revise this documentation project on
-GitHub::
+GitHub.
 
-  https://github.com/edx/edx-platform/docs/en_us/students/source
+https://github.com/edx/edx-documentation/tree/master/en_us/students/source
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub
-Flow`_.
-
-All pull requests need approval from edX. For more information, contact edX at
-`docs@edx.org`_.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst

--- a/en_us/xblock-tutorial/source/front_matter/read_me.rst
+++ b/en_us/xblock-tutorial/source/front_matter/read_me.rst
@@ -2,20 +2,15 @@
 Read Me
 *******
 
-The *EdX XBlock Tutorial* is created using RST_ files and Sphinx_. You, the
-user community, can help update and revise this documentation project on
+The *Open edX XBlock Tutorial* is created using RST_ files and Sphinx_. You,
+the user community, can help update and revise this documentation project on
 GitHub.
 
-.. code-block:: html
+https://github.com/edx/edx-documentation/tree/master/en_us/xblock-tutorial/source
 
-  https://github.com/edx/edx-documentation/tree/master/en_us/xblock-tutorial/source
-
-To suggest a revision, you should fork the project, make changes in your fork,
-and submit a pull request back to the original project: this is known as the
-`GitHub Flow`_.
-
-All pull requests need approval from edX. For more information, contact edX at
-docs@edx.org.
+The edX documentation team welcomes contributions from Open edX community
+members. You can find guidelines for how to `contribute to edX Documentation`_
+in the GitHub edx/edx-documentation repository.
 
 .. include:: ../../../links/links.rst
 


### PR DESCRIPTION
## [DOC-3183](https://openedx.atlassian.net/browse/DOC-3183)

Shauna suggested a more relevant link in the Installation guide's readme file. This PR updates the boilerplate text found in the readme for every guide in the edx-doc repo to send people to the suggested location on GitHub, using linked text, in addition to the source files for the specific guide.

A follow on PR will make this change for the Insights guid ein the edx-analytics-dashboard repo.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @shaunagm 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @pdesjardins @srpearce
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @jbarciauskas 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
