### PR TITLE
Add instructions for troubleshooting ecommerce test failures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Anderson Resende <andersonresende86@gmail.com>
 Peter Desjardins <pdesjardins@edx.org>
 Kyle Vigil <kylevigil@gmail.com>
 Ned Batchelder <ned@edx.org>
+Joyce Zhu <jzhu29@u.rochester.edu>

--- a/en_us/install_operations/source/ecommerce/test_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/test_ecommerce.rst
@@ -34,6 +34,14 @@ the unit test suite.)
 
      $ make validate
 
+  .. note::
+    If numerous unit tests fail with an ``OfflineGenerationError`` message, run
+    the following command, then try to run unit tests again.
+
+    .. code-block:: bash
+
+       $ DJANGO_SETTINGS_MODULE=ecommerce.settings.test make static
+
 * To run unit tests with quality checks but without migrations, run the
   following command.
 


### PR DESCRIPTION
Documents the `DJANGO_SETTINGS_MODULE=ecommerce.settings.test make static` command, which sometimes needs to be run before running the ecommerce test suite. Also adds me to AUTHORS file. 
### Reviewers
- [x] Subject matter expert: @douglashall  
- [x] Doc team review (sanity check/copy edit/dev edit):  @pdesjardins 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
