### PR TITLE
Add orphan flag to prevent build errors

### DIFF
--- a/en_us/open_edx_students/source/SFD_instructor_dash_help.rst
+++ b/en_us/open_edx_students/source/SFD_instructor_dash_help.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _Course Team Help:
 
 #####################

--- a/en_us/students/source/SFD_instructor_dash_help.rst
+++ b/en_us/students/source/SFD_instructor_dash_help.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _Course Team Help:
 
 #####################


### PR DESCRIPTION
Adds an `:orphan:` flag to the two hidden Instructor Dashboard files to prevent build errors.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Doc team review (sanity check: @edx/doc
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
