### PR TITLE
DOC: Zooming tool not supported (TNL-5417)

### DIFF
--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -375,10 +375,7 @@ tools that you can add to your course.
      - Word clouds arrange text that learners enter in response to a question
        into a colorful graphic.
      - Provisional support
-   * - :ref:`Zooming Image`
-     - Learners can view sections of an image in detail. You specify the
-       sections in an image that can be enlarged.
-     - Full support
+
 
 
 .. _Unsupported Additional Exercises and Tools:
@@ -462,6 +459,10 @@ tools available in Studio. For more information, see
        team and learners to work together to maintain the list of resources.
        For example, team members and learners can suggest new resources, vote
        for useful ones, or flag abuse and spam.
+     - Not supported
+   * - :ref:`Zooming Image`
+     - Learners can view sections of an image in detail. You specify the
+       sections in an image that can be enlarged.
      - Not supported
 
 

--- a/en_us/shared/exercises_tools/zooming_image.rst
+++ b/en_us/shared/exercises_tools/zooming_image.rst
@@ -4,7 +4,7 @@
 Zooming Image Tool
 ##################
 
-.. note:: EdX offers full support for this tool.
+.. note:: EdX does not support this tool.
 
 You can present information to your learners with an image. If your image
 is very large or very detailed, learners might not be able to see all the


### PR DESCRIPTION
## [TNL-5417](https://openedx.atlassian.net/browse/TNL-5417)

This PR updates exercises and tools info for the zooming image tool - was previously fully supported, now unsupported.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @cahrens 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review: @sstack22 

FYI: @jaakana, @mmacfarlane, @clrux 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
### Post-review
- [ ] Squash commits
