### PR TITLE
Updates references to Dogwood to use Eucalyptus instead

### DIFF
--- a/en_us/install_operations/source/index.rst
+++ b/en_us/install_operations/source/index.rst
@@ -11,7 +11,9 @@ This document applies to the most recent version of the Open edX Platform; that
 is, it applies to the *master* branch of the edX Platform.
 
 This document also contains instructions for installing Open edX releases. The
-most recent release of Open edX is :ref:`Dogwood <Open edX Dogwood Release>`.
+most recent release of Open edX is :ref:`Eucalyptus <Open edX Eucalyptus
+Release>`.
+
 
 .. toctree::
    :numbered:

--- a/en_us/install_operations/source/platform_releases/dogwood.rst
+++ b/en_us/install_operations/source/platform_releases/dogwood.rst
@@ -10,6 +10,10 @@ This section describes how to install the Open edX Dogwood release.
  :local:
  :depth: 1
 
+.. note::
+  Now that the Open edX Eucalyptus release is available, edX no longer
+  supports the Dogwood release.
+
 ******************************
 What's Included in Dogwood
 ******************************

--- a/en_us/open_edx_release_notes/source/CSMHE/CSMHE_overview.rst
+++ b/en_us/open_edx_release_notes/source/CSMHE/CSMHE_overview.rst
@@ -15,10 +15,8 @@ is needed.
 For procedures about how to upgrade all Open edX instances that follow master,
 see :ref:`CSMHE Procedures`.
 
-.. note:: No changes are required or supported at this time for Open edX
- installations that use the **Dogwood** release. For those installations, the
- changes described in this section will be a part of the upgrade to the next
- Open edX release, Eucalyptus.
+.. note:: The changes described in this section are a part of the upgrade to
+ the Open edX Eucalyptus release.
 
 ****************************************************************
 What Is the ``courseware_studentmodulehistory`` Table?

--- a/en_us/open_edx_release_notes/source/CSMHE/index.rst
+++ b/en_us/open_edx_release_notes/source/CSMHE/index.rst
@@ -7,10 +7,8 @@ Replacing the ``courseware_studentmodulehistory`` Table
 This section describes a change to the ``courseware_studentmodulehistory``
 database table.
 
-.. note:: No changes are required or supported at this time for Open edX
- installations that use the **Dogwood** release. For those installations, the
- changes described in this section will be a part of the upgrade to the next
- Open edX release, Eucalyptus.
+.. note:: The changes described in this section are a part of the upgrade to
+ the Open edX Eucalyptus release.
 
 The change to the ``courseware_studentmodulehistory`` database table requires a
 new database configuration, and offers an optional data migration. This change

--- a/en_us/open_edx_release_notes/source/dogwood.rst
+++ b/en_us/open_edx_release_notes/source/dogwood.rst
@@ -10,6 +10,11 @@ This page lists the highlights of the Dogwood release.
  :depth: 1
  :local:
 
+.. note::
+ With the :ref:`Open edX Eucalyptus Release`, the Dogwood release is no longer
+ supported. This page remains in these release notes as a record of when new
+ features were included in Open edX.
+
 **************
 New Features
 **************

--- a/en_us/open_edx_release_notes/source/links.rst
+++ b/en_us/open_edx_release_notes/source/links.rst
@@ -39,6 +39,16 @@
 
 .. _Profile Images API Version 1.0: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/profile_images/index.html
 
+.. Eucalyptus doc links
+
+.. _Installing, Configuring, and Running the Open edX Platform\: Eucalyptus Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-eucalyptus.master
+
+.. _Building and Running an Open edX Course\: Eucalyptus Release: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-eucalyptus.master
+
+.. _Open edX Learner's Guide\: Eucalyptus Release: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-eucalyptus.master
+
+.. _Open edX Platform APIs\: Eucalyptus Release: http://edx.readthedocs.io/projects/edx-platform-api/en/open-release-eucalyptus.master
+
 .. Dogwood doc links:
 
 .. _Installing, Configuring, and Running the Open edX Platform Dogwood Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-dogwood.rc/platform_releases/dogwood.html

--- a/en_us/open_edx_release_notes/source/os_documentation.rst
+++ b/en_us/open_edx_release_notes/source/os_documentation.rst
@@ -4,17 +4,19 @@ Open edX Documentation
 
 All Open edX documentation is available at `docs.edx.org`_.
 
-*******************************
-Dogwood Release Documentation
-*******************************
+*********************************
+Eucalyptus Release Documentation
+*********************************
 
 The following documentation is available for the Open edX Dogwood release.
 
-* `Installing, Configuring, and Running the Open edX Platform Dogwood Release`_
+* `Installing, Configuring, and Running the Open edX Platform: Eucalyptus Release`_
 
-* `Building and Running an Open edX Course for Dogwood`_
+* `Building and Running an Open edX Course: Eucalyptus Release`_
 
-* `Open edX Learner's Guide for Dogwood`_
+* `Open edX Learner's Guide: Eucalyptus Release`_
+
+* `Open edX Platform APIs: Eucalyptus Release`_
 
 *******************************
 Latest Documentation


### PR DESCRIPTION
## [DOC-3100](https://openedx.atlassian.net/browse/DOC-3100)

Grepping through the doc repo identified these references to Dogwood. Updates files to refer and link to Eucalyptus as the supported Open edX release.
### Date Needed

25 Aug
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @nedbat 
- [ ] Subject matter expert: 
- [x] Doc team review (dev edit): @catong @pdesjardins 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Verify that doc links are accurate!!!
- [x] Squash commits
