### PR TITLE
Use non-breaking space to join url to icon

### DIFF
--- a/en_us/_themes/edx_theme/static/css/theme.css
+++ b/en_us/_themes/edx_theme/static/css/theme.css
@@ -3453,7 +3453,7 @@ footer p {
 }
 .rst-content a.reference.external:after {
 	font-family: fontawesome-webfont;
-	content: " \f08e ";
+	content: "\00a0\f08e ";
 	color: #b3b3b3;
 	vertical-align: super;
 	font-size: 60%


### PR DESCRIPTION
Wasn't it annoying when a line would break between a URL and the external-link icon? Ugh.  No longer.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @pdesjardins @srpearce
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Sandbox (optional)
- [ ] Point to or build a sandbox for the software change and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
