### PR TITLE
Added a note to the Open edX course author's guide about needing to set ENABLE_SPECIAL_EXAMS to true before being able to enable timed exams.

### DIFF
--- a/en_us/shared/course_features/timed_exams.rst
+++ b/en_us/shared/course_features/timed_exams.rst
@@ -50,6 +50,18 @@ To enable timed exams in your course, follow these steps.
 
 #. Select **Save Changes**. You can now create timed exams in your course.
 
+.. only:: Open_edX
+
+  .. note::
+
+    The **Enable Timed Exams** field appears in the **Advanced Settings** page
+    for your course even if timed exams are not enabled for your Open edX site.
+    If you enable timed exams for a course, but special exams are not enabled
+    for your site, you will not be able to include timed exams. Enabling timed
+    exams for an Open edX site is a task that is usually performed by a system
+    administrator. For more information, see :ref:`installation:Enable Timed
+    Exams` in *Installing, Configuring, and Running the Open edX Platform*.
+
 *****************************
 Set a Subsection to be Timed
 *****************************
@@ -72,6 +84,14 @@ steps.
    the Assignment Type and Due Date for a Subsection>` for the subsection.
 
 #. Select the **Advanced** tab.
+
+   .. only:: Open_edX
+
+    If the **Settings** dialog box does not contain the **Advanced** tab, timed
+    exams might not be enabled for your Open edX site. Enabling timed exams for
+    an Open edX site is a task that is usually performed by a system
+    administrator. For more information, see :ref:`installation:Enable Timed
+    Exams` in *Installing, Configuring, and Running the Open edX Platform*.
 
 #. In the **Set as a Special Exam** section, select **Timed**.
 


### PR DESCRIPTION
## [DOC-3207](https://openedx.atlassian.net/browse/DOC-3207)

Added a note to the Open edX course author's guide about needing to set ENABLE_SPECIAL_EXAMS to true before being able to enable timed exams.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @adampalay 
- [x] Subject matter expert: @douglashall 
- [x] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @srpearce
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [x] http://draft-enable-site-special-exams.readthedocs.io/en/latest/course_features/timed_exams.html#enable-timed-exams
### Post-review
- [x] Squash commits
