### PR TITLE
Add link anchor to Levels of Support

### DIFF
--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -14,6 +14,8 @@ additional exercises and tools.
   :local:
   :depth: 2
 
+.. _Levels of Support:
+
 ******************
 Levels of Support
 ******************


### PR DESCRIPTION
This PR adds an anchor to the Levels of Support heading in the Create Exercises and Tools file. Merging now to allow error free builds in a longer-running PR.

Testing
- [x] Clean run of run_tests.sh
