### PR TITLE
Replace reference to architecture council with reference to OEP

### DIFF
--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -25,7 +25,8 @@ you don't have to rearchitect it late in your development cycle. We'll help you
 understand the analytics, performance, test, accessibility, and other various
 requirements up front. We'll also be able to let you know if work you're
 planning duplicates work edX or others are doing. Finally, we'll let you know
-if your work requires `architecture council review`_.
+if your proposal, or parts of your proposal, would benefit from the `Open edX
+Propsal (OEP) process`_.
 
 You can get in touch with us using our `Community Discussions`_.
 
@@ -62,7 +63,7 @@ overview of the process is here:
    :alt: A visualization of the pull request process
    :target: ../_images/pr-process.png
 
-.. _architecture council review: https://openedx.atlassian.net/wiki/display/OPEN/OSPR%3A+Architecture+Review
+.. _Open edX Propsal (OEP) process: https://oep.readthedocs.io/en/latest/oep-0001.html
 .. _The instructions here: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst#step-0-join-the-conversation
 .. _contribution agreement: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst#step-1-sign-a-contribution-agreement
 .. _edx-code mailing list: https://groups.google.com/forum/#!forum/edx-code

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -63,7 +63,7 @@ overview of the process is here:
    :alt: A visualization of the pull request process
    :target: ../_images/pr-process.png
 
-.. _Open edX Propsal (OEP) process: http://open-edx-proposals.readthedocs.io/en/latest/
+.. _Open edX Proposal (OEP) process: http://open-edx-proposals.readthedocs.io/en/latest/
 .. _The instructions here: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst#step-0-join-the-conversation
 .. _contribution agreement: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst#step-1-sign-a-contribution-agreement
 .. _edx-code mailing list: https://groups.google.com/forum/#!forum/edx-code

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -26,7 +26,7 @@ understand the analytics, performance, test, accessibility, and other various
 requirements up front. We'll also be able to let you know if work you're
 planning duplicates work edX or others are doing. Finally, we'll let you know
 if your proposal, or parts of your proposal, would benefit from the `Open edX
-Propsal (OEP) process`_.
+Proposal (OEP) process`_.
 
 You can get in touch with us using our `Community Discussions`_.
 
@@ -63,7 +63,7 @@ overview of the process is here:
    :alt: A visualization of the pull request process
    :target: ../_images/pr-process.png
 
-.. _Open edX Propsal (OEP) process: https://oep.readthedocs.io/en/latest/oep-0001.html
+.. _Open edX Propsal (OEP) process: http://open-edx-proposals.readthedocs.io/en/latest/
 .. _The instructions here: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst#step-0-join-the-conversation
 .. _contribution agreement: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst#step-1-sign-a-contribution-agreement
 .. _edx-code mailing list: https://groups.google.com/forum/#!forum/edx-code


### PR DESCRIPTION
Replace reference to architecture council with reference to OEP
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @shaunagm
- [ ] Subject matter expert: @cpennington 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
