### PR TITLE
Updated devstack installation instructions

### DIFF
--- a/en_us/install_operations/source/installation/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/installation/devstack/install_devstack.rst
@@ -21,27 +21,73 @@ You must also ensure that you have the administrator password for your local
 computer. The administrator password is needed to configure NFS (network file
 system) to allow users to access code directories directly from your computer.
 
-.. _Install DevStack:
+===========================
+Selecting a Download Option
+===========================
 
-******************************************************
-Install Devstack with a Direct Vagrant Box Download
-******************************************************
+The Open edX virtual machine box file has a file size of approximately four
+gigabytes. To download the box file, you can use one of these methods.
 
-During an installation of this type, the Vagrant virtual machine management
-tool downloads an Open edX virtual maching ``box`` file.
+* Install devstack with a direct Vagrant box download. The first time you start
+  the devstack virtual machine, the Vagrant virtual machine management tool
+  downloads the box file.
 
-.. note::
+* Use a BitTorrent client to download the Vagrant box file before you
+  install devstack. The first time you start the devstack virtual machine, the
+  Vagrant virtual machine management tool uses the previously downloaded box
+  file.
 
-   The first time you start the devstack virtual machine, Vagrant downloads a
-   ``box`` file, which has a file size of approximately four gigabytes. This
-   installation method might not be suitable if your internet connection is
-   limited or intermittent.
+If your internet connection is limited or intermittent, edX recommends that you
+torrent the box file. However, this step is optional.
 
-   You can also install devstack using a torrent file that you download
-   separately. For more information, see
-   :ref:`install_devstack_with_torrent_file`.
 
-To install devstack with a direct Vagrant box download, follow these steps.
+.. _Torrent the box file:
+
+===============================
+Torrent the Box File (Optional)
+===============================
+
+#. Download the torrent file for the latest Open edX release. For the URLs and 
+   box names of the Open edX releases, see `Open edX Releases Wiki page`_.
+
+   .. code-block:: bash
+
+     curl -OJL https://s3.amazonaws.com/edx-static/vagrant-images/eucalyptus-devstack-2016-08-19.box?torrent
+
+#. Use a BitTorrent client to open the ``.torrent`` file and download the ``.box``
+   file. For more information about using a BitTorrent client, see the
+   documentation for the client software that you choose.
+
+#. Find the name of the Vagrant box for the Open edX release that you
+   are installing. To find the Vagrant box name for an Open edX release,
+   see `Open edX Releases Wiki page`_.
+
+#. Create a Vagrant box using the ``vagrant box add`` command. Specify the
+   name of the box and the file path of the box file that you downloaded. The
+   name of the box you create must match the box name for the Open edX release
+   you are installing.
+
+   .. code-block:: bash
+
+     vagrant box add {BOX-NAME} {BOX-FILE}
+
+   Where {BOX-NAME} is the name of the box specified on the Open edX Releases
+   Wiki page, and {BOX-FILE} is the path to the box file you downloaded.
+   For example, the following command creates a box named
+   ``eucalyptus-devstack-2016-08-19``.
+
+   .. code-block:: bash
+
+     vagrant box add eucalyptus-devstack-2016-08-19 /path/to/box/eucalyptus-devstack-2016-08-19.box
+
+
+.. _Install Devstack:
+
+****************
+Install Devstack
+****************
+
+To install devstack, follow these steps.
 
 #. Ensure the ``nfsd`` client is running. You can use the ``nfsd status``
    command.
@@ -66,39 +112,41 @@ To install devstack with a direct Vagrant box download, follow these steps.
      mkdir devstack
      cd devstack
 
-#. Download the devstack Vagrant file.
-
-   .. code-block:: bash
-
-     curl -L https://raw.github.com/edx/configuration/master/vagrant/release/devstack/Vagrantfile > Vagrantfile
-
 #.  Set the ``OPENEDX_RELEASE`` environment variable to the Git tag name of the
-    named release of the Open edX platform that you are installing. For
+    release of the Open edX platform that you are installing. For
     information about the latest Open edX releases and the Git tag names for
     them, see `Open edX Releases Wiki page`_.
 
-    For example, ``named-release/dogwood`` is the Git tag name for the Dogwood
-    named release. The following command sets the value of the OPENEDX_RELEASE
-    environment variable to ``named-release/dogwood``.
+    For example, ``open-release/eucalyptus.latest`` is the Git tag name for the
+    latest Eucalyptus release. The following command sets the value of the
+    ``OPENEDX_RELEASE`` environment variable to ``open-release/eucalyptus.latest``.
 
     .. code-block:: bash
 
-      export OPENEDX_RELEASE="named-release/dogwood"
+      export OPENEDX_RELEASE="open-release/eucalyptus.latest"
 
     If you do not set this environment variable, Vagrant will install the most
     recent snapshot version of the Open edX platform. The snapshot version is
     not a supported release.
 
-#. Create and start the devstack virtual machine.
+#. Download the install script.
 
    .. code-block:: bash
 
-     vagrant up
+     curl -OL https://raw.github.com/edx/configuration/$OPENEDX_RELEASE/util/install/install_stack.sh
 
-   The first time you start the devstack virtual machine, Vagrant downloads
-   the base box, which has a file size of about 4GB. If you destroy and
-   recreate the virtual machine, Vagrant re-uses the box it downloaded. See
-   `Vagrant's documentation on boxes`_ for more information.
+#. Run the install script to create and start the devstack virtual machine.
+
+   .. code-block:: bash
+
+     bash install_stack.sh devstack $OPENEDX_RELEASE
+
+   .. note:: This step downloads the box file if you did not already
+      :ref:`use Torrent<Torrent the Box File>` to download and add it.
+
+   If you destroy and recreate the virtual machine, Vagrant reuses the box
+   file and does not download it again. See `Vagrant's documentation on
+   boxes`_ for more information.
 
    When prompted, enter the administrator password for your local computer.
 
@@ -108,109 +156,5 @@ Stack` to begin using devstack.
 For help with the devstack installation, see
 :ref:`troubleshooting_devstack_installation`.
 
-.. _install_devstack_with_torrent_file:
-
-*******************************************************
-Install Devstack with a Torrent Vagrant Box Download
-*******************************************************
-
-You can use a BitTorrent client to download the Vagrant box file. Downloading
-the box file and installing it in your Vagrant environment will prevent Vagrant
-from downloading the box file directly when you start it for the first time.
-This may be useful if you have a limited or intermittent connection to the
-internet and cannot download a large file.
-
-To install devstack using a box file that you download with a BitTorrent
-client, follow these steps.
-
-#. Ensure the ``nfsd`` client is running. Use the ``nfsd status`` command.
-
-   .. code-block:: bash
-
-     sudo nfsd status
-     nfsd service is enabled
-     nfsd is running (pid 313, 8 threads)
-
-   If the nfsd service is not running, use the ``nfsd start`` command.
-
-   .. code-block:: bash
-
-     sudo nfsd start
-     Starting the nfsd service
-
-#. Create a ``devstack`` directory and navigate to it in the command prompt.
-
-   .. code-block:: bash
-
-     mkdir devstack
-     cd devstack
-
-#. Download the devstack Vagrant file.
-
-   .. code-block:: bash
-
-     curl -O https://raw.github.com/edx/configuration/master/vagrant/release/devstack/Vagrantfile
-
-#. Download the torrent file for the latest Open edX release. For information
-   about the latest Open edX releases and to download torrent files for them,
-   see `Open edX Releases Wiki page`_.
-
-   .. code-block:: bash
-
-     curl -O https://s3.amazonaws.com/edx-static/vagrant-images/20151221-dogwood-devstack-rc2.box?torrent
-
-#. Use a BitTorrent client to open the torrent file and download the ``.box``
-   file. For more information about using a BitTorrent client, see the
-   documentation for the client software that you choose.
-
-#.  Set the ``OPENEDX_RELEASE`` environment variable to the Git tag name for
-    the Open edX release that you are installing. To find the Git tag name for
-    an Open edX release, see `Open edX Releases Wiki page`_.
-
-    For example, the following command sets the value of the OPENEDX_RELEASE
-    environment variable to ``named-release/dogwood``.
-
-    .. code-block:: bash
-
-      export OPENEDX_RELEASE="named-release/dogwood"
-
-    .. note::
-
-        If you do not set this environment variable, Vagrant will install the
-        most recent snapshot version of the Open edX platform, and will
-        download the ``box`` file for it directly. The size of the ``box`` file
-        is approximately four gigabytes.  The snapshot version is not a
-        supported release.
-
-#. Find the name of the Vagrant ``box`` for the named Open edX release that you
-   are installing. To find the Vagrant ``box`` name for an Open edX release,
-   see `Open edX Releases Wiki page`_.
-
-#. Create a Vagrant ``box`` using the ``vagrant box add`` command. Specify the
-   name of the box and the file path of the box file that you downloaded. The
-   name of the box you create must match the box name for the Open edX release
-   you are installing.
-
-   For example, the following command creates a box named ``dogwood-devstack-
-   rc2``.
-
-   .. code-block:: bash
-
-     vagrant box add dogwood-devstack-rc2 \
-     /path/to/vagrant-images_20151221-dogwood-devstack-rc2.box
-
-#. Create and start the devstack virtual machine.
-
-   .. code-block:: bash
-
-     vagrant up
-
-   When prompted, enter the administrator password for your local computer.
-
-When you have completed these steps, see :ref:`Starting the Open edX Developer
-Stack` to begin using devstack.
-
-For help with the devstack installation, see
-:ref:`troubleshooting_devstack_installation`.
 
 .. include:: ../../../../links/links.rst


### PR DESCRIPTION
Uses the new install_stack.sh script

Factor out the torrent instructions
