### PR TITLE
Adds info that HTML tags can be added to label and description

### DIFF
--- a/en_us/shared/exercises_tools/checkbox.rst
+++ b/en_us/shared/exercises_tools/checkbox.rst
@@ -780,7 +780,8 @@ Children
 ``<label>``
 ***********
 
-Required. Identifies the question or prompt.
+Required. Identifies the question or prompt. You can include HTML tags within
+this element.
 
 Attributes
 ==========
@@ -795,7 +796,8 @@ None.
 ``<description>``
 *****************
 
-Optional. Provides clarifying information about how to answer the question.
+Optional. Provides clarifying information about how to answer the question. You
+can include HTML tags within this element.
 
 Attributes
 ==========

--- a/en_us/shared/exercises_tools/dropdown.rst
+++ b/en_us/shared/exercises_tools/dropdown.rst
@@ -412,7 +412,8 @@ Children
 ``<label>``
 ***********
 
-Required. Identifies the question or prompt.
+Required. Identifies the question or prompt. You can include HTML tags within
+this element.
 
 Attributes
 ==========
@@ -427,7 +428,8 @@ None.
 ``<description>``
 *****************
 
-Optional. Provides clarifying information about how to answer the question.
+Optional. Provides clarifying information about how to answer the question. You
+can include HTML tags within this element.
 
 Attributes
 ==========

--- a/en_us/shared/exercises_tools/math_expression_input.rst
+++ b/en_us/shared/exercises_tools/math_expression_input.rst
@@ -277,7 +277,8 @@ Children
 ``<label>``
 ***********
 
-Required. Identifies the question or prompt.
+Required. Identifies the question or prompt. You can include HTML tags within
+this element.
 
 Attributes
 ==========
@@ -292,7 +293,8 @@ None.
 ``<description>``
 *****************
 
-Optional. Provides clarifying information about how to answer the question.
+Optional. Provides clarifying information about how to answer the question. You
+can include HTML tags within this element.
 
 Attributes
 ==========

--- a/en_us/shared/exercises_tools/multiple_choice.rst
+++ b/en_us/shared/exercises_tools/multiple_choice.rst
@@ -537,7 +537,8 @@ Children
 ``<label>``
 ***********
 
-Required. Identifies the question or prompt.
+Required. Identifies the question or prompt. You can include HTML tags within
+this element.
 
 Attributes
 ==========
@@ -552,7 +553,8 @@ None.
 ``<description>``
 *****************
 
-Optional. Provides clarifying information about how to answer the question.
+Optional. Provides clarifying information about how to answer the question. You
+can include HTML tags within this element.
 
 Attributes
 ==========

--- a/en_us/shared/exercises_tools/numerical_input.rst
+++ b/en_us/shared/exercises_tools/numerical_input.rst
@@ -761,7 +761,8 @@ Children
 ``<label>``
 ***********
 
-Required. Identifies the question or prompt.
+Required. Identifies the question or prompt. You can include HTML tags within
+this element.
 
 Attributes
 ==========
@@ -776,7 +777,8 @@ None.
 ``<description>``
 *****************
 
-Optional. Provides clarifying information about how to answer the question.
+Optional. Provides clarifying information about how to answer the question. You
+can include HTML tags within this element.
 
 Attributes
 ==========

--- a/en_us/shared/exercises_tools/text_input.rst
+++ b/en_us/shared/exercises_tools/text_input.rst
@@ -604,7 +604,8 @@ Children
 ``<label>``
 ***********
 
-Required. Identifies the question or prompt.
+Required. Identifies the question or prompt. You can include HTML tags within
+this element.
 
 Attributes
 ==========
@@ -619,7 +620,8 @@ None.
 ``<description>``
 *****************
 
-Optional. Provides clarifying information about how to answer the question.
+Optional. Provides clarifying information about how to answer the question. You
+can include HTML tags within this element.
 
 Attributes
 ==========


### PR DESCRIPTION
## [DOC-3366](https://openedx.atlassian.net/browse/DOC-3366)

The label and description OLX elements can now include HTML tags.
### Date Needed

Releasing 4 Oct 2016
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @muhammad-ammar 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check): @edx/doc
- [ ] Product review: @sstack22 
- [ ] Partner support: 
- [ ] PM review: 

FYI: @cptvitamin 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Sandbox
- [ ] Live on [stage](https://studio.stage.edx.org/container/block-v1:Solutions+PB101+2015+type@vertical+block@155fcd56caab46d7af168ad992c419cb?action=new) (open the linked problem and view in the advanced editor)
### Post-review
- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
