### PR TITLE
Send people to the central getting help page

### DIFF
--- a/en_us/install_operations/source/installation/getting_help.rst
+++ b/en_us/install_operations/source/installation/getting_help.rst
@@ -15,7 +15,7 @@ Where to Find Help
 There are a number of places to get help, including mailing lists and real-time
 chat.  Please choose an appropriate venue for your question.  This helps ensure
 that you get good prompt advice, and keeps discussion focused.  For details of
-your options, see the `Community Discussions`_ page.
+your options, see the `Getting Help page`_.
 
 
 *******************************************
@@ -45,7 +45,7 @@ Stay involved in the discussion, and try to give them what they need. They know
 best what information they need to solve the problem.
 
 
-.. _Community Discussions: https://open.edx.org/resources/community-discussions
+.. _Getting Help page: https://open.edx.org/getting-help
 .. _openedx-ops: http://groups.google.com/forum/#!forum/openedx-ops
 
 .. include:: ../../../links/links.rst

--- a/en_us/shared/preface.rst
+++ b/en_us/shared/preface.rst
@@ -330,14 +330,14 @@ Additional repositories are used for other projects. Our contributor agreement,
 contributor guidelines and coding conventions, and other resources are
 available in these repositories.
 
-======================
-Community Discussions
-======================
+============
+Getting Help
+============
 
-The `Community Discussions`_ page in the Open edX Portal lists different
-ways that you can ask, and answer, questions.
+The `Getting Help`_ page in the Open edX Portal lists different
+ways that you can ask, and get answers to, questions.
 
-.. _Community Discussions: https://open.edx.org/resources/community-discussions
+.. _Getting Help: https://open.edx.org/getting-help
 
 ====================
 Wikis and Web Sites


### PR DESCRIPTION
We're trying to use the getting-help page as the one landing page for people needing help.
