### PR TITLE
Add documentation about switching from ShoppingCart to E-Commerce.

### DIFF
--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -273,7 +273,34 @@ steps.
      the Django administration panel in the LMS. For more information about
      configuring the OIDC client, see :ref:`Configure OIDC`.
 
+*****************************************
+Switch from ShoppingCart to E-Commerce
+*****************************************
 
+By default, the ShoppingCart service is enabled when you install an Open edX
+instance. To use the E-Commerce service to handle ecommerce-related tasks
+instead of ShoppingCart, follow these steps.
+
+#. Sign in to the Django administration console for your base URL. For example,
+   ``http://{your_URL}/admin``.
+
+#. In the **Commerce** section, next to **Commerce configuration**, select **Add**. 
+
+#. Select **Enabled**.
+
+#. Select **Checkout on ecommerce service**.
+
+#. (Optional) In the **Single course checkout page**  field, override the
+   default path value of ``/basket/single-item/`` with your own path value.
+
+   .. important:: If you override the default path value, you must also change
+     all of the code that relies on that path.
+
+#. Set the **Cache Time To Live** value in seconds.
+
+#. Select the site for which you want to enable the E-Commerce service.
+
+#. Select **Save**.
 
 .. _Development Outside Devstack:
 


### PR DESCRIPTION
In order to use the Otto ecommerce service, after it's installation the user needs to switch from the old ShoppingCart. This is a very rough documentation but it's enough to get the ball rolling.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
