### PR TITLE
Corrects the URL for Platform API Euc docs in master

### DIFF
--- a/en_us/open_edx_release_notes/source/links.rst
+++ b/en_us/open_edx_release_notes/source/links.rst
@@ -47,7 +47,7 @@
 
 .. _Open edX Learner's Guide\: Eucalyptus Release: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-eucalyptus.master
 
-.. _Open edX Platform APIs\: Eucalyptus Release: http://edx.readthedocs.io/projects/edx-platform-api/en/open-release-eucalyptus.master
+.. _Open edX Platform APIs\: Eucalyptus Release: http://edx.readthedocs.io/projects/edx-platform-api/en/eucalyptus.1/
 
 .. Dogwood doc links:
 


### PR DESCRIPTION
Ned found a way to get an approximate Eucalyptus Platform API guide. It uses a different URL
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @nedbat 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
