### PR TITLE
Removes enable step for supported DnD problem type

### DIFF
--- a/en_us/shared/exercises_tools/drag_and_drop.rst
+++ b/en_us/shared/exercises_tools/drag_and_drop.rst
@@ -29,12 +29,12 @@ Overview of Drag and Drop Problems
 
 A drag and drop problem includes a background image and one or more items that
 learners can drag into target zones on the background image. You can include as
-many draggable items and as many target zones as you need. You can include decoy
-items that do not have a target and you can include decoy targets that do not
-correspond to draggable items.
+many draggable items and as many target zones as you need. You can include
+decoy items that do not have a target, and you can include decoy targets that
+do not correspond to draggable items.
 
 When learners view a drag and drop problem in the LMS, the problem includes a
-top section and a bottom section. Learners drag items from the top section  on
+top section and a bottom section. Learners drag items from the top section on
 to the background image in the section below it.
 
 The way that a learner selects, or grabs, an item depends on the type of
@@ -50,8 +50,9 @@ You can configure a drag and drop problem to give learners unlimited attempts
 to match items to target zones or you can configure it to behave restrictively,
 like a test.
 
-* In standard mode, the problem gives learners unlimited attempts
-  to match items and it provides immediate feedback to indicate whether an item is matched correctly.
+* In standard mode, the problem gives learners unlimited attempts to match
+  items and it provides immediate feedback to indicate whether an item is
+  matched correctly.
 
 * In assessment mode, learners must match all of the draggable items to target
   zones and then submit the problem. The problem does not reveal
@@ -105,10 +106,10 @@ drag items onto.
 A target zone is a rectangular area on the background image. You can show or
 hide the borders of a zone for learners. You can add titles for zones or leave
 the **Title** field empty. However, you must fill in the **Description** field
-for each zone. The description is only exposed to screen readers. The description
-must describe the content of the zone for visually impaired learners. For
-example, a zone that includes an apple might have a description that says
-"A round, red fruit with a stem."
+for each zone. The description is only exposed to screen readers. The
+description must describe the content of the zone for visually impaired
+learners. For example, a zone that includes an apple might have a description
+that says "A round, red fruit with a stem."
 
 A background image must fit within the course screen. The LMS automatically
 scales images that are too wide. If you choose a background image that is
@@ -248,39 +249,11 @@ reveals which items are correctly matched and gives learners an opportunity to
 move items that are not correct. If you do not specify a limit, learners have
 unlimited attempts.
 
-.. _enabling_drag_and_drop_problem:
-
-********************************
-Enabling Drag and Drop Problems
-********************************
-
-Before you can add drag and drop problems, you must enable the drag and drop
-problem type for your course.
-
-To enable the drag and drop problem type, you add the ``"drag-and-drop-v2"``
-key to the **Advanced Module List** on the **Advanced Settings** page. (Be sure
-to include the quotation marks around the key value.) For more information, see
-:ref:`Enable Additional Exercises and Tools`.
-
-After you enable the ``drag-and-drop-v2`` problem type, **Drag and Drop**
-appears in the **Advanced** menu of the **Add New Component** screen.
-
-.. note::
-    By default, your course includes a **Drag and Drop** problem type in the
-    **Problem > Advanced** menu of the **Add New Component** screen. This is an
-    older drag and drop problem type that has been replaced by the ``drag-and-
-    drop-v2`` advanced module in the **Advanced** menu of the **Add New
-    Component** screen.
-
 .. _creating_a_drag_and_drop_problem:
 
 *********************************
 Creating a Drag and Drop Problem
 *********************************
-
-You must enable the drag and drop problem type for your course before you can
-add a drag and drop problem. For more information, see
-:ref:`enabling_drag_and_drop_problem`.
 
 To create a drag and drop problem, follow these steps.
 
@@ -332,10 +305,8 @@ To create a drag and drop problem, follow these steps.
      target zone for each item in the **Zone** field. Add a label, success
      feedback text, and error feedback text. For more information about how the
      text in these fields appears, see
-     :ref:`overview_of_drag_and_drop_problems`.  For more information about
-     draggable items, see
-     :ref:`drag_and_drop_draggable_items`.
-
+     :ref:`overview_of_drag_and_drop_problems`. For more information about
+     draggable items, see :ref:`drag_and_drop_draggable_items`.
 
 .. _drag_and_drop_editor_fields:
 

--- a/en_us/shared/exercises_tools/drag_and_drop_deprecated.rst
+++ b/en_us/shared/exercises_tools/drag_and_drop_deprecated.rst
@@ -5,11 +5,13 @@ Drag and Drop Problem (Deprecated)
 ##################################
 
 .. note::
-    EdX does not support this problem type. This drag and drop problem type has
-    been replaced by a newer drag and drop problem type. The newer drag and drop
-    problem type includes significant improvements and you should use it for any
-    new course development. For more information about the replacement drag and
-    drop problem type, see :ref:`drag_and_drop_problem`.
+    EdX does not support this problem type.
+
+This drag and drop problem type has been replaced by a newer drag and drop
+problem type. The newer drag and drop problem type includes significant
+improvements and you should use it for any new course development. For more
+information about the replacement drag and drop problem type, see
+:ref:`drag_and_drop_problem`.
 
 .. warning::
 
@@ -27,21 +29,22 @@ Drag and Drop Problem (Deprecated)
    option in the problem component, a **Show Answer** button appears in the
    LMS, but the button does not work.
 
-.. note:: EdX offers provisional support for this problem type.
-
 In drag and drop problems, learners respond to a question by dragging text or
 objects to a specific location on an image.
 
 .. image:: ../../../shared/images/DragAndDropProblem.png
- :alt: Image of a drag and drop problem
+ :alt: Image of a drag and drop problem.
 
 *********************************
-Creating a Drag and Drop Problem
+Adding a Drag and Drop Problem
 *********************************
 
-To create a simple drag and drop problem in which learners drag labels onto an
-image, you upload the image that you want learners to drag labels onto, and
-then create a problem component.
+Before you can include problems that use this deprecated problem type in your
+course, you must configure your course to :ref:`add unsupported problems
+<Add_Unsupported_Exercises_Problems>`.
+
+To create a drag and drop problem, you upload the image that you want learners
+to drag labels onto, and then create a problem component.
 
 #. On the **Files & Uploads** page, upload your image file. For more
    information about uploading files, see :ref:`Add Files to a Course`.
@@ -74,7 +77,7 @@ then create a problem component.
     want your learners to drag the Iceland label to an area in the upper-left
     part of the image and drag a Sweden label near the lower-right part of your
     image, the code would resemble the following (where 2 is the ID for the
-    Sweden label):
+    Sweden label).
 
     .. code-block:: xml
 
@@ -82,7 +85,8 @@ then create a problem component.
                 '1':    [[50, 50], 75]
                 '2':    [[550, 350], 75]}
 
-    .. note:: Make sure the code contains the closing curly brace (**}**).
+    .. note:: Make sure the code contains the closing curly brace (``}``).
+
 #. Click **Save**.
 
 ==========================================


### PR DESCRIPTION
## [DOC-3406](https://openedx.atlassian.net/browse/DOC-3406)

Per [SOL-1602](https://openedx.atlassian.net/browse/SOL-1612), only one (the newer) DnD problem type is supported. It appears without an enablement step on the list of advanced problems available to add in Studio. 
The older DnD problem type is now completely deprecated, and does not appear as an option in Studio unless you configure your course to add unsupported problems. 
### Date Needed

ASAP, released today.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @haikuginger 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @mattdrayer @sstack22 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
