### PR TITLE
Set copyright year dynamically

### DIFF
--- a/shared/conf.py
+++ b/shared/conf.py
@@ -1,6 +1,7 @@
 # Shared configuration for edX docs.
 
 import sys, os, urllib
+import datetime
 
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -97,7 +98,7 @@ if the_builder != "json":
 
 # General information about the project.
 
-copyright = u'2016, edX Inc.'
+copyright = '{year}, edX Inc.'format(year=datetime.datetime.now().year)
 
 
 


### PR DESCRIPTION
## [DOC-3212](https://openedx.atlassian.net/browse/DOC-3212)

I have made the copyright year dynamic in the docs. 
It is mentioned [here](https://openedx.atlassian.net/browse/DOC-3212) that there are many conf.py files, but I only see one with the copyright date. If necessary, I can add the copyright year to all other conf.py files.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [X] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

@catong 
### Testing
- [X] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Sandbox (optional)
- [ ] Point to or build a sandbox for the software change and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
