### PR TITLE
fixed redirects

### DIFF
--- a/en_us/developers/source/analytics.rst
+++ b/en_us/developers/source/analytics.rst
@@ -319,11 +319,11 @@ of the open edX community understand your intent and use the events correctly.
 You might find the following references helpful as you prepare your PR. 
 
 * The *edX Platform Developer's Guide* provides guidelines for `contributing
-  to open edX <http://edx.readthedocs.org/projects/edx-developer-
+  to open edX <http://edx.readthedocs.io/projects/edx-developer-
   guide/en/latest/process/index.html>`_.
 
 * The `edX Research
-  Guide <http://edx.readthedocs.org/projects/devdata/en/latest/>`_ is a
+  Guide <http://edx.readthedocs.io/projects/devdata/en/latest/>`_ is a
   reference for information about emitted events that are included in the edX
   tracking logs.
 

--- a/en_us/developers/source/extending_platform/javascript.rst
+++ b/en_us/developers/source/extending_platform/javascript.rst
@@ -29,11 +29,11 @@ See :ref:`The Custom JavaScript Display and Grading Example Template` for
 information about the template application built in to edX Studio.
 
 Course teams should see the following sections of the `Building and Running an
-edX Course <http://edx.readthedocs.org/projects/ca/en/latest/>`_ guide.
+edX Course <http://edx.readthedocs.io/projects/ca/en/latest/>`_ guide.
 
-* `Custom JavaScript Display and Grading <http://edx.readthedocs.org/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_
+* `Custom JavaScript Display and Grading <http://edx.readthedocs.io/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_
 
-* `Establishing a Grading Policy <http://edx.readthedocs.org/projects/ca/en/latest/building_course/establish_grading_policy.html>`_
+* `Establishing a Grading Policy <http://edx.readthedocs.io/projects/ca/en/latest/building_course/establish_grading_policy.html>`_
 
 The rest of this section provides more information for developers who are
 creating JavaScript applications for courses on the edX platform.
@@ -78,7 +78,7 @@ optionally to provide feedback as a formative assessment.
 #. In edX Studio, upload an HTML file that contains the JavaScript you want to
    show students.
 #. Copy the **Embed URL** of the file.
-#. `Create a Custom JavaScript Display and Grading Problem <http://edx.readthedocs.org/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_. The template
+#. `Create a Custom JavaScript Display and Grading Problem <http://edx.readthedocs.io/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_. The template
    for the problem contains the definition for a sample JavaScript application
    that requires and grades student interaction.
 #. Edit the XML of the component to remove grading information and refer to the

--- a/en_us/developers/source/extending_platform/js_template_example.rst
+++ b/en_us/developers/source/extending_platform/js_template_example.rst
@@ -4,7 +4,7 @@
 The Custom JavaScript Display and Grading Example Template
 ###########################################################
 
-As referred to in `course team documentation <http://edx.readthedocs.org/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_, there is a built-in template in edX Studio that uses a sample JavaScript application.
+As referred to in `course team documentation <http://edx.readthedocs.io/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_, there is a built-in template in edX Studio that uses a sample JavaScript application.
 
 This sample application has students select two different shapes, a cone and a
 cube. The correct state is when the cone is selected and the cube is not

--- a/en_us/developers/source/process/code-considerations.rst
+++ b/en_us/developers/source/process/code-considerations.rst
@@ -282,6 +282,6 @@ you have questions, please contact us at docs@edx.org.
 
 
 
-.. _cover letter: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/cover-letter.html
+.. _cover letter: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/process/cover-letter.html
 .. _GitHub repository: https://github.com/edx/edx-documentation
 .. _edX documentation: http://docs.edx.org

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -83,10 +83,10 @@ questions or concerns.
 For XBlocks you intend to install on edx.org, please also read the `XBlock
 Review Guidelines`_.
 
-.. _Internationalization Coding Guidelines: https://openedx.atlassian.net/wiki/edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _Internationalization Coding Guidelines: https://openedx.atlassian.net/wiki/edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/i18n.html
 .. _RTL UI Best Practices: https://github.com/edx/edx-platform/wiki/RTL-UI-Best-Practices
-.. _Accessibility Guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/accessibility.html
-.. _Analytics Guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/analytics.html
+.. _Accessibility Guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/accessibility.html
+.. _Analytics Guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/analytics.html
 .. _Eventing Design and Review Process: https://openedx.atlassian.net/wiki/display/AN/Eventing+Design+and+Review+Process
 .. _XBlock Review Guidelines: https://openedx.atlassian.net/wiki/display/OPEN/XBlock+review+guidelines
 

--- a/en_us/landing_page/source/index.rst
+++ b/en_us/landing_page/source/index.rst
@@ -36,4 +36,4 @@ If you use or host an Open edX site
   Platform`.
 
 .. _docs.edx.org: https://docs.edx.org
-.. _edX Release Notes: http://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -10,11 +10,11 @@
 
 .. _Coming Soon Programs Page: https://open.edx.org/announcements/coming-soon-xseries-programs-page
 
-.. _Using edX Insights: http://edx.readthedocs.org/projects/edx-insights/en/latest/
+.. _Using edX Insights: http://edx.readthedocs.io/projects/edx-insights/en/latest/
 
-.. _Review Answers to Graded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Answers.html#review-answers-to-graded-problems
+.. _Review Answers to Graded Problems: http://edx.readthedocs.io/projects/edx-insights/en/latest/performance/Performance_Answers.html#review-answers-to-graded-problems
 
-.. _Review Answers to Ungraded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Ungraded.html#review-answers-to-ungraded-problems
+.. _Review Answers to Ungraded Problems: http://edx.readthedocs.io/projects/edx-insights/en/latest/performance/Performance_Ungraded.html#review-answers-to-ungraded-problems
 
 .. _Open edX Analytics wiki: http://edx-wiki.atlassian.net/wiki/display/OA/Open+edX+Analytics+Home
 
@@ -22,7 +22,7 @@
 
 .. _Entity Relationship Diagram for ORA Data: https://openedx.atlassian.net/wiki/display/AN/Entity+Relationship+Diagram+for+ORA+Data
 
-.. _edX Enrollment API: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/enrollment/index.html
+.. _edX Enrollment API: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/enrollment/index.html
 
 .. _course-data: http://groups.google.com/a/edx.org/forum/#!forum/course-data
 
@@ -404,7 +404,7 @@
 
 .. _Dogwood blog post: https://open.edx.org/blog/newest-open-edx-release-dogwood-now-available
 
-.. _Adding E-Commerce to the Open edX Platform (Dogwood): http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-dogwood.rc/ecommerce/index.html
+.. _Adding E-Commerce to the Open edX Platform (Dogwood): http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-dogwood.rc/ecommerce/index.html
 
 .. _Open edX Conference: http://con.openedx.org/
 

--- a/en_us/olx/source/about/overview.rst
+++ b/en_us/olx/source/about/overview.rst
@@ -79,7 +79,7 @@ Replace the placeholders in the following template with your information.
       <article class="response">
         <h3>What web browser should I use?</h3>
         <p>The Open edX platform works best with the current versions of Chrome, Firefox, Safari, and Microsoft Edge.</p>
-        <p>See our <a href="http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
+        <p>See our <a href="http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
       </article>
       <article class="response">
         <h3>Question 2?</h3>

--- a/en_us/open_edx_course_authors/source/course_features/lti/index.rst
+++ b/en_us/open_edx_course_authors/source/course_features/lti/index.rst
@@ -32,5 +32,5 @@ You use the topics in this section to prepare your course for reuse.
 You can also include content from an LTI provider in your Open edX courses. For
 more information, see :ref:`LTI Component`.
 
-.. _Configuring an edX Instance as an LTI Tool Provider: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/configuration/lti/index.html
+.. _Configuring an edX Instance as an LTI Tool Provider: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/lti/index.html
 

--- a/en_us/open_edx_course_authors/source/front_matter/change_log.rst
+++ b/en_us/open_edx_course_authors/source/front_matter/change_log.rst
@@ -208,7 +208,7 @@ Apr-Jun 2015
      - Updated the :ref:`Add a Course Update` section to include information
        about sending notifications to the edX mobile applications.
    * -
-     - Added the list of `Mobile-Ready Problem Types <http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/create_exercises_and_tools.html#mobile-ready-problem-types>`_.
+     - Added the list of `Mobile-Ready Problem Types <http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/create_exercises_and_tools.html#mobile-ready-problem-types>`_.
    * -
      - Added the :ref:`Setting Up Course Certificates` section.
    * -

--- a/en_us/open_edx_release_notes/source/links.rst
+++ b/en_us/open_edx_release_notes/source/links.rst
@@ -7,37 +7,37 @@
 
 .. Latest Doc Links
 
-.. _edX Release Notes: http://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/
 
-.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/
+.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/
 
-.. _Open edX Developer's Guide: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/
+.. _Open edX Developer's Guide: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/
 
-.. _Open edX Data Analytics API: http://edx.readthedocs.org/projects/edx-data-analytics-api/en/latest/index.html
+.. _Open edX Data Analytics API: http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/index.html
 
-.. _EdX XBlock Tutorial: http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/
+.. _EdX XBlock Tutorial: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/
 
-.. _EdX XBlock API Guide: http://edx.readthedocs.org/projects/xblock/en/latest/
+.. _EdX XBlock API Guide: http://edx.readthedocs.io/projects/xblock/en/latest/
 
-.. _EdX Open Learning XML Guide: http://edx.readthedocs.org/projects/edx-open-learning-xml/en/latest/
+.. _EdX Open Learning XML Guide: http://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/
 
-.. _Open edX Platform APIs: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
+.. _Open edX Platform APIs: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
 
-.. _Mobile API: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
+.. _Mobile API: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
 
-.. _Enrollment API: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
+.. _Enrollment API: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
 
-.. _Course Structure API Version 0: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/course_structure/index.html
+.. _Course Structure API Version 0: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/course_structure/index.html
 
-.. _Building and Running an Open edX Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/index.html
+.. _Building and Running an Open edX Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/index.html
 
-.. _Open edX Learner's Guide: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/index.html
+.. _Open edX Learner's Guide: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/index.html
 
-.. _Events in Tracking Logs: http://edx.readthedocs.org/projects/devdata/en/latest/internal_data_formats/tracking_logs.html
+.. _Events in Tracking Logs: http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs.html
 
-.. _User API Version 1.0: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/user/index.html
+.. _User API Version 1.0: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/user/index.html
 
-.. _Profile Images API Version 1.0: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/profile_images/index.html
+.. _Profile Images API Version 1.0: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/profile_images/index.html
 
 .. Eucalyptus doc links
 
@@ -53,17 +53,17 @@
 
 .. _Installing, Configuring, and Running the Open edX Platform Dogwood Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-dogwood.rc/platform_releases/dogwood.html
 
-.. _Building and Running an Open edX Course for Dogwood: http://edx.readthedocs.org/projects/open-edx-ca/en/dogwood/
+.. _Building and Running an Open edX Course for Dogwood: http://edx.readthedocs.io/projects/open-edx-ca/en/dogwood/
 
-.. _Open edX Learner's Guide for Dogwood: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/dogwood/
+.. _Open edX Learner's Guide for Dogwood: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/dogwood/
 
 .. Cypress Doc Links
 
-.. _Enabling Badges: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_badging.html
+.. _Enabling Badges: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_badging.html
 
-.. _Enable or Disable Badges for Your Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html?highlight=badges#enable-or-disable-badges-for-your-course
+.. _Enable or Disable Badges for Your Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html?highlight=badges#enable-or-disable-badges-for-your-course
 
-.. _Upload a Badge to Mozilla Backpack: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/SFD_certificates.html?highlight=badges#upload-a-badge-to-mozilla-backpack
+.. _Upload a Badge to Mozilla Backpack: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/SFD_certificates.html?highlight=badges#upload-a-badge-to-mozilla-backpack
 
 .. _base.py: https://github.com/edx/edx-ora2/blob/a4ce7bb00190d7baff60fc90fb613229565ca7ef/openassessment/fileupload/backends/base.py
 
@@ -73,75 +73,75 @@
 
 .. _Version 3 of the YouTube API: https://developers.google.com/youtube/v3/
 
-.. _Set YouTube API Key: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/youtube_api.html
+.. _Set YouTube API Key: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/youtube_api.html
 
-.. _Enabling Third Party Authentication: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/tpa/index.html
+.. _Enabling Third Party Authentication: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/tpa/index.html
 
-.. _Enabling Course and Video Licensing: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_licensing.html
+.. _Enabling Course and Video Licensing: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_licensing.html
 
-.. _Enabling Custom Courses: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_ccx.html
+.. _Enabling Custom Courses: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_ccx.html
 
-.. _Searching the Course: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/SFD_course_search.html
+.. _Searching the Course: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/SFD_course_search.html
 
-.. _Installing, Configuring, and Running the Open edX Platform Cypress Release: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/
+.. _Installing, Configuring, and Running the Open edX Platform Cypress Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/
 
-.. _Building and Running an Open edX Course for Cypress: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/index.html
+.. _Building and Running an Open edX Course for Cypress: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/index.html
 
-.. _Open edX Learner's Guide for Cypress: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/index.html
+.. _Open edX Learner's Guide for Cypress: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/index.html
 
-.. _Open Response Assessments: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/open_response_assessments/index.html
+.. _Open Response Assessments: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/open_response_assessments/index.html
 
-.. _Adding Feedback and Hints to a Problem: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/create_problem.html#adding-feedback-and-hints-to-a-problem
+.. _Adding Feedback and Hints to a Problem: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/create_problem.html#adding-feedback-and-hints-to-a-problem
 
-.. _Poll Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/poll_question.html
+.. _Poll Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/poll_question.html
 
-.. _Survey Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/survey.html
+.. _Survey Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/survey.html
 
-.. _Licensing a Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/licensing_course.html
+.. _Licensing a Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/licensing_course.html
 
-.. _Course and Video Licenses: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/SFD_licensing.html
+.. _Course and Video Licenses: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/SFD_licensing.html
 
-.. _Working with Libraries: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/libraries.html
+.. _Working with Libraries: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/libraries.html
 
-.. _Exploring the Profile Page: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/getting_started/dashboard_acctsettings_profile.html#exploring-the-profile-page
+.. _Exploring the Profile Page: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/getting_started/dashboard_acctsettings_profile.html#exploring-the-profile-page
 
-.. _Exploring the Profile Page for Learners: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-profile-page
+.. _Exploring the Profile Page for Learners: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-profile-page
 
-.. _Including Learner Cohorts: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/cohorts/index.html
+.. _Including Learner Cohorts: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/cohorts/index.html
 
-.. _Setting Up Course Certificates: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html
+.. _Setting Up Course Certificates: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html
 
-.. _Interpret the Grade Report: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#interpret-the-problem-grade-report
+.. _Interpret the Grade Report: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#interpret-the-problem-grade-report
 
-.. _Generate a Problem Grade Report for Enrolled Students: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#generate-a-problem-grade-report-for-enrolled-students-all-courses
+.. _Generate a Problem Grade Report for Enrolled Students: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#generate-a-problem-grade-report-for-enrolled-students-all-courses
 
-.. _Enrollment: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_enrollment.html
+.. _Enrollment: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_enrollment.html
 
-.. _Creating a Custom Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/custom_courses.html
+.. _Creating a Custom Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/custom_courses.html
 
-.. _Enable Course Search: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/edx_search.html
+.. _Enable Course Search: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/edx_search.html
 
-.. _Course Search: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/search_course.html
+.. _Course Search: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/search_course.html
 
 .. Birch Links
 
-.. _Building and Running an Open edX Course for Birch: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/index.html
+.. _Building and Running an Open edX Course for Birch: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/index.html
 
-.. _Including Student Cohorts: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/cohorts/index.html
+.. _Including Student Cohorts: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/cohorts/index.html
 
-.. _Working with Content Libraries: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/creating_content/libraries.html
+.. _Working with Content Libraries: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/creating_content/libraries.html
 
-.. _Specify Prerequisite Courses: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#specify-prerequisite-courses
+.. _Specify Prerequisite Courses: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#specify-prerequisite-courses
 
-.. _Require an Entrance Exam: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#require-an-entrance-exam
+.. _Require an Entrance Exam: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#require-an-entrance-exam
 
-.. _Student Notes Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/student_notes.html
+.. _Student Notes Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/student_notes.html
 
-.. _Rerunning a Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/course_rerun.html
+.. _Rerunning a Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/course_rerun.html
 
-.. _Google Calendar Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_calendar.html
+.. _Google Calendar Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_calendar.html
 
-.. _Google Drive Files Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_docs.html
+.. _Google Drive Files Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_docs.html
 
 
 .. _Sphinx: http://sphinx-doc.org/

--- a/en_us/shared/accessibility/best_practices_course_content_dev.rst
+++ b/en_us/shared/accessibility/best_practices_course_content_dev.rst
@@ -672,7 +672,7 @@ you use MathJax to author your math content. MathJax renders math in a variety
 of formats on the client side, offering the end user the ability to consume
 math content in their preferred format. EdX Studio supports authoring math
 directly in LaTeX using the `LaTeX Source Compiler
-<https://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/create_html_component.html#import-latex-code>`_ to transform LaTeX into MathJax.
+<https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/creating_content/create_html_component.html#import-latex-code>`_ to transform LaTeX into MathJax.
 
 ======================================================
 Accessible Mathematical Content Resources

--- a/en_us/shared/developing_course/course_components.rst
+++ b/en_us/shared/developing_course/course_components.rst
@@ -252,7 +252,7 @@ You develop parent and child components in XML, then import the XML course into
 Studio to verify that the structure is as you intended.
 
 For more information about working with your course's XML files, including
-information about terminology, see the `EdX Open Learning XML Guide <https://edx.readthedocs.org/projects/edx-open-learning-xml/en/latest/>`_.
+information about terminology, see the `EdX Open Learning XML Guide <https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/>`_.
 
 The following examples show the XML used to create the unit and components
 shown in Studio above.

--- a/en_us/shared/preface.rst
+++ b/en_us/shared/preface.rst
@@ -457,9 +457,9 @@ email message to info@edx.org.
 For opportunities to meet others who are interested in edX courses, check the
 edX Global Community meetup_ group.
 
-.. _Building and Running an edX Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/
-.. _Building and Running an Open edX Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/
-.. _Building and Running an Open edX Course - latest: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/
+.. _Building and Running an edX Course: http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/
+.. _Building and Running an Open edX Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/
+.. _Building and Running an Open edX Course - latest: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/
 .. _docs@edx.org: docs@edx.org
 .. _edx101: https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VIIJbWTF_yM
 .. _StudioX: https://www.edx.org/course/creating-course-edx-studio-edx-studiox#.VRLYIJPF8kR
@@ -468,7 +468,7 @@ edX Global Community meetup_ group.
 .. _edX Partner Support: https://partners.edx.org/edx_zendesk
 .. _edx-code: http://groups.google.com/forum/#!forum/edx-code
 .. _edx/configuration: http://github.com/edx/configuration/wiki
-.. _edX Data Analytics API: http://edx.readthedocs.org/projects/edx-data-analytics-api/en/latest/index.html
+.. _edX Data Analytics API: http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/index.html
 .. _docs.edx.org: http://docs.edx.org
 .. _edx/edx-analytics-dashboard: https://github.com/edx/edx-analytics-dashboard
 .. _edx/edx-platform: https://github.com/edx/edx-platform
@@ -476,27 +476,27 @@ edX Global Community meetup_ group.
 .. _edX Open Learning XML Guide: http://edx-open-learning-xml.readthedocs.org/en/latest/index.html
 .. _edX Partner Portal: https://partners.edx.org
 .. _forums: https://partners.edx.org/forums/partner-forums
-.. _edX Platform APIs: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
-.. _edX Platform Developer's Guide: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/
-.. _edX Research Guide: http://edx.readthedocs.org/projects/devdata/en/latest/
-.. _edX Release Notes: http://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Platform APIs: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
+.. _edX Platform Developer's Guide: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/
+.. _edX Research Guide: http://edx.readthedocs.io/projects/devdata/en/latest/
+.. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/
 .. _edX Status: http://status.edx.org/
 .. _edx-tools: https://github.com/edx/edx-tools/wiki
 .. _frequently asked questions: http://www.edx.org/student-faq
-.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/
+.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/
 .. _meetup: http://www.meetup.com/edX-Global-Community/
 .. _openedx-analytics: http://groups.google.com/forum/#!forum/openedx-analytics
 .. _Open edX Analytics: http://edx-wiki.atlassian.net/wiki/display/OA/Open+edX+Analytics+Home
-.. _Open edX Learner's Guide: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/
+.. _Open edX Learner's Guide: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/
 .. _openedx-ops: http://groups.google.com/forum/#!forum/openedx-ops
 .. _Open edX Portal: https://open.edx.org
 .. _open.edx.org/user/register: https://open.edx.org/user/register
-.. _Open edX Release Notes: http://edx.readthedocs.org/projects/open-edx-release-notes/en/latest/
+.. _Open edX Release Notes: http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/
 .. _openedx-studio: http://groups.google.com/forum/#!forum/openedx-studio
 .. _openedx-translation: http://groups.google.com/forum/#!forum/openedx-translation
 .. _open Confluence wiki: http://openedx.atlassian.net/wiki/
 .. _partners.edx.org: https://partners.edx.org
 .. _Twitter:  http://twitter.com/edXstatus
 .. _Using edX Insights: http://edx-insights.readthedocs.org/en/latest/
-.. _Open EdX XBlock API Guide: http://edx.readthedocs.org/projects/xblock/en/latest/
-.. _Open edX XBlock Tutorial: http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/index.html
+.. _Open EdX XBlock API Guide: http://edx.readthedocs.io/projects/xblock/en/latest/
+.. _Open edX XBlock Tutorial: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/index.html

--- a/en_us/shared/set_up_course/search_course.rst
+++ b/en_us/shared/set_up_course/search_course.rst
@@ -26,7 +26,7 @@ When the search engine returns results, either for an individual course or
 across all courses, learners can select any search result to view that result
 in the course body.
 
-For more information about the student experience, see `Searching the Course <http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/SFD_course_search.html>`_.
+For more information about the student experience, see `Searching the Course <http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/SFD_course_search.html>`_.
 
 .. note::
  Studio indexes most content that learners see on the **Course** page. However,

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -72,7 +72,7 @@ DEVELOPERS = object()
 HELP_LINKS = {
     (PARTNER, COURSE_TEAMS): None, #"https://partners.edx.org/forums/partner-forums",
     (PARTNER, LEARNERS): None, #"https://support.edx.org",
-    (PARTNER, RESEARCHERS): "http://edx.readthedocs.org/projects/devdata/en/latest/front_matter/preface.html#resources-for-researchers",
+    (PARTNER, RESEARCHERS): "http://edx.readthedocs.io/projects/devdata/en/latest/front_matter/preface.html#resources-for-researchers",
     (PARTNER, DEVELOPERS): "https://open.edx.org/resources/e-mail-lists",
     (OPENEDX, COURSE_TEAMS): "https://open.edx.org/resources/e-mail-lists",
     (OPENEDX, DEVELOPERS): "https://open.edx.org/resources/e-mail-lists",
@@ -103,22 +103,22 @@ copyright = u'2016, edX Inc.'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'opencoursestaff' : ('http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/', None),
-    'data' : ('http://edx.readthedocs.org/projects/devdata/en/latest/', None),
-    'partnercoursestaff': ('http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/', None),
-    'insights' : ('http://edx.readthedocs.org/projects/edx-insights/en/latest/', None),
-    'xblockapi' : ('http://edx.readthedocs.org/projects/xblock/en/latest/', None),
-    'xblocktutorial' : ('http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/', None),
-    'installation' : ('http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/', None),
-    'olx' : ('http://edx.readthedocs.org/projects/edx-open-learning-xml/en/latest/', None),
-    'learners' : ('http://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/', None),
-    'openlearners' : ('http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/', None),
-    'opendevelopers' : ('http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/', None),
-    'openplatformapi' : ('http://edx.readthedocs.org/projects/edx-platform-api/en/latest/', None),
-    'opendataapi' : ('http://edx.readthedocs.org/projects/edx-data-analytics-api/en/latest/', None),
-    'openreleasenotes' : ('http://edx.readthedocs.org/projects/open-edx-release-notes/en/latest/', None),
-    'partnerreleasenotes': ('http://edx.readthedocs.org/projects/edx-release-notes/en/latest/', None),
-    '2014releasenotes' : ('http://edx.readthedocs.org/projects/edx-2013-2014-release-notes/en/latest/', None)
+    'opencoursestaff' : ('http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/', None),
+    'data' : ('http://edx.readthedocs.io/projects/devdata/en/latest/', None),
+    'partnercoursestaff': ('http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/', None),
+    'insights' : ('http://edx.readthedocs.io/projects/edx-insights/en/latest/', None),
+    'xblockapi' : ('http://edx.readthedocs.io/projects/xblock/en/latest/', None),
+    'xblocktutorial' : ('http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/', None),
+    'installation' : ('http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/', None),
+    'olx' : ('http://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/', None),
+    'learners' : ('http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/', None),
+    'openlearners' : ('http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/', None),
+    'opendevelopers' : ('http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/', None),
+    'openplatformapi' : ('http://edx.readthedocs.io/projects/edx-platform-api/en/latest/', None),
+    'opendataapi' : ('http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/', None),
+    'openreleasenotes' : ('http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/', None),
+    'partnerreleasenotes': ('http://edx.readthedocs.io/projects/edx-release-notes/en/latest/', None),
+    '2014releasenotes' : ('http://edx.readthedocs.io/projects/edx-2013-2014-release-notes/en/latest/', None)
 }
 
 extlinks = {


### PR DESCRIPTION
Changed all occurances of edx.readthedocs.org to edx.readthedocs.io
These redirects were pointed out by the sphinx linkcheck builder.

Related link: https://github.com/edx/edx-documentation/pull/1267
