### PR TITLE
Added a devstack troubleshooting procedure about removing a lingering MongoDB lock file 

### DIFF
--- a/en_us/install_operations/source/configuration/theming/activate_theme.rst
+++ b/en_us/install_operations/source/configuration/theming/activate_theme.rst
@@ -45,7 +45,7 @@ To propogate this variable to the ``lms.env.json`` file, you run Ansible.
 Alternatively, the ``lms.env.json`` file can be modified directly to set these
 variables:
 
-.. code-block:: json
+.. code-block:: none
 
   ENABLE_COMPREHENSIVE_THEMING: true,
   COMPREHENSIVE_THEME_DIRS: ["/edx/app/themes", ],

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -269,6 +269,8 @@
 
 .. _mongodb: http://docs.mongodb.org/manual/
 
+.. _MongoDB® database: http://www.mongodb.com
+
 .. _AWS Command Line Interface: http://aws.amazon.com/cli/
 
 .. _AWS Documentation: http://aws.amazon.com/documentation/

--- a/en_us/shared/installation/troubleshooting_vm_installation.rst
+++ b/en_us/shared/installation/troubleshooting_vm_installation.rst
@@ -1,9 +1,14 @@
-In some cases, you might see a time out error when you attempt to create an edX
-virtual machine. Open edX virtual machines are devstack, fullstack, or
-analytics devstack installations.
+This section provides information about problems that you might encounter when
+using Open edX virtual machines (VMs). Open edX VMs are devstack,
+fullstack, or analytics devstack installations.
 
-For example, you might see the following error message during a virtual machine
-installation.
+=============================================
+Time out Error While Creating an Open edX VM
+=============================================
+
+In some cases, you might see a time out error when you attempt to create an edX
+VM. For example, you might see the following error message during a virtual
+machine installation.
 
 .. code-block:: shell
 
@@ -26,5 +31,34 @@ To correct the error, follow these steps.
 #. In Virtualbox, choose **Preferences > Network > Host-only Networks** and
    remove the host-only network that was most recently created.
 #. Enter ``vagrant up`` on the command line.
+
+=================================================
+Starting Open edX Servers after a MongoDB Failure
+=================================================
+
+If you do not stop Open edX servers such as the LMS before halting the Vagrant
+VM that they are running on, the server leaves a `MongoDB® database`_ lock file
+in place. This lock file will prevent the Open edX server from starting MongoDB
+when you try to start the server again.
+
+The following error message appears in the console when this problem occurs.
+
+.. code-block:: none
+
+    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-
+    packages/pymongo/mongo_client.py", line 425, in __init__ raise
+    ConnectionFailure(str(e)) pymongo.errors.ConnectionFailure: [Errno 111]
+    Connection refused
+
+Invoke the following commands as the ``vagrant`` user on the VM to remove the
+MongoDB lock file, restore its configuration, and start the database service.
+After you invoke these commands, you can start the Open edX server again.
+
+.. code-block:: shell
+
+    sudo rm /edx/var/mongo/mongodb/mongod.lock
+    sudo mongod -repair --config /etc/mongod.conf
+    sudo chown -R mongodb:mongodb /edx/var/mongo/.
+    sudo service mongod start
 
 .. include:: ../../../../links/links.rst


### PR DESCRIPTION
## [DOC-3190](https://openedx.atlassian.net/browse/DOC-3190)

Added a devstack/anystack troubleshooting procedure about removing a lingering MongoDB lock file after an inelegant server shutdown. Also fixed a syntax highlighting warning in the activate_theme.rst file.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @benpatterson 
- [x] Subject matter expert: @bjacobel 
- [x] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @srpearce
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [x] http://draft-mongodb-troubleshooting.readthedocs.io/en/latest/installation/devstack/troubleshooting_vm_installation.html#starting-open-edx-servers-after-a-mongodb-failure
### Post-review
- [x] Squash commits
