### PR TITLE
[DOC-3236] - For people learning about XBlocks, test and correct directory location statements

### DIFF
--- a/en_us/xblock-tutorial/source/getting_started/setup_sdk.rst
+++ b/en_us/xblock-tutorial/source/getting_started/setup_sdk.rst
@@ -68,7 +68,6 @@ Then create the virtual environment in your ``xblock_development`` directory.
 
 .. include:: ../reusable/clone_sdk.rst
 
-When the requirements are installed, you are ready to :ref:`create your first
-XBlock <Create Your First XBlock>`.
+When the requirements are installed, you are in the ``xblock_development`` directory, which contains the ``venv`` and ``xblock-sdk`` subdirectories. You can now :ref:`create your first XBlock <Create Your First XBlock>`.
 
 .. include:: ../../../links/links.rst


### PR DESCRIPTION
## [DOC-3236](https://openedx.atlassian.net/browse/DOC-3236)

Added a note, informing the user which directory they are currently in.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

FYI: @shaunagm @lamagnifica 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
### Details About the Commit

I completed all the steps in these pages:
3.2 - SetUp XBlock
http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/getting_started/setup_sdk.html
3.3 - Create XBlock
http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/getting_started/create_first_xblock.html
3.2
At the end of third step, we are here:
xblock_development
+----- venv
+----- xblock-sdk current
The 4th (last) step in 3.2.3 is:
"Run the following command to return to the xblock_development directory, where you will perform the rest of your work."
I think that this line has no errors as the further steps in 3.3 are indeed triggered from 'xblock_development' directory itself (which we have told the user to navigate to, at the end of 3.2.3)
At this point, we are:
xblock_development current
+----- venv
+----- xblock-sdk
3.3
The first command to be run in 3.3.1 is 'xblock-sdk/bin/workbench-make-xblock'
This command is run from 'xblock_development' directory only. After successfully running this command and providing the short name and Class name, our directory structure looks like this:
xblock_development current
+----- myxblock
+----- venv
+----- xblock-sdk
3.3.2 i.e Install XBlock 'pip install -e myxblock' also works from 'xblock_development' folder and so does the further steps 3.3.3 and 3.3.4
