### PR TITLE
Replace individual git usernames with the team tag

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Possible roles follow. The PR submitter checks the boxes after each reviewer fin
 
 - [ ] Subject matter expert: 
 - [ ] Subject matter expert: 
-- [ ] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @pdesjardins @srpearce
+- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
 - [ ] Product review:
 - [ ] Partner support: 
 - [ ] PM review: 


### PR DESCRIPTION
With Peter leaving, this seemed like a good time to streamline this.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check): @catong @srpearce
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing

-N/A Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
