### PR TITLE
Updates the create_problem file in the OLX guide

### DIFF
--- a/en_us/olx/source/problem-xml/create_problem.rst
+++ b/en_us/olx/source/problem-xml/create_problem.rst
@@ -1,8 +1,11 @@
 .. _Working with Problems:
 
 ################################
-Working with Problems
+Working with Problem Components
 ################################
+
+This section covers the basics of problem components: what they look like to
+you and your learners, and the options that every problem component has.
 
 .. contents::
   :local:
@@ -12,17 +15,24 @@ Working with Problems
 Overview of Problem Components
 ******************************
 
-The problem component allows you to add interactive, automatically
-graded exercises to your course content. You can create many different
-types of problems in OLX (open learning XML).
+The problem component allows you to add interactive exercises to the verticals
+in your course. You can add many different types of exercises and problems.
 
-All problems receive a point score, but, by default, problems do not count
-toward a learner's grade. If you want the problems to count toward the
-learner's grade, change the assignment type of the subsection that contains
-the problems.
+=====================================
+Creating Graded or Ungraded Problems
+=====================================
 
-This section covers the basics of problem components: what they look like to
-you and your learners, and the options that every problem component has.
+All problems receive a point score. However, when you establish the grading
+policy for your course, you specify the assignment types that will count toward
+learners' grades; for example, homework, lab, midterm, and final.
+
+As you develop your course, you can add problem components to the units in any
+subsection. The problem components that you add automatically inherit the
+assignment type that is defined at the subsection level. You can only set
+assignment types at the subsection level, not at the unit or individual
+component level.
+
+For more information, see :ref:`Grading Policy`.
 
 .. _Problem Student View:
 
@@ -39,54 +49,26 @@ following settings.
   :local:
   :depth: 1
 
+This section describes the OLX elements and attributes that you define for the
+problem settings. For a detailed description of each setting, see
+:ref:`opencoursestaff:Problem Settings`.
+
 ===============
 Display Name
 ===============
 
-This setting indicates the name of your problem. This name appears as a heading
-above the problem in the LMS, and it identifies the problem for you in
-Insights.
-
-The following illustration shows the display name of a problem in Studio, in
-the LMS, and in Insights.
-
-.. image:: ../../../shared/images/display_names_problem.png
- :alt: The identifying display name for a problem in Studio, the LMS, and
-     Insights.
- :width: 800
-
-Each problem type supplies a default display name that identifies the type of
-problem component added. Changing the default to a unique, descriptive display
-name can help you and your learners identify different problems quickly and
-accurately. If you delete the default display name and do not enter your own
-identifying name, the platform supplies "problem" for you.
-
-For more information about metrics for your course's problem components, see
-`Using edX Insights`_.
-
-With OLX, you set the display name as an attribute of the ``problem`` element.
+Using OLX, you set the display name as an attribute of the ``<problem>``
+element.
 
 .. code-block:: xml
 
   <problem display_name="Geography Homework"></problem>
 
-
 ==============================
 Maximum Attempts
 ==============================
 
-This setting specifies the number of times a learner is allowed to attempt
-answering the problem. By default, the course-wide **Maximum Attempts**
-advanced setting is null, meaning that the maximum number of attempts for
-problems is unlimited. If the course-wide **Maximum Attempts** setting is
-changed to a specific number, the **Maximum Attempts** setting for individual
-problems defaults to that number, and cannot be set to unlimited.
-
-.. note:: Only questions that have a **Maximum Attempts** setting of 1 or
- higher are included on the Learner Answer Distribution report that you can
- download during your course.
-
-With OLX, you set the maximum attempts as an attribute of the ``problem``
+Using OLX, you set the maximum attempts as an attribute of the ``<problem>``
 element.
 
 .. code-block:: xml
@@ -100,74 +82,12 @@ element.
 Problem Weight
 ==============================
 
-.. note:: The LMS stores scores for all problems, but scores only count
-          toward a learner's final grade if they are in a subsection that is
-          graded.
-
-This setting specifies the maximum number of points possible for the
-problem. The problem weight appears next to the problem title.
-
-
-.. image:: ../../../shared/images/ProblemWeight_DD.png
- :alt: Image of a problem from a learner's point of view, with the possible
-       points circled
-
-By default, each response field, or "answer space", in a problem component is
-worth one point. Any problem component can have multiple response fields. For
-example, the problem component above contains one dropdown problem that has
-three separate questions, and also has three response fields.
-
-With OLX, you set a different component weight as an attribute of the
-``problem`` element.
+Using OLX, you set the component weight as an attribute of the ``<problem>``
+element.
 
 .. code-block:: xml
 
   <problem weight="2.0"></problem>
-
-Computing Scores
-****************
-
-The score that a learner earns for a problem is the result of the
-following formula.
-
-**Score = Weight × (Correct answers / Response fields)**
-
-*  **Score** is the point score that the learner receives.
-
-*  **Weight** is the problem's maximum possible point score.
-
-*  **Correct answers** is the number of response fields that contain correct
-   answers.
-
-*  **Response fields** is the total number of response fields in the problem.
-
-**Examples**
-
-The following are some examples of computing scores.
-
-*Example 1*
-
-A problem's **Weight** setting is left blank. The problem has two
-response fields. Because the problem has two response fields, the
-maximum score is 2.0 points.
-
-If one response field contains a correct answer and the other response
-field contains an incorrect answer, the learner's score is 1.0 out of 2
-points.
-
-*Example 2*
-
-A problem's weight is set to 12. The problem has three response fields.
-
-If a learner's response includes two correct answers and one incorrect
-answer, the learner's score is 8.0 out of 12 points.
-
-*Example 3*
-
-A problem's weight is set to 2. The problem has four response fields.
-
-If a learner's response contains one correct answer and three incorrect
-answers, the learner's score is 0.5 out of 2 points.
 
 .. _Randomization:
 
@@ -175,94 +95,19 @@ answers, the learner's score is 0.5 out of 2 points.
 Randomization
 ===============
 
-.. note:: The **Randomization** setting serves a different purpose from
- "problem randomization". The **Randomization** setting affects how numeric
- values or multiple choice options are randomized within a single problem.
- Problem randomization offers different problems or problem versions to
- different learners. For more information, see :ref:`Problem Randomization`.
-
-For numerical input problems that include a Python script to generate numbers
-randomly, or multiple choice problems that are set up to shuffle answers, this
-setting specifies when problem appearance changes.
-
-.. note:: This setting should only be set to an option other than **Never**
- for problems that are configured to do random number generation or shuffle
- multiple choice answers.
-
-For example, in this problem, the highlighted values change every time a
-learner selects **Check** for this problem.
-
-.. image:: ../../../shared/images/Rerandomize.png
- :alt: An image of the same problem shown twice, with color highlighting on
-   values that change.
- :width: 800
-
-If you want to randomize numeric values in a problem, you complete both of
-these steps.
-
-* Make sure that you edit your problem to include a Python script that randomly
-  generates numbers.
-
-* Select **Edit** and then **Settings** for the problem to specify an option
-  other than **Never** for the **Randomization** setting.
-
-If you want to shuffle answers in a multiple choice problem, you complete both
-of these steps.
-
-* Use the simple or advanced editor to set up your problem to :ref:`shuffle
-  answers<Shuffle Answers in a Multiple Choice Problem>`.
-
-* Select **Edit** and then **Settings** for the problem to specify an option
-  other than **Never** for the **Randomization** setting.
-
-..  For more information, see :ref:`Use Randomization in a Numerical Input Problem`.
-..  ^^ add back to first bullet when DOC-2175 gets done - Alison 30 Jul 15
-
-The edX Platform has a 20-seed maximum for randomization. This means that
-learners see up to 20 different problem variants for every problem that has
-**Randomization** set to an option other than **Never**. It also means that
-every answer for the 20 different variants is reported by the Answer
-Distribution report and edX Insights. Limiting the number of variants to a
-maximum of 20 allows for better analysis of learner submissions by allowing you
-to detect common incorrect answers and usage patterns for such answers.
-
-For more information, see :ref:`Student_Answer_Distribution` in this guide, and
-`Review Answers to Graded Problems`_ or `Review Answers to Ungraded Problems`_
-in *Using edX Insights*.
-
-You can choose the following options for the **Randomization** setting.
-
-.. list-table::
-   :widths: 15 70
-   :header-rows: 1
-
-   * - Option
-     - Description
-   * - **Always**
-     - Learners see a different version of the problem each time they select
-       Check.
-   * - **On Reset**
-     - Learners see a different version of the problem each time they select
-       Reset.
-   * - **Never**
-     - All learners see the same version of the problem. For most courses, this
-       option is supplied by default. Select this option for every problem in
-       your course that does not include a Python script to generate random
-       numbers.
-   * - **Per Student**
-     - Individual learners see the same version of the problem each time they
-       look at it, but that version is different from the version that other
-       learners see.
-
-
-With OLX, you set value randomization as an attribute of the ``problem``
+Using OLX, you set value randomization as an attribute of the ``<problem>``
 element.
 
 .. code-block:: xml
 
   <problem rerandomize="always"></problem>
 
+You can specify the following values for this attribute.
 
+* always
+* on_reset
+* never
+* per_student
 
 .. _Show Answer:
 
@@ -270,70 +115,23 @@ element.
 Show Answer
 ===============
 
-This setting defines when the problem shows the answer to the learner.
-This setting has the following options.
-
-+-------------------+--------------------------------------+
-| **Always**        | Always show the answer when the      |
-|                   | learner selects the **Show Answer**  |
-|                   | button.                              |
-+-------------------+--------------------------------------+
-| **Answered**      | Show the answer after the learner    |
-|                   | tries to answer the problem.         |
-|                   |                                      |
-|                   | If the question can be, and is,      |
-|                   | reset, the answer                    |
-|                   | is not shown until the learner tries |
-|                   | the problem again. (When a learner   |
-|                   | answers a question, the question is  |
-|                   | considered to be                     |
-|                   | both attempted and answered. When    |
-|                   | the question is reset, the question  |
-|                   | is still attempted, but not yet      |
-|                   | answered.)                           |
-+-------------------+--------------------------------------+
-| **Attempted**     | Show the answer after the learner    |
-|                   | tries to answer the problem.         |
-|                   |                                      |
-|                   | If the question can be, and is,      |
-|                   | reset, the answer                    |
-|                   | *continues to show*.                 |
-|                   | (When a learner answers a question,  |
-|                   | the question is considered to be     |
-|                   | both attempted and                   |
-|                   | answered. When the question is       |
-|                   | reset, the question is still         |
-|                   | attempted, but not yet answered.)    |
-+-------------------+--------------------------------------+
-| **Closed**        | Show the answer after the learner    |
-|                   | has used up all his attempts to      |
-|                   | answer the problem or the due date   |
-|                   | has passed.                          |
-+-------------------+--------------------------------------+
-| **Finished**      | Show the answer after the learner    |
-|                   | has answered the problem correctly,  |
-|                   | the learner has no attempts left, or |
-|                   | the problem due date has passed.     |
-+-------------------+--------------------------------------+
-| **Correct or      | Show the answer after the learner    |
-| Past Due**        | has answered the problem correctly   |
-|                   | or the problem due date has passed.  |
-+-------------------+--------------------------------------+
-| **Past Due**      | Show the answer after the due date   |
-|                   | for the problem has passed.          |
-+-------------------+--------------------------------------+
-| **Never**         | Never show the answer. In this case, |
-|                   | the **Show Answer** button does not  |
-|                   | appear next to the problem in Studio |
-|                   | or in the LMS.                       |
-+-------------------+--------------------------------------+
-
-With OLX, you set the show answer preference as an attribute of the
-``problem`` element.
+Using OLX, you set the show answer preference as an attribute of the
+``<problem>`` element.
 
 .. code-block:: xml
 
   <problem showanswer="correct_or_past_due"></problem>
+
+You can specify the following values for this attribute.
+
+* always
+* answered
+* attempted
+* closed
+* correct_or_past_due
+* finished
+* past_due
+* never
 
 .. _Show Reset Button:
 
@@ -341,28 +139,12 @@ With OLX, you set the show answer preference as an attribute of the
 Show Reset Button
 =================
 
-This setting defines whether a **Reset** button is visible on the problem.
-Learners can select **Reset** to clear any input that has not yet been
-submitted, and try again to answer the problem. If the learner has already
-submitted an answer, selecting **Reset** clears the submission and, if the
-problem contains randomized variables and randomization is set to **On Reset**,
-changes the values the learner sees in the problem. If the number of maximum
-attempts that was set for this problem has been reached, the **Reset** button
-is not visible.
-
-This problem-level setting overrides the course-level **Show Reset Button for
-Problems** setting.
-
-With OLX, you set the show reset button preference as an attribute of the
-``problem`` element.
+Using OLX, you set the show reset button preference as an attribute of the
+``<problem>`` element.
 
 .. code-block:: xml
 
   <problem show_reset_button="true"></problem>
-
-.. include:: ../../../shared/exercises_tools/Section_adding_hints.rst
-
-.. include:: ../../../shared/exercises_tools/Section_partial_credit.rst
 
 .. _Modifying a Released Problem:
 
@@ -415,39 +197,31 @@ ask your learners to go back and resubmit answers to a problem.
    and revise the copy.) Then ask all your learners to complete the new
    problem.
 
-.. _Additional Work with Problems:
-
-************************************
-Additional Work with Problems
-************************************
-
-You have some further options when you work with problems. You can include more
-than one problem in a single problem component, or you can set up a problem
-that presents different versions to different learners.
 
 .. _Multiple Problems in One Component:
 
-====================================
+***********************************
 Multiple Problems in One Component
-====================================
+***********************************
 
-You can create a problem that has more than one response type. For example, you
-might want to create a numerical input problem, and then include a multiple
-choice question about the numerical input problem. Or, you might want a learner
-to be able to check the answers to many problems at one time. To do this, you
-can include multiple problems inside a single ``problem`` element. The problems
-can be different types.
+You can create a problem that includes more than one response type. For
+example, you might want to create a numerical input problem and then include a
+multiple choice problem that refers to the numerical input problem. Or,
+you might want a learner to be able to check the answers to many problems at
+one time. To do this, you can include multiple problems inside a single
+``<problem>`` element. The problems can be different types.
 
-.. note::
-  You cannot use a :ref:`Custom JavaScript` in a component that contains more
-  than one problem. Each custom JavaScript problem must be in its own
-  component.
+Each question and its answer options are enclosed by the element that
+identifies the type of problem, such as ``<multiplechoiceresponse>`` for a
+multiple choice question or ``<formularesponse>`` for a math expression input
+question.
 
-To create multiple problems in one component, create a new blank advanced
-problem component, and then add the XML for each problem in the component
-editor. You only need to include the XML for the problem and its answers. You
-do not have to include the code for other elements, such as the **Check**
-button.
+You can provide a different explanation for each question by using the
+``<solution>`` element.
+
+As a best practice, edX recommends that you avoid including unformatted
+paragraph text between the questions. Screen readers can skip over text that is
+inserted among multiple questions.
 
 Elements such as the **Check**, **Show Answer**, and **Reset** buttons, as well
 as the settings that you select for the problem component, apply to all of the
@@ -457,6 +231,15 @@ component as a whole rather than three attempts to answer each problem
 individually. If a learner selects **Check**, the LMS scores all of the
 problems in the component at once. If a learner selects **Show Answer**, the
 answers for all the problems in the component appear.
+
+.. note::
+  You cannot use a :ref:`Custom JavaScript` in a component that contains more
+  than one problem. Each custom JavaScript problem must be in its own
+  component.
+
+.. include:: ../../../shared/exercises_tools/Section_adding_hints.rst
+
+.. include:: ../../../shared/exercises_tools/Section_partial_credit.rst
 
 .. _Problem Randomization:
 
@@ -476,7 +259,7 @@ content libraries. For more information, see :ref:`Randomized Content Blocks`.
    versions to different learners, whereas the **Randomization** setting
    controls when a Python script randomizes the variables within a single
    problem. For more information about the **Randomization** setting, see
-   :ref:`Randomization`.
+   :ref:`opencoursestaff:Randomization`.
 
 
 .. _Create Randomized Problems:


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

I realized belatedly that the OLX guide has its own create_problem.rst file. This file duplicated a lot of the information that is in the shared create_problem.rst file (which is used in the partner and Open edX versions of the Building & Running guide). This PR removes some of the duplicated information.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (dev edit): @catong  @srpearce 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
