### PR TITLE
[DOC-3236] Added instruction to switch to correct directory

### DIFF
--- a/en_us/xblock-tutorial/source/reusable/create_xblock.rst
+++ b/en_us/xblock-tutorial/source/reusable/create_xblock.rst
@@ -5,8 +5,9 @@ Create an XBlock
 You use the XBlock SDK to create skeleton files for an XBlock. To do this,
 follow these steps at a command prompt.
 
-#. In the ``xblock_development`` directory, which contains the ``venv`` and
-   ``xblock-sdk`` directories, run the following command to create the skeleton
+#. Change to the ``xblock_development`` directory, which contains the ``venv`` and ``xblock-sdk`` subdirectories.
+
+#. Run the following command to create the skeleton
    files for the XBlock.
 
    .. code-block:: none


### PR DESCRIPTION
## [DOC-3236](https://openedx.atlassian.net/browse/DOC-3236)

Added a new step to elaborate which directory the user should be in, before they start creating the xblock. Please refer to the discussion on [this](https://github.com/edx/edx-documentation/pull/1273) PR for reference: 
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

FYI: Tag anyone else who might be interested in this PR here.
@lamagnifica @shaunagm 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
