### PR TITLE
DOC-3339: Updates scripts to remove OLX and Course Catalog API automation

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -35,20 +35,17 @@ if [ ${#projects[@]} -eq 0 ]
 then
     projects=(
         "en_us/course_authors"
-        "en_us/course_catalog_api_user_guide"
         "en_us/data"
         "en_us/developers"
         "en_us/edx_style_guide"
         "en_us/install_operations"
         "en_us/landing_page"
-        "en_us/olx"
         "en_us/open_edx_course_authors"
         "en_us/open_edx_release_notes"
         "en_us/open_edx_students"
         "en_us/ORA2"
         "en_us/release_notes"
         "en_us/students"
-        "en_us/xblock-tutorial"
     )
 fi
 

--- a/utilities/build-rtd-documents.sh
+++ b/utilities/build-rtd-documents.sh
@@ -9,7 +9,7 @@
 
 # To run this script, navigate to its directory and make sure the file is executable:
 
-# C1MQH7NLG944:~ peterdesjardins$ chmod a+x build-rtd-documents.sh 
+# C1MQH7NLG944:~ peterdesjardins$ chmod a+x build-rtd-documents.sh
 # C1MQH7NLG944:~ peterdesjardins$ ls -l build-rtd-documents.sh
 # -rwxr-xr-x  1 peterdesjardins  staff  758 Feb  2 14:12 build-rtd-documents.sh
 
@@ -29,18 +29,18 @@ then
             open-edx-building-and-running-a-course
             open-edx-learner-guide
             edx-developer-guide
-            edx-open-learning-xml
-            xblock-tutorial
             edx-release-notes
-            course-catalog-api-guide
             "
 else
    DOC_IDS=${1}
 fi
-         
+
 # xblock - Removed this project because it is failing local builds
 # edx-platform-api - Removed from list because of its separate repo
 # edx-data-analytics-api - Removed from list because of its separate repo
+# edx-open-learning-xml - Removed from list, moved to Inactive status
+# course-catalog-api-guide - Removed from list, moved to Inactive status
+# xblock-tutorial - Removed from list, moved to Inactive status
 
 for DOC_ID in ${DOC_IDS}
 do
@@ -49,5 +49,5 @@ do
   echo "Building ${DOC_ID}"
   # Invoke the build API for the document ID using curl
   curl -X POST https://readthedocs.org/build/${DOC_ID}
-  
+
 done


### PR DESCRIPTION
## [DOC-3339](https://openedx.atlassian.net/browse/DOC-3339)

Removes guides now in inactive status from scripts that automate doc testing and building. I ran both scripts locally and received the expected results.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @nedbat @benpatterson 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Squash commits
