### PR TITLE
DOC-3256 Indicate reverification block is unsupported

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/in_course_reverification.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/in_course_reverification.rst
@@ -18,6 +18,12 @@ assessments to require verification.
 Enable In-Course Identity Reverification
 *****************************************
 
+.. note:: The in-course identity reverification process requires using the
+   edx-reverification-block, which is :ref:`unsupported<Levels of Support>`.
+   Before you can enable in-course identity reverification you must follow the
+   steps to :ref:`allow the addition of unsupported<
+   Add_Unsupported_Exercises_Problems>` tools and problem types.
+
 To enable in-course identity reverification for your course, follow these
 steps.
 


### PR DESCRIPTION
## [DOC-3256](https://openedx.atlassian.net/browse/DOC-3256)

This PR updates the "Offering Academic Course Credit" information in the B&R guide to indicate that the edx-reverification-xblock is unsupported. The note provides a link to the (in https://github.com/edx/edx-documentation/pull/1170: not yet merged) topic about the Advanced Setting that when set to true, allows adding unsupported problem types and tools. 
### Date Needed: Friday Aug 19

Feature is already merged; waiting for DevOps.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @cahrens 
- [x] Product: @sstack22  
- [x] Doc team review (sanity check/copy edit/dev edit): @pdesjardins or @lamagnifica 

FYI: @jaakana, @mmacfarlane
### Testing
- [x] Ran ./run_tests.sh without warnings or errors - except for known issue with new anchor
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
