### PR TITLE
Add note about grading before course end date

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/credit_courses.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/credit_courses.rst
@@ -33,6 +33,12 @@ steps.
 Specify the Minimum Credit-Eligible Grade
 ********************************************
 
+.. note::
+  To make sure that learners' grades are correct, you must assign final grades
+  for credit courses before you create certificates for the course. You assign
+  final grades after the course end date. For more information, see
+  :ref:`Checking Student Progress and Issuing Certificates`.
+
 In addition to setting the usual grade scale for your course, you indicate a
 specific grade that learners must receive to earn credit for your course.
 

--- a/en_us/install_operations/source/configuration/enable_certificates.rst
+++ b/en_us/install_operations/source/configuration/enable_certificates.rst
@@ -190,6 +190,8 @@ course, including adding signatories and images for organization logo and
 signature images for signatories. For details, :ref:`opencoursestaff:Setting Up
 Course Certificates` in *Building and Running an Open edX Course*.
 
+.. _Generate Certificates for a Course:
+
 *****************************************
 Generate Certificates For a Course
 *****************************************

--- a/en_us/shared/manage_live_course/bulk_email.rst
+++ b/en_us/shared/manage_live_course/bulk_email.rst
@@ -790,8 +790,8 @@ about future access to course materials. Be sure to replace values enclosed by
 
   * If you qualify for a certificate (overall score {number}% or higher), the
     edX dashboard will include a link to your certificate in the near future.
-    While you may see the link in a few days, it can take up to two weeks edX
-    to generate all of the course certificates.
+    While you may see the link in a few days, it can take up to two weeks for
+    edX to generate all of the course certificates.
 
   * As an enrolled student, you will have access to the lecture videos even
     after the course ends. Assessments will remain, but you will no longer be

--- a/en_us/shared/student_progress/checking_student_progress.rst
+++ b/en_us/shared/student_progress/checking_student_progress.rst
@@ -1,12 +1,11 @@
 .. _Checking Student Progress and Issuing Certificates:
 
-#####################################################
-Assign Final Grades and Enable On-Demand Certificates
-#####################################################
+###############
+Ending a Course
+###############
 .. This chapter will be renamed and expanded to include course wrap-up activities and best practices.
 
-This topic describes how to assign grades and issue certificates to learners in
-your course.
+This topic describes how to complete several end-of-course tasks.
 
 .. contents::
    :local:
@@ -18,75 +17,109 @@ For more information, see the following other topics about certificates.
 * :ref:`Reporting Certificate Data`
 
 ****************************************
-Overview
+Sending a Farewell Message
 ****************************************
 
 As you prepare for the end of your course, you can send learners a :ref:`course
 farewell<Course Farewell and Certificates>` email message.
 
+**********************
+Assigning Final Grades
+**********************
+
 To assign a final grade to each learner enrolled in a course, you generate
-grades after the **Course End Date** and **Time** have passed. For more
-information, see :ref:`Access_grades`.
+grades after the course end date and time have passed. For more information,
+see :ref:`Access_grades`.
 
-The learner's final grade and the grading configuration you set in Studio are
-used to determine whether the learner has earned a certificate for the course.
+The learner's final grade and the grading configuration you set in Studio
+determine whether the learner has earned a certificate for the course.
 
-****************************************
-On-Demand Certificates
-****************************************
+********************
+Issuing Certificates
+********************
 
-If you have a self-paced course, you can allow your learners to request their
-certificates as soon as they have completed enough of the course with a high
-enough grade to qualify for a certificate. Learners might want to request a
-certificate right away, or they might wait until they have completed the
-course.
+Typically, you generate and issue certificates after the course ends for
+instructor-paced courses, or at specific intervals for self-paced courses.
 
-========================================
-Allow Learners to Request Certificates
-========================================
+For self-paced courses, you can also allow learners to request and download
+certificates before they have completed all of the course materials. To receive
+these on-demand certificates, learners must have completed enough of the
+course, and with a high enough grade, to qualify for a certificate.
 
-To allow learners to request certificates from the **Progress** page, follow
-these steps.
+===================================
+Issue Course-Generated Certificates
+===================================
 
-#. View the live version of your course.
+.. only:: Partners
 
-#. Select **Instructor**, and then select **Certificates**.
+   For most courses, you work with your edX partner manager to issue
+   certificates. For instructor-paced courses, you must assign final grades
+   before you can issue certificates. For more information, contact your edX
+   partner manager.
 
-#. Select **Enable Student-Generated Certificates**.
+.. only:: Open_edX
 
-   When they have qualified, learners can request their certificates from the
-   **Progress** page.
+   If the administrator of your instance of Open edX has configured your
+   instance to allow course teams to generate and issue certificates, you can
+   issue certificates for your course. For more information, see
+   :ref:`installation:Generate Certificates for a Course`.
 
-   To prevent learners from requesting certificates, select **Disable Student-
-   Generated Certificates**.
+   If your Open edX administrator has not configured your instance to allow
+   course teams to generate and issue certificates, you must work with your
+   administrator to issue your course certificates. For more information, see
+   :ref:`installation:Enable Certificates`.
+
+=======================================================
+Allow On-Demand Certificates (Self-Paced Courses Only)
+=======================================================
+
+You can allow your learners to receive on-demand certificates as soon as they
+qualify for a certificate in your course. This process has two steps.
+
+#. :ref:`Allow learners to request certificates<Allow Learners to Request
+   Certificates>`.
+#. :ref:`Allow learners to download certificates<Allow Learners to Download
+   Certificates>`.
 
 .. only:: Partners
 
   For information about how learners request certificates, see
   :ref:`learners:SFD On Demand Certificates`.
 
-=====================================================
-Communicate to Learners about Requesting Certificates
-=====================================================
+.. note::
+  If your course offers on-demand certificates, we encourage you to include
+  this information on your course About page, on the **Home** page, and in
+  communication with your learners.
 
-If your course offers on-demand certificates, we encourage you to include this
-information on your course About page, on the **Home** page, and in
-communication with your learners.
+.. _Allow Learners to Request Certificates:
 
-.. only:: Partners
+Allow Learners to Request On-Demand Certificates
+********************************************************
 
-   Course teams should also discuss additional self-paced settings with their
-   edX partner manager during the course announcement process.
+To allow learners to request on-demand certificates, you modify the **Enable
+Student- Generated Certificates** setting on the Instructor Dashboard.
 
-==============================================================
-Allow Learners to Download Certificates when They Qualify
-==============================================================
+#. View the live version of your course.
 
-To allow learners to download certificates from the dashboard when they qualify
-for them, you must modify the **Certificates Display Behavior** advanced
-setting in Studio.
+#. In the LMS, select **Instructor**, and then select **Certificates**.
 
-#. From the **Settings** menu, select **Advanced Settings**.
+#. Select **Enable Student-Generated Certificates**.
+
+   When they have qualified, learners can request their certificates from the
+   **Progress** page.
+
+   To prevent learners from requesting certificates, select **Disable
+   Student-Generated Certificates**.
+
+.. _Allow Learners to Download Certificates:
+
+Allow Learners to Download On-Demand Certificates
+*********************************************************
+
+To allow learners to download on-demand certificates, you modify the
+**Certificates Display Behavior** advanced setting in Studio.
+
+#. In Studio, on the **Settings** menu, select **Advanced Settings**.
 
 #. On the **Advanced Settings** page, locate **Certificates Display Behavior**.
 


### PR DESCRIPTION
## [DOC-3186](https://openedx.atlassian.net/browse/DOC-3186)

Add brief note to [Specify the Minimum Credit-Eligible Grade](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/credit_courses/credit_courses.html#specify-the-minimum-credit-eligible-grade) instructing course teams to make sure grading is complete before the course end date.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Doc team review (sanity check): @edx/doc
- [ ] Product review: Lauren Holliday
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
