### PR TITLE
Fixes DOC-3218 in the named release branch

### DIFF
--- a/en_us/install_operations/source/platform_releases/dogwood.rst
+++ b/en_us/install_operations/source/platform_releases/dogwood.rst
@@ -153,8 +153,7 @@ Automatic Upgrading
 ===================
 
 The ``migrate.sh`` script is in the `edX configuration repository
-<https://github.com/edx/configuration/blob/master/util/vagrant/migrate.sh>`_ on
-GitHub.
+<https://github.com/edx/configuration/blob/named-release/dogwood.rc/util/vagrant/migrate.sh>`_ on GitHub.
 
 .. note::
   The upgrade scripts provided are verified only for upgrading instances


### PR DESCRIPTION
## [DOC-3218](https://openedx.atlassian.net/browse/DOC-3218)

Rather than pointing people moving to Dogwood to the upgrade.sh script in master, they should use the migrate.sh script in its new location.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @shaunagm 
- [ ] Subject matter expert: @nedbat 
- [ ] Doc team review (sanity check):  @pdesjardins
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

Apologies for the 2nd tag, folks.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
