### PR TITLE
DOC-3379, DOC-3380 - update text in doc to reflect course navigation UI changes

### DIFF
--- a/en_us/shared/developing_course/course_outline.rst
+++ b/en_us/shared/developing_course/course_outline.rst
@@ -90,10 +90,11 @@ your course content.
    learners select a subsection. A tooltip with the unit's name appears when
    learners move the pointer onto an icon.
 
-   Learners select icons in the unit navigation bar to access course units.
-   They can also use the **Previous** and **Next** options at either end of the
-   unit navigation bar to move back to the previous unit or forward to the next
-   unit.
+   Learners select icons in the unit navigation bar to access course units. They
+   can also use the **Previous** and **Next** options at either end of the unit
+   navigation bar to move back to the previous unit or forward to the next unit.
+   The current unit is indicated with bold underlining in the unit navigation
+   bar.
 
 .. _Navigating the Course Outline:
 

--- a/en_us/shared/developing_course/course_units.rst
+++ b/en_us/shared/developing_course/course_units.rst
@@ -69,11 +69,11 @@ Viewing Units as a Learner
 
 To a learner using the edX learning management system (LMS), each unit in the
 subsection is represented by an icon in the unit navigation bar at the top of
-the **Course** page. The components in the selected unit appear below the unit
+the **Course** page. The current unit is indicated with bold underlining in the
+unit navigation bar. The components in the current unit appear below the unit
 navigation bar.
 
-The following image shows a subsection with five units in the LMS. The fourth
-unit is open.
+The following image shows a subsection in the LMS that contains several units.
 
 .. image:: ../../../shared/images/Units_LMS.png
  :alt: A unit in the LMS, with all of the unit icons in the unit navigation bar

--- a/en_us/shared/students/SFD_licensing.rst
+++ b/en_us/shared/students/SFD_licensing.rst
@@ -74,7 +74,7 @@ the bottom of the page when you view content in the **Course** tab.
 
 .. image:: ../../shared/images/learner_course_license.png
   :alt: A course unit page with a pointer to the license.
-  :width: 600
+  :width: 300
 
 If a video has a different license than the course as a whole, you see
 the license at the bottom right of the video player.


### PR DESCRIPTION
## [DOC-3379](https://openedx.atlassian.net/browse/DOC-3379), ## [DOC-3380](https://openedx.atlassian.net/browse/DOC-3380)

This PR updates learner and course team doc that is no longer accurate based on course navigation UI changes.
### Date Needed - already released.
### Reviewers
- [x] Doc team review (sanity check): @edx/doc 
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
