### PR TITLE
Change edx.ui.lms.sequence.link_clicked.

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -605,7 +605,7 @@ course content.
 
 ``event`` **Member Fields**:
 
-The ``edx.ui.lms.sequence.link_clicked`` event includes both a ``name`` field
+The ``edx.ui.lms.link_clicked`` event includes both a ``name`` field
 and an ``event_type`` field. For more information about these common fields,
 see :ref:`common`.
 
@@ -628,8 +628,8 @@ see :ref:`common`.
      - The URL of the page that the selected link leads to.
 
 
-Example ``edx.ui.lms.sequence.link_clicked`` Event
-***************************************************
+Example ``edx.ui.lms.link_clicked`` Event
+*****************************************
 
 The following example shows the relevant fields of the event that is emitted
 when a user selects any hypertext link from the course content.


### PR DESCRIPTION
## [DOC-3415](https://openedx.atlassian.net/browse/DOC-3415)

Replaced two instances of "edx.ui.lms.sequence.link_clicked" with "edx.ui.lms.link_clicked".

Bug fix:  not needed on any timescale.

Original doc story was DOC-3005.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @stroilova 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
