### PR TITLE
Add note for open edx self pacing setup via admin panel

### DIFF
--- a/en_us/shared/set_up_course/setting_pacing.rst
+++ b/en_us/shared/set_up_course/setting_pacing.rst
@@ -72,6 +72,18 @@ not appear in the LMS.
 Set Pacing for Your Course
 ***************************
 
+
+.. only:: Open_edX
+
+    Before you can use this feature to set up a self-paced course, it must be enabled using the Open edX Django admin panel.
+    Follow these steps, or contact your Open edX site administrator for assistance.
+
+    #. Log in to your Open edX Django Admin panel.
+    #. In the **Self_Paced** section, locate **Self paced configurations** and then select **Add**.
+    #. Check the **Enabled** and **Enable course home page improvements** checkboxes.
+    #. Select **Save**.
+
+
 .. note::
  You cannot change the course pacing after the course start date has passed.
 


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

Just added a note describing how to enable "Self paced configurations" via the admin panel. I was following the existing docs and was confused when I didn't see the new UI...until I realized there was this extra step in /admin.
### Date Needed (optional)

n/a
### Reviewers

@lamagnifica

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Sandbox (optional)
- [ ] Point to or build a sandbox for the software change and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
