### PR TITLE
Added release note for SSO with Sites change

### DIFF
--- a/en_us/release_notes/source/2016/lms/lms_2016-10-03.rst
+++ b/en_us/release_notes/source/2016/lms/lms_2016-10-03.rst
@@ -14,3 +14,9 @@
 
 *  When learners select **Help** in an edx.org course, the :ref:`learners:edX
    Learner's Guide` now opens to a related topic.
+
+* Third Party Auth providers and SAML Configurations are now configured
+  per-Site, so a different selection of Third Party Auth SSO providers can be
+  made available to different Sites. This also means that any pre-existing SSO
+  providers are assigned automatically to the default Site in edX upon
+  upgrading to this release.


### PR DESCRIPTION
This change adds a release note for [ENT-16](https://github.com/edx/edx-platform/pull/13474) to help alert on-lookers of the oncoming change to the behavior of Third Party Auth SSO providers.

There's a related PR to document the new Site fields [here](https://github.com/edx/edx-documentation/pull/1290).
### Reviewers
- [ ] Subject matter expert: @douglashall 
- [ ] Doc team review: @edx/doc
