### PR TITLE
Documented the Site fields in Third Party Auth

### DIFF
--- a/en_us/install_operations/source/configuration/tpa/index.rst
+++ b/en_us/install_operations/source/configuration/tpa/index.rst
@@ -5,10 +5,10 @@ Enabling Third Party Authentication
 #######################################
 
 To enhance sign in options for your users, you can enable third party
-authentication between institutional authentication systems and your
-implementation of the edX platform. After you enable third party
-authentication, users can register and sign in to your Open edX site with their
-campus or institutional credentials.
+authentication between institutional authentication systems and the sites you
+define for your implementation of the edX platform. After you enable third
+party authentication, users can register and sign in to your Open edX site with
+their campus or institutional credentials.
 
 .. toctree::
    :maxdepth: 1

--- a/en_us/install_operations/source/configuration/tpa/tpa_SAML_IdP.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_SAML_IdP.rst
@@ -4,7 +4,7 @@
 Integrating with a SAML Identity Provider
 ##########################################
 
-You can integrate your Open edX installation with federated identity solutions
+You can integrate your Open edX site with federated identity solutions
 that use the SAML 2.0 (Security Assertion Markup Language, version 2.0)
 standard. An example is Shibboleth, a single sign on system that is used by
 many educational institutions.
@@ -19,7 +19,7 @@ Exchange Metadata
 
 SAML metadata is an XML file that contains the information necessary for secure
 interactions between identity providers and security providers. You send the
-URL of your metadata file, created when you :ref:`configured your installation
+URL of your metadata file, created when you :ref:`configured your Open edX site
 as a SAML service provider<Configuring your Installation as a SAML Service
 Provider>`, to each identity provider that you want to add. Similarly, you
 obtain the metadata URLs from identity providers before you add and enable them
@@ -59,6 +59,10 @@ To add and enable a SAML 2.0 identity provider, follow these steps.
      Open edX and works with most SAML providers. Select a different option
      only if you have added a custom backend that provides additional
      functionality.
+
+   - **Site**: Select the site that you are configuring to use this IdP. Each
+     IdP can only belong to one site at a time. For more information about
+     sites in Open edX, see :ref:`Configuring Open edX sites`.
 
    - **IdP slug**: A short, unique name to identify this IdP in the URL. The
      slug becomes part of a URL, so the value that you enter cannot include

--- a/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
@@ -1,13 +1,13 @@
 .. _Configuring your Installation as a SAML Service Provider:
 
 ###############################################################
-Configuring your Installation as a SAML Service Provider
+Configuring your Open edX Site as a SAML Service Provider
 ###############################################################
 
-The first step in configuring your Open edX installation to act as a SAML SP is
+The first step in configuring your Open edX site to act as a SAML SP is
 to create a credential key pair to ensure secure data transfers with identity
 providers. To complete the configuration procedure, you configure your Open edX
-installation as a SAML SP, which creates your metadata XML file.
+site as a SAML SP, which creates your metadata XML file.
 
 .. contents::
    :local:
@@ -43,8 +43,8 @@ Add Keys to the LMS Configuration File
 .. note:: Configuration settings added to the ``lms.auth.json`` file are reset
  to their default values when you use Ansible to update edx-platform.
 
-To configure your Open edX installation with your public and private SAML keys,
-follow these steps.
+To configure an Open edX site with your public and private SAML keys, follow
+these steps.
 
 #. Open the ``edx/app/edxapp/lms.auth.json`` file in your text editor.
 
@@ -105,10 +105,10 @@ follow these steps.
 
 
 **************************************************
-Configure your Installation as a Service Provider
+Configure your Open edX Site as a Service Provider
 **************************************************
 
-To configure your Open edX installation as a SAML service provider, follow
+To configure your Open edX site as a SAML service provider, follow
 these steps.
 
 #. Sign in to the Django administration console for your base URL. For example,
@@ -116,6 +116,10 @@ these steps.
 
 #. In the **Third_Party_Auth** section, next to **SAML Configuration** select
    **Add**.
+
+   .. note:: If you want to change the configuration of an existing service
+    provider, next to **SAML Configuration** select **Change**, and then
+    select **Update** for the provider that you want to configure.
 
 #. Select **Enabled**.
 
@@ -125,6 +129,10 @@ these steps.
     uniquely identifies your site, the naming convention that edX recommends is
     to include the server's domain name. For example,
     ``http://saml.mydomain.com/``.
+
+  - **Site**: Specify the site that you are configuring to be a SAML service
+    provider. There can only be one SAML Service Provider per site. For more
+    information about Sites in Open edX, see :ref:`Configuring Open edX sites`.
 
   - **Organization Info**: Use the format in the example that follows to
     specify a language and locale code and identifying information for your

--- a/en_us/install_operations/source/configuration/tpa/tpa_providers.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_providers.rst
@@ -5,34 +5,33 @@ Supported Identity Providers
 #######################################
 
 In an exchange of authentication and authorization data, an identity provider
-securely asserts the identity and access rights of a set of users. Your
-implementation of the Open edX platform is the service provider that allows
-the users access on the basis of credentials sent by an identity provider.
+securely asserts the identity and access rights of a set of users. Your Open
+edX site is the service provider that allows the users access on the basis of credentials sent by an identity provider.
 
-For example, your Open edX installation hosts the courses of three different
-institutions. When you configure the open edX installation to be a service
+For example, your Open edX site hosts the courses of three different
+institutions. When you configure the Open edX site to be a service
 provider, and configure each of the three institutions to be identity
 providers, you permit learners who have valid user credentials at any of
-those institutions to access the Open edX site. 
+those institutions to access the Open edX site.
 
-.. You can enable third party authentication between your Open edX system and identity providers that use the SAML 2.0 (Security Assertion Markup Language, version 2.0) or OAuth2 standards for authentication. 
+.. You can enable third party authentication between your Open edX site and identity providers that use the SAML 2.0 (Security Assertion Markup Language, version 2.0) or OAuth2 standards for authentication.
 
-.. replace the first following sentence with the above when ready to add OAuth2 
+.. replace the first following sentence with the above when ready to add OAuth2
 .. - Alison 5 Aug 15
 
-You can enable third party authentication between your Open edX system and
+You can enable third party authentication between your Open edX site and
 identity providers that use the SAML 2.0 (Security Assertion Markup Language,
 version 2.0) standard for authentication. For more information, see
 :ref:`Integrating with a SAML Identity Provider`.
 
-.. Regardless of the standard that the identity provider you want to integrate with uses, you begin by :ref:`enabling the third party authentication feature<Enable the Third Party Authentication Feature>` for your installation.
+.. Regardless of the standard that the identity provider you want to integrate with uses, you begin by :ref:`enabling the third party authentication feature<Enable the Third Party Authentication Feature>` for your site.
 
-.. replace the following para with the above para when ready to add OAuth2 
+.. replace the following para with the above para when ready to add OAuth2
 .. - Alison 5 Aug 15
 
 At an Open edX installation, you begin by :ref:`enabling the third party
 authentication feature<Enable the Third Party Authentication Feature>` for your
-installation.
+site.
 
 At an institution that has a partner membership with edX, you can :ref:`enable
 third party authentication<Enabling Third Party Authentication Edge>` between
@@ -41,6 +40,6 @@ your institutional authentication systems and the edX Edge site.
 If you are using :ref:`edX as an LTI tool provider<Configuring an edX Instance
 as an LTI Tool Provider>` to a external learning management system or
 application, you can set up an authentication workflow between your Open edX
-system and the system that is the LTI tool consumer. For more information, see
+site and the system that is the LTI tool consumer. For more information, see
 :ref:`Options for LTI Authentication and User Provisioning` and
 :ref:`Configuring Open edX for LTI Authentication`.


### PR DESCRIPTION
## [DOC-3367](https://openedx.atlassian.net/browse/DOC-3367)

This PR adds documentation for the new Site fields in light of [ENT-16](https://openedx.atlassian.net/browse/ENT-16), which is set to be in the 2016-10-04 release of edX.

The feature adds support for having different SSO providers show up on different Sites by allowing edX operators to choose which Site a given SSO provider shows up on.
### Date Needed

The merge deadline for this documentation update is October 7th, 2016.
Support for specifying the Site for TPA providers/SAML Configurations is set to be in the 2016-10-04 release of edX.
### Reviewers
- [x] Subject matter expert: @douglashall 
- [x] Doc team review (sanity check): @edx/doc
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Release notes PR: https://github.com/edx/edx-documentation/pull/1291
