### PR TITLE
WIP: Reference `eucalyptus.2` tag instead of 1

### DIFF
--- a/en_us/install_operations/source/installation/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/installation/devstack/install_devstack.rst
@@ -117,13 +117,13 @@ To install devstack, follow these steps.
     information about the latest Open edX releases and the Git tag names for
     them, see `Open edX Releases Wiki page`_.
 
-    For example, ``open-release/eucalyptus.1`` is the Git tag name for the
-    first Eucalyptus release. The following command sets the value of the
-    ``OPENEDX_RELEASE`` environment variable to ``open-release/eucalyptus.1``.
+    For example, ``open-release/eucalyptus.2`` is the Git tag name for the
+    second Eucalyptus release. The following command sets the value of the
+    ``OPENEDX_RELEASE`` environment variable to ``open-release/eucalyptus.2``.
 
     .. code-block:: bash
 
-      export OPENEDX_RELEASE="open-release/eucalyptus.1"
+      export OPENEDX_RELEASE="open-release/eucalyptus.2"
 
     If you do not set this environment variable, Vagrant will install the most
     recent snapshot version of the Open edX platform. The snapshot version is

--- a/en_us/install_operations/source/installation/fullstack/install_fullstack.rst
+++ b/en_us/install_operations/source/installation/fullstack/install_fullstack.rst
@@ -57,13 +57,13 @@ To install fullstack follow these steps.
     information about the latest Open edX releases and the Git tag names for
     them, see the `Open edX Releases Wiki page`_.
 
-    For example, ``open-release/eucalyptus.1`` is the Git tag name for the
-    first Eucalyptus release. The following command sets the value of the
-    ``OPENEDX_RELEASE`` environment variable to ``open-release/eucalyptus.1``.
+    For example, ``open-release/eucalyptus.2`` is the Git tag name for the
+    second Eucalyptus release. The following command sets the value of the
+    ``OPENEDX_RELEASE`` environment variable to ``open-release/eucalyptus.2``.
 
     .. code-block:: bash
 
-      export OPENEDX_RELEASE="open-release/eucalyptus.1"
+      export OPENEDX_RELEASE="open-release/eucalyptus.2"
 
 #. Download the install script.
 

--- a/en_us/install_operations/source/platform_releases/eucalyptus.rst
+++ b/en_us/install_operations/source/platform_releases/eucalyptus.rst
@@ -57,7 +57,7 @@ required software to run the Open edX platform.
 If you are upgrading from the Dogwood release, see `Upgrading from Dogwood to
 Eucalyptus`_.
 
-Eucalyptus releases have Git tag names like ``open-release/eucalyptus.1``.
+Eucalyptus releases have Git tag names like ``open-release/eucalyptus.2``.
 The available names are detailed on the `Open edX Releases Wiki page`_.
 
 
@@ -90,7 +90,7 @@ edX, run the upgrade script for your type of installation.
 
     .. code-block:: bash
 
-        $ export OPENEDX_RELEASE=open-release/eucalyptus.1
+        $ export OPENEDX_RELEASE=open-release/eucalyptus.2
         $ curl -OL https://raw.github.com/edx/configuration/$OPENEDX_RELEASE/util/vagrant/upgrade.sh
 
 #.  Run the script.


### PR DESCRIPTION
**WIP: Do no merge yet**

Refer to `eucalyptus.2` instead of `eucalyptus.1`.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @nedbat
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
