### PR TITLE
Update drag and drop event 'item.dropped'

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -4710,6 +4710,8 @@ input, this event is also emitted after the learner submits the number input.
 
 **Event Source**: Server
 
+**History**: ``item`` and ``location_id`` added 7 Sep 2016.
+
 ``context`` **Member Fields**:
 
 This event type includes the :ref:`common<context>` ``context.module`` member
@@ -4727,6 +4729,11 @@ field.
    * - ``input``
      - integer
      - The number input value entered by the learner.
+   * - ``item``
+     - string
+     - The display name of the draggable item selected by the learner.  For
+       items that do not have a display name, this contains the item's image
+       URL.
    * - ``item_id``
      - integer
      - The index assigned to the draggable item selected by the learner.
@@ -4745,6 +4752,11 @@ field.
      - string
      - The text identifier for the target zone in which the learner placed the
        item.
+   * - ``location_id``
+     - integer
+     - The automatically generated unique index assigned to the target zone in
+       which the learner placed the item.  The assigned index is persistent for
+       each instance.
 
 ``edx.drag_and_drop_v2.item.picked_up``
 ***************************************


### PR DESCRIPTION
## [SOL-1805](https://openedx.atlassian.net/browse/SOL-1805)

Adds documentation on the `item` and `location_id` fields of the `item.dropped` drag and drop event.

See [xblock-drag-and-drop-v2 PR 97](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/97) for details on the code change.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] OpenCraft: @pomegranited
- [x] Subject matter expert: @lamagnifica 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [x] Product review: @sstack22

CC @cahrens , @stroilova 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors - 9 warnings found, but all unrelated to this change.
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
