### PR TITLE
Updates contact info for video upload work

### DIFF
--- a/en_us/course_authors/source/video/video_course.rst
+++ b/en_us/course_authors/source/video/video_course.rst
@@ -130,8 +130,8 @@ To create or obtain a transcript in .srt format, you can work with a company
 that provides captioning services.
 
 To ensure quality and accuracy of transcripts, edX works with `3Play Media`_.
-To request a 3Play account at edX's discounted rate, contact your edX partner
-manager.
+To request a 3Play Media account at edX's discounted rate, contact 3Play at
+http://www.3playmedia.com/edx/.
 
 ===================================
 Associate a Transcript with a Video

--- a/en_us/course_authors/source/video/video_overview.rst
+++ b/en_us/course_authors/source/video/video_overview.rst
@@ -31,10 +31,10 @@ multiple playback and download needs.
 Course Team Video Upload Overview
 ************************************
 
-The edX media team establishes accounts for your institution at YouTube and
-Amazon Web Services (AWS). For more information about the preliminary setup
-that your institution works with edX to complete, see :ref:`Video Getting
-Started`.
+The edX partner support team establishes accounts for your institution at
+YouTube™ and Amazon Web Services™ (AWS). For more information about the
+preliminary setup that your institution works with edX to complete, see
+:ref:`Video Getting Started`.
 
 After these services are set up, course teams use Studio to upload one file to
 the edX servers for each of the videos that they want to include in their

--- a/en_us/course_authors/source/video/video_prereqs.rst
+++ b/en_us/course_authors/source/video/video_prereqs.rst
@@ -5,7 +5,7 @@ Getting Started with Video
 ###########################
 
 Before your course teams can begin to upload videos in Studio, you work with
-the edX media team to make sure that these preparatory tasks are complete.
+edX partner support to make sure that these preparatory tasks are complete.
 
 * :ref:`Identify Video Administrators`
 
@@ -44,8 +44,8 @@ general, the CMS enables an administrator to:
 
 * Download reports and other analytics that measure views.
 
-Video administrators also work with course teams and the edX media team to
-distribute information and resolve questions about video files. 
+Video administrators also work with course teams and edX partner support to
+distribute information and resolve questions about video files.
 
 EdX recommends that organizations identify specific individuals to be the
 video administrators for all of your courses. By working with the edX team
@@ -55,16 +55,16 @@ procedures for managing your video assets.
 .. _Establish Access to YouTube Account:
 
 ****************************************
-Establish Access to YouTube Account 
+Establish Access to YouTube Account
 ****************************************
 
 =========================================
-Video Administrator Access to the Account 
+Video Administrator Access to the Account
 =========================================
 
 For :ref:`video administrators<Identify Video Administrators>` to use the
 YouTube CMS, they must have administrative access to your CMS account. Because
-account access is granted to specific email addresses, the edX media team
+account access is granted to specific email addresses, edX partner support
 works with one of your video administrators to set up an email address
 specifically for this purpose and give it administrative privileges.
 
@@ -72,18 +72,19 @@ This procedure only needs to be completed once and can be done by one of
 the video administrators.
 
 ===================================
-Establishing Access to the Account 
+Establishing Access to the Account
 ===================================
 
 #. Create a single Google email (Gmail) account. The recommended format
    for the account name is your edx.org member identifier followed by
-   "CMSmanager". For example, ``HarvardXCMSmanager@gmail.com`` or 
+   "CMSmanager". For example, ``HarvardXCMSmanager@gmail.com`` or
    ``MITxCMSmanager@gmail.com``.
 
-#. Send the email address to the edX media team at ``media@edx.org``.
+#. Send the email address to edX partner support at
+   ``partner-support@edx.org``.
 
-   On receipt, the media team adds the Gmail address to your YouTube CMS
-   account and gives the account administrative privileges. This process
+   On receipt, the partner support team adds the Gmail address to your YouTube
+   CMS account and gives the account administrative privileges. This process
    results in an activation message that is sent to your CMSmanager Gmail
    account. Access to the CMS account is not provided until activation is
    complete.
@@ -125,7 +126,7 @@ more.
 Creating YouTube Channels
 ===============================
 
-.. note:: This procedure only needs to be completed once per course, but it 
+.. note:: This procedure only needs to be completed once per course, but it
  must be complete before the course team begins to add videos to the course in
  Studio.
 
@@ -153,9 +154,9 @@ Creating YouTube Channels
 #. Agree to the terms and then click **Done**. The list of channels now
    includes the channel that you just created.
 
-#. Contact the edX media team at ``media@edx.org``. After you create the
-   channel for a course, the media team can enable the video upload feature
-   for that course in Studio.
+#. Contact edX partner support at ``partner-support@edx.org``. After you create
+   the channel for a course, the partner support team can enable the video
+   upload feature for that course in Studio.
 
 Optionally, give management access to the channel to members of the
 corresponding course team.
@@ -195,7 +196,7 @@ and invites them to manage the channel.
 
 #. Advise the course team member to expect and respond to the email message
    to activate the channel manager account. Activation must be complete for
-   management access to be granted. 
+   management access to be granted.
 
    See steps 4-5 for :ref:`establishing access to a YouTube account<Establish
    Access to YouTube Account>`.
@@ -204,7 +205,7 @@ Course team members who complete the activation process are channel managers.
 When they log in to YouTube at https://www.youtube.com using the email address
 that has channel manager privileges, they can manage course content.
 
-.. important:: It takes 24 hours to complete the automated encoding and 
+.. important:: It takes 24 hours to complete the automated encoding and
  hosting process for each video file that a course team uploads in Studio.
  Channel managers cannot use YouTube to work with the resulting hosted file
  until after the process is complete.

--- a/en_us/course_authors/source/video/video_uploads.rst
+++ b/en_us/course_authors/source/video/video_uploads.rst
@@ -4,7 +4,7 @@
 Uploading Videos in Studio
 ###########################
 
-After a video administrator works with the edX media team to complete
+After a video administrator works with edX partner support to complete
 :ref:`preliminary setup<Video Getting Started>` for the entire institution,
 individual course teams can begin to upload video files for their courses in
 Studio. This section describes the specifications met by successful video
@@ -58,7 +58,8 @@ succeed, you must upload videos in **.mp4** or **.mov** format.
 Compression Specifications
 ===========================
 
-For best results, your video files should have these compression specifications.
+For best results, your video files should have these compression
+specifications.
 
 .. list-table::
    :widths: 40 40
@@ -90,10 +91,10 @@ For best results, your video files should have these compression specifications.
 File Naming Conventions
 ================================
 
-Each video file must have a unique name. The edX media team recommends that
-organizations define a naming convention for video files, and apply it to
-videos for all courses. At a minimum, your naming convention should include
-these elements.
+Each video file must have a unique name. The edX partner support team
+recommends that organizations define a naming convention for video files, and
+apply it to videos for all courses. At a minimum, your naming convention should
+include these elements.
 
 * A course identifier.
 * The year of the initial course run.
@@ -119,7 +120,7 @@ parties identify and track video files over time.
 .. This procedure needs to be completed only once per course in Studio.
 
 .. #. Work with your institution's video administrator to obtain the video
-   identifier for your course. The edX media team defines a unique video
+   identifier for your course. The edX partner support team defines a unique video
    identifier for each course.
 
 .. #. Open the course in Studio.
@@ -153,7 +154,7 @@ Upload Video Files
 
 Before you can upload video files, the video upload feature must be enabled
 for the course. Your video administrator coordinates this task with the edX
-media team. See :ref:`Create YouTube Channels`.
+partner support team. See :ref:`Create YouTube Channels`.
 
 #. Open the course in Studio.
 
@@ -223,11 +224,11 @@ The encoding and hosting process assigns these statuses to video files.
   can play your original .mp4 or .mov file and that it meets the other
   specifications for successful video processing. See :ref:`Specifications for
   Successful Video Files`. Upload the file, or a replacement file, again. If
-  processing fails more than once for a file, contact the edX media team at
-  media@edx.org.
+  processing fails more than once for a file, contact edX partner support at
+  partner-support@edx.org.
 
 Statuses of **Invalid Token** or **Unknown** indicate a configuration
-problem. Inform your edX partner manager if these statuses appear.
+problem. Inform edX partner support if these statuses appear.
 
 For more information, see :ref:`Video Encoding and Hosting Overview`.
 
@@ -298,7 +299,8 @@ its destination.
 * **youtube URL**: The YouTube location of a 1080p resolution video. By
   default, the edX video player delivers this video.
 
-The edX encoding and hosting process produces these alternative formats to ensure optimal playback quality for your learners.
+The edX encoding and hosting process produces these alternative formats to
+ensure optimal playback quality for your learners.
 
 
 .. _Creating Videos: https://courses.edx.org/courses/edX/edX101/2014/courseware/c2a1714627a945afaceabdfb651088cf/9dd6e5fdf64b49a89feac208ab544760/

--- a/en_us/shared/course_components/create_preroll_video.rst
+++ b/en_us/shared/course_components/create_preroll_video.rst
@@ -5,7 +5,7 @@ Adding a Pre-Roll Video to Your edX Course
 *******************************************
 
 .. note:: Only courses that run on the edx.org website can include a pre-roll
- video. In addition, your organization must work with the edX media team to
+ video. In addition, your organization must work with edX partner support to
  encode and host your video files. For more information, see `Processing Video
  Files`_.
 


### PR DESCRIPTION
## [DOC-3238](https://openedx.atlassian.net/browse/DOC-3238)

The media team is no longer the direct contact for video pipeline work. Replace with edX partner support as listed in the ticket.

I also found another reference, in the pre-roll video section.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @rjgrubb
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check): @catong @pdesjardins
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @jaakana
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
