### PR TITLE
Added the section about importing and exporting courses to the Open edX course author's doc

### DIFF
--- a/en_us/open_edx_course_authors/source/releasing_course/export_import_course.rst
+++ b/en_us/open_edx_course_authors/source/releasing_course/export_import_course.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/releasing_course/export_import_course.rst

--- a/en_us/open_edx_course_authors/source/releasing_course/index.rst
+++ b/en_us/open_edx_course_authors/source/releasing_course/index.rst
@@ -9,3 +9,4 @@ Releasing Your Course
 
    beta_testing
    course_launching
+   export_import_course


### PR DESCRIPTION
## [DOC-3255](https://openedx.atlassian.net/browse/DOC-3255)

Add the section about importing and exporting course to the Open edX course author's doc. It's missing at the moment:

http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/releasing_course/index.html
http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/releasing_course/index.html
### Reviewers
- [x] Doc team review (sanity check): @catong @lamagnifica @pdesjardins @srpearce

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Squash commits
