### PR TITLE
Adds information about creating and configuring multiple sites for an instance

### DIFF
--- a/en_us/install_operations/source/configuration/index.rst
+++ b/en_us/install_operations/source/configuration/index.rst
@@ -11,6 +11,7 @@ configuration options.
    :maxdepth: 2
 
    updating_platform
+   sites/index
    theming/index
    customize_registration_page
    config_allowed_regis_emails

--- a/en_us/install_operations/source/configuration/sites/configure_site.rst
+++ b/en_us/install_operations/source/configuration/sites/configure_site.rst
@@ -1,0 +1,99 @@
+.. _Configuring Sites Independently:
+
+#################################
+Configuring Sites Independently
+#################################
+
+You can set configuration properties independently for individual sites. The
+values that you define for individual sites override the default values that
+are present in the ``cms.env.json`` or ``lms.env.json`` files. For example, you
+can set the ``PLATFORM_NAME`` property to a different value for each of your
+sites to indicate that the sites present courses for different organizations or
+audiences.
+
+*******************
+Configuring a Site
+*******************
+
+To set configuration properties for a site, follow these steps.
+
+#. Sign in to the Django administration console for your base URL. For example,
+   ``http://{your_URL}/admin``.
+
+#. Select **Site Configurations** to open the
+   ``http://{hostname}/admin/site_configuration/siteconfiguration`` page.
+
+#. Select **Add site configuration**.
+
+#. From the **Site** menu, select the site you want to configure.
+
+#. Enter configuration properties in the **Values** field. Structure all
+   properties in valid JavaScript Object Notation (JSON) format.
+
+   The following example shows a set of configuration properties for a site.
+
+   .. code-block:: json
+
+       {
+         "course_email_from_addr":"courses@onlineu.edu",
+         "university":"Online University",
+         "PLATFORM_NAME":"Online University",
+         "email_from_address":"courses@onlineu.edu",
+         "payment_support_email":"payments@onlineu.edu",
+         "SITE_NAME":"onlineu.edu",
+         "site_domain":"onlineu.edu",
+         "SESSION_COOKIE_DOMAIN":"onlineu.edu",
+       }
+
+   .. note:: To make courses site-specific, you set the ``course_org_filter``
+     property to an organization identifier. Only that organization's courses
+     are available from the site.
+
+#. When you are ready for the configuration settings to take effect,
+   select **Enabled**.
+
+   The configuration properties that you set do not affect the site
+   until you select **Enabled**. If needed, you can return to the **Site
+   configurations** screen for this site to enable the configuration properties
+   later.
+
+#. Select **Save**.
+
+.. do you select Save or something else on this page? - Alison (guessing that you do)
+
+*******************************
+Site Configuration Reference
+*******************************
+
+An example of the properties that you define to configure a site follows.
+
+.. code-block:: json
+
+  {
+    "ECOMMERCE_API_URL":"https://my-site.sandbox.edx.org/api/v2",
+    "ECOMMERCE_PUBLIC_URL_ROOT":"https://my-site.sandbox.edx.org",
+    "ECOMMERCE_API_SIGNING_KEY":"ecommerce-secret",
+    "COURSE_CATALOG_VISIBILITY_PERMISSION":"see_in_catalog",
+    "COURSE_ABOUT_VISIBILITY_PERMISSION":"see_about_page",
+    "ENABLE_COMBINED_LOGIN_REGISTRATION":true,
+    "ENABLE_PAID_COURSE_REGISTRATION":true,
+    "ENABLE_SHOPPING_CART":true,
+    "ENABLE_SHOPPING_CART_BULK_PURCHASE":false,
+    "course_email_template_name":"my-site",
+    "course_email_from_addr":"my-site@example.com",
+    "ALLOW_AUTOMATED_SIGNUPS":true,
+    "domain_prefix":"my-site",
+    "university":"Education Programs",
+    "PLATFORM_NAME":"Education Programs",
+    "platform_name":"Education Programs",
+    "show_only_org_on_student_dashboard":true,
+    "email_from_address":"my-site@example.com",
+    "payment_support_email":"payments@example.com",
+    "SITE_NAME":"my-site.sandbox.edx.org",
+    "site_domain":"my-site.sandbox.edx.org",
+    "SESSION_COOKIE_DOMAIN":"my-site.sandbox.edx.org",
+    "course_org_filter":"MyOrgX",
+    "course_index_overlay_text":"<img src='/static/my-site/images/400x103.png' width='400' height='103' />",
+    "homepage_overlay_html":"<img src='/static/my-site/images/400x103.png' width='400' height='103' />",
+    "payment_email_signature":"Education Programs<br>The Digital Programs Team<br>my-site@example.com<br>101 Example Street<br>Example State"
+  }

--- a/en_us/install_operations/source/configuration/sites/create_site.rst
+++ b/en_us/install_operations/source/configuration/sites/create_site.rst
@@ -1,0 +1,22 @@
+.. _Create a Site:
+
+#############################
+Create an Open edX Site
+#############################
+
+To create an Open edX site, follow these steps.
+
+#. Sign in to the Django administration console for your base URL. For example,
+   ``http://{your_URL}/admin``.
+
+#. Select **Sites** to open the ``http://{your_URL}/admin/sites/site`` page.
+
+#. Enter the domain name for the site. This is the domain name in the URL for
+   the site. For example, ``myuniversity.edu``.
+
+   To make a site available on a non-default port that is entered as part of
+   the URL, the domain name must include the port number. For example, if an
+   LMS site is available at ``my-site.localhost:8000``, the domain name for
+   the site must be ``my-site.localhost:8000``.
+
+#. Select **Save**.

--- a/en_us/install_operations/source/configuration/sites/index.rst
+++ b/en_us/install_operations/source/configuration/sites/index.rst
@@ -1,0 +1,29 @@
+.. _Configuring Open edX Sites:
+
+#############################
+Configuring Open edX Sites
+#############################
+
+By default, an Open edX installation has one site for users to interact with.
+You can configure multiple sites within your Open edX installation. A site
+presents Open edX courses and content in an individual way. If you set up
+multiple sites, you can configure them independently of each other. For
+example, you can assign a different theme to each site and specify which
+courses are available on each site.
+
+You host each site on a separate domain or subdomain from your Open edX
+installation. You configure the domain name for a site in the Django admin site
+when you create it. For example, you might configure one site
+with the domain name ``university.edu`` and another site with the domain
+name ``advancedplacement.edu``. Or you might configure one site with the domain
+name ``arts.myuniversity.edu`` and another site with the domain name
+``sciences.myuniversity.edu``.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   create_site
+   configure_site
+
+.. For more information about themes, see... TBD

--- a/en_us/open_edx_release_notes/source/eucalyptus.rst
+++ b/en_us/open_edx_release_notes/source/eucalyptus.rst
@@ -129,12 +129,14 @@ For more information, see the `Configuring Data Storage`_ wiki page.
 Themes for Multiple Sites
 ==========================
 
-With this release, it is now possible to configure themes for multiple sites
-in a single installation of the Open edX platform.
+With this release, it is now possible to configure themes for multiple sites in
+a single installation of the Open edX platform. For more information about how
+to configure multiple sites for your installation, see
+:ref:`installation:Configuring Open edX Sites`.
 
-Documentation updates for this feature are currently in progress. For real time
-conversations about theming, join our community `Slack`_ team on the #theming
-channel.
+Documentation updates for the theming feature are currently in progress. For
+real time conversations about theming, join our community `Slack`_ team on the
+#theming channel.
 
 .. _Slack: https://openedx-slack-invite.herokuapp.com/
 
@@ -563,7 +565,7 @@ Patch Releases
   exactly 3 arguments (2 given)" exception has been fixed.
 
 * Course discussion performance has been improved. (:jira:`TNL-5173`)
-  
+
 * Learners can now correctly add a comment to a response in inline course
   discussions.  (:jira:`TNL-5389`)
 


### PR DESCRIPTION
## [DOC-2635](https://openedx.atlassian.net/browse/DOC-2635)

Based on Peter Desjardin's work, this PR adds procedures for creating and configuring Open edX sites.
### Date Needed

This feature is already available in Eucalyptus and master.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @mattdrayer 
- [x] Subject matter expert: @saleem-latif 
- [x] Subject matter expert: @douglashall  
- [x] Doc team review (sanity check): @edx/doc
- [ ] Product review: 
- [ ] Partner support: 
- [ ] PM review: 

FYI: @nedbat @andy-armstrong @scottrish 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
