### PR TITLE
Remove recommendation to install edx-analytics-pipeline on the host machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ autodeploy.properties
 .ws_migrations_complete
 
 *.log
+*.swp

--- a/develop.sh
+++ b/develop.sh
@@ -13,6 +13,6 @@ fi
 project_dir=$1
 port=${2:-9090}
 
-cd $1
+cd $project_dir
 make html
-sphinx-autobuild -b html -d build/doctrees -c source source build/html --port $port
+sphinx-autobuild --ignore '*.swp' --ignore '*~' -b html -d build/doctrees -c source source build/html --port $port

--- a/en_us/install_operations/source/installation/analytics/install_analytics.rst
+++ b/en_us/install_operations/source/installation/analytics/install_analytics.rst
@@ -15,36 +15,6 @@ stack.
    :local:
    :depth: 1
 
-
-*************************************
-Installing the Software Prerequisites
-*************************************
-
-In addition to the :ref:`software prerequisites<Software Prerequisites>` that
-fullstack and devstack require, for analytics devstack, you must install a
-tool that the Open edX Analytics Pipeline uses to deploy itself. To install
-this tool, follow these steps.
-
-#. Clone the repository on your host, not on the virtual machine.
-
-   .. code-block:: bash
-
-      $ git clone https://github.com/edx/edx-analytics-pipeline
-
-
-#. Install the project dependencies into a virtualenv on your host.
-
-   .. code-block:: bash
-
-      $ cd edx-analytics-pipeline
-      $ virtualenv venv
-      $ source venv/bin/activate
-      $ make bootstrap
-
-The system is now ready to start running tasks on analytics devstack
-using the ``remote-task`` tool.
-
-
 .. _Install the Analytics Devstack:
 
 ******************************
@@ -53,6 +23,13 @@ Installing Analytics Devstack
 
 To install analytics devstack extensions directly from the command line,
 follow these steps.
+
+#. Halt any running Open edX devstacks. Navigate to the directory that contains the Vagrantfile for the devstack and run ``vagrant suspend`` or ``vagrant halt``.
+
+   .. code-block:: bash
+
+     $ cd ~/open-edx/devstack/
+     $ vagrant suspend
 
 #. Create the ``analyticstack`` directory and navigate to it in the command
    prompt.
@@ -74,5 +51,70 @@ follow these steps.
 
      $ vagrant up
 
+#. Clone the edx-analytics-pipeline repository.
+
+   .. code-block:: bash
+
+     $ git clone git@github.com:edx/edx-analytics-pipeline.git ./edx-analytics-pipeline/
+
+#. Prepare the data pipeline inside the virtual machine.
+
+   .. code-block:: bash
+
+     $ vagrant ssh
+     $ cd /edx/app/analytics_pipeline/
+     $ sudo mkdir venvs
+     $ sudo chown vagrant:vagrant venvs
+     $ virtualenv venvs/analytics_pipeline/
+     $ . venvs/analytics_pipeline/bin/activate
+     $ cd analytics_pipeline
+     $ make system-requirements
+     $ make develop
+
+   .. note::
+
+      The version of edx-analytics-pipeline that you checked out on your host will be mounted at `/edx/app/analytics_pipeline/analytics_pipeline` inside the virtual machine. Vagrant directory sharing allows the code to be modified using an editor on the host machine and executed within the virtual machine.
+
+#. Run tests and quality checks.
+
+   .. code-block:: bash
+
+     $ make coverage
+
+#. Run the acceptance tests as the hadoop user.
+
+   .. code-block:: bash
+
+     $ sudo su hadoop
+     $ cd /edx/app/analytics_pipeline/
+     $ . venvs/analytics_pipeline/bin/activate
+     $ cd analytics_pipeline
+
+     # The next step will take hours to run.
+     $ make test-acceptance-local
+
+   A subset of acceptance tests can be run using the ``ONLY_TESTS`` parameter.
+
+   .. code-block:: bash
+
+     $ make test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_enrollments
+
+   Acceptance tests usually destroy any existing state before running, this behavior can be disabled by setting the ``DISABLE_RESET_STATE`` environment variable.
+
+   .. code-block:: bash
+
+     $ DISABLE_RESET_STATE=true make test-acceptance-local ONLY_TESTS=edx.analytics.tasks.tests.acceptance.test_enrollments
+
+   .. note::
+
+      Acceptance tests emulate deployment of the code to a remote Hadoop cluster. During this process it checks out a new copy of the code from the repo. For this reason, all changes must be committed before running the test.
+
+#. Display parameters for a task. This technique can be used to see the parameters for any task.
+
+   .. code-block:: bash
+
+     $ launch-task ImportEnrollmentsIntoMysql --help
+
+   The `EdX Analytics Pipeline Reference Guide <http://edx-analytics-pipeline-reference.readthedocs.io/en/latest/index.html>`_ contains a more detailed list of available tasks and their parameters.
 
 .. include:: ../../../../links/links.rst

--- a/en_us/olx/source/front_matter/change_log.rst
+++ b/en_us/olx/source/front_matter/change_log.rst
@@ -99,7 +99,7 @@ March 2015
    * - 11 Mar 2015
      - Added the secton :ref:`Adding Tooltips to a Problem`.
    * -
-     - Added the chapter :ref:`Working with Problems`.
+     - Added the chapter "Working with Problems".
    * - 5 Mar 2015
      - Updated the :ref:`Preface` to include information about the :ref:`The
        edX Partner Portal` and the :ref:`The Open edX Portal`.

--- a/en_us/shared/exercises_tools/numerical_input.rst
+++ b/en_us/shared/exercises_tools/numerical_input.rst
@@ -206,6 +206,8 @@ editor to add a problem without, or with, hints and feedback.
 
 .. include:: ../../../shared/exercises_tools/Section_simple_editor.rst
 
+.. _Use the Advanced Editor to Add a Numerical Input Problem:
+
 =========================================================
 Use the Advanced Editor to Add a Numerical Input Problem
 =========================================================
@@ -447,8 +449,8 @@ Awarding Partial Credit in a Numerical Input Problem
 
 You can configure a numerical input problem to award partial credit to learners
 who submit an answer that is close or related to the correct answer. You must
-use the :ref:`advanced editor<Use the Advanced Editor to Create a Numerical
-Input Problem>` to configure partial credit.
+use the :ref:`advanced editor<Use the Advanced Editor to Add a Numerical Input
+Problem>` to configure partial credit.
 
 .. only:: Partners
 


### PR DESCRIPTION
While preparing for a training session, I realized this doc was significantly out of date and provides instructions that leave your machine in an odd state with many different copies of the data pipeline checked out in different places. These revised instructions reduce the number of copies needed.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @brianhw 
- [ ] Subject matter expert: @HassanJaveed84 
- [x] Subject matter expert: @pomegranited  
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc 

FYI: @bradenmacdonald 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
