### PR TITLE
rm unnecessary 'cd devstack' step

### DIFF
--- a/en_us/install_operations/source/installation/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/installation/devstack/install_devstack.rst
@@ -110,7 +110,6 @@ To install devstack, follow these steps.
    .. code-block:: bash
 
      mkdir devstack
-     cd devstack
 
 #.  Set the ``OPENEDX_RELEASE`` environment variable to the Git tag name of the
     release of the Open edX platform that you are installing. For


### PR DESCRIPTION
the commands that follow are meant to be run above the devstack dir, not from within it. `bash install_stack.sh devstack`  installs devstack inside another devstack dir, so you end up with your devstack in devstack/devstack.  Furthermore, when you complete the script, you get a message that says `Finished installing! You may now 'cd devstack' and login using 'vagrant ssh'`  but you are already IN devstack.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] @feanil 
- [ ] @nedbat 
