### PR TITLE
SQL tables for roles added to data pkg

### DIFF
--- a/en_us/data/source/data_czars/package.rst
+++ b/en_us/data/source/data_czars/package.rst
@@ -231,11 +231,23 @@ the course content that the learner accesses. No file is produced for courses
 that do not have any records in this table (for example, recently created
 courses). See :ref:`courseware_studentmodule`.
 
+``{org}-{course}-{run}-django_comment_client_role_users-{site}-analytics.sql``
+******************************************************************************
+
+This file lists the role that every enrolled user has for course discussions.
+See :ref:`django_comment_client_role_users`.
+
 ``{org}-email_opt_in-{site}-analytics.csv``
 ***********************************************
 
 This file reports the email preference selected by learners who are enrolled
 in any of your institution's courses. See :ref:`Institution_Data`.
+
+``{org}-{course}-{run}-student_courseaccessrole-{site}-analytics.sql``
+**********************************************************************
+
+This file reports the users who have a privileged role for the course. See
+:ref:`student_courseaccessrole`.
 
 ``{org}-{course}-{run}-student_courseenrollment-{site}-analytics.sql``
 ************************************************************************

--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -280,8 +280,11 @@ is_staff
   information in the LMS by selecting **Instructor**.
 
 .. note::
-     This designation has no bearing on a user's role in the discussion
-     forums, and confers no elevated privileges there.
+     This designation has no bearing on a user's role in the discussion forums,
+     and confers no elevated privileges there. For more information about
+     tables with course and discussion role data, see
+     :ref:`student_courseaccessrole` and
+     :ref:`django_comment_client_role_users`.
 
 -----------
 is_active
@@ -900,6 +903,159 @@ mode
   * All enrollments prior to 20 Aug 2013 were "honor".
 
 
+.. _student_courseaccessrole:
+
+==================================================
+Columns in the ``student_courseaccessrole`` Table
+==================================================
+
+This table lists the users who have a privileged role or roles for working in
+a course.
+
+A separate table, ``django_comment_client_role_users``, identifies privileges
+for course discussions. For more information, see
+:ref:`django_comment_client_role_users`.
+
+**History**: Added 15 Oct 2016.
+
+The ``student_courseaccessrole`` table has the following columns.
+
+.. list-table::
+     :widths: 15 15 15 15
+     :header-rows: 1
+
+     * - Column
+       - Type
+       - Null
+       - Key
+     * - user_id
+       - int(11)
+       - NO
+       - PRI
+     * - course_id
+       - varchar(255)
+       - NO
+       -
+     * - role
+       - varchar(255)
+       - NO
+       -
+
+---------
+user_id
+---------
+  The course team member's ID in ``auth_user.id``.
+
+-----------
+course_id
+-----------
+  The course identifier, in the format ``{key type}:{org}+{course}+{run}``. For
+  example, ``course-v1:edX+DemoX+Demo_2014``.
+
+  **History**: In Oct 2014, identifiers for some new courses began to use
+  the format shown above. Other new courses, and all courses created prior to
+  Oct 2014, use the format ``{org}/{course}/{run}``,  for example,
+  ``MITx/6.002x/2012_Fall``.
+
+-----------
+role
+-----------
+  The identifying name for the privilege level assigned to the user. The
+  ``role`` is one of the following values.
+
+  * beta_testers
+  * ccx_coach
+  * finance_admin
+  * instructor
+
+    .. note:: Course teams set this role in Studio or the LMS by selecting
+      **Staff**.
+
+  * library_user
+  * sales_admin
+  * staff
+
+    .. note:: Course teams set this role in Studio or the LMS by selecting
+      **Admin**.
+
+  For more information about the roles that you can assign in the LMS, see
+  :ref:`partnercoursestaff:Add Course Team Members` and
+  :ref:`partnercoursestaff:Give Other Users Access to Your Library`.
+
+.. Diana, are the library admin and library staff access levels identified separately from the course instructor (aka staff) and course staff (aka admin) roles? See http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/libraries.html#give-other-users-access-to-your-library
+
+.. _django_comment_client_role_users:
+
+=========================================================
+Columns in the ``django_comment_client_role_users`` Table
+=========================================================
+
+This table identifies the privilege role for working in course discussions for
+every user enrolled in a course.
+
+A separate table, ``student_courseaccessrole``, identifies users who have
+privileged roles for a course. For more information, see
+:ref:`student_courseaccessrole`.
+
+**History**: Added 15 Oct 2016.
+
+The ``django_comment_client_role_users`` table has the following columns.
+
+.. list-table::
+     :widths: 15 15 15 15
+     :header-rows: 1
+
+     * - Column
+       - Type
+       - Null
+       - Key
+     * - user_id
+       - int(11)
+       - NO
+       - PRI
+     * - course_id
+       - varchar(255)
+       - NO
+       -
+     * - name
+       - varchar(255)
+       - NO
+       -
+
+---------
+user_id
+---------
+  The course team member's ID in ``auth_user.id``.
+
+-----------
+course_id
+-----------
+  The course identifier, in the format ``{key type}:{org}+{course}+{run}``. For
+  example, ``course-v1:edX+DemoX+Demo_2014``.
+
+  **History**: In Oct 2014, identifiers for some new courses began to use
+  the format shown above. Other new courses, and all courses created prior to
+  Oct 2014, use the format ``{org}/{course}/{run}``,  for example,
+  ``MITx/6.002x/2012_Fall``.
+
+-----------
+name
+-----------
+  The identifying name for the privilege level that the user has in the course
+  discussions. The ``name`` is one of the following values.
+
+  * Administrator
+  * Community
+
+    .. note:: Discussion administrators set this role in the LMS by selecting
+      **Community TA**.
+
+  * Moderator
+  * Student
+
+  For more information about the discussion roles that you can assign in the
+  LMS, see :ref:`partnercoursestaff:Assigning_discussion_roles`.
+
 .. _user_api_usercoursetag:
 
 ===============================================
@@ -1407,9 +1563,9 @@ last_activity_at
 
 .. _verify_student_verificationstatus:
 
-=======================================================
-Columns in the verify_student_verificationstatus Table
-=======================================================
+==========================================================
+Columns in the ``verify_student_verificationstatus`` Table
+==========================================================
 
 The ``verify_student_verificationstatus`` table shows learner re-verification
 attempts and outcomes.

--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -4141,6 +4141,9 @@ complete, the server emits an ``edx.forum.thread.created`` event.
        Also present for ``edx.forum.response.created`` and
        ``edx.forum.comment.created`` events.
 
+       The :ref:`student_courseaccessrole` table lists all users who have a
+       privileged role for the course.
+
    * - ``user_forums_roles``
      - array
      - Identifies a user who does not have discussion management privileges as
@@ -4149,6 +4152,9 @@ complete, the server emits an ``edx.forum.thread.created`` event.
 
        Also present for ``edx.forum.response.created`` and
        ``edx.forum.comment.created`` events.
+
+       The :ref:`django_comment_client_role_users` table lists the discussion
+       role of every enrolled user.
 
 .. _edx.forum.thread.voted:
 
@@ -5711,6 +5717,9 @@ When a team is deleted, the server emits an ``edx.team.deleted`` event. Course
 team members who have any of the **Staff**, **Admin**, **Discussion Admin**,
 **Discussion Moderator**, or **Community TA** roles can delete teams.
 
+For more information about course and discussion role data, see
+:ref:`student_courseaccessrole` and :ref:`django_comment_client_role_users`.
+
 **Event Source**: Server
 
 ``event`` **Member Fields**:
@@ -5773,6 +5782,9 @@ is deleted, because all members are removed when a team is deleted.
 Course team members who have any of the **Staff**, **Admin**, **Discussion
 Admin**, **Discussion Moderator**, or **Community TA** roles can remove
 learners from teams.
+
+For more information about course and discussion role data, see
+:ref:`student_courseaccessrole` and :ref:`django_comment_client_role_users`.
 
 **Event Source**: Server
 
@@ -6691,7 +6703,10 @@ enrollment events.
   ``context.user_id`` identify the course team member who made the change, and
   the ``event.user_id`` identifies the student who was enrolled or unenrolled.
 
+The :ref:`student_courseaccessrole` table lists all users who have a privileged
+
 For details about the enrollment events, see :ref:`enrollment`.
+role for the course.
 
 .. _instructor_cohort_events:
 


### PR DESCRIPTION
## [DOC-3405](https://openedx.atlassian.net/browse/DOC-3405)

Adds info about the two new tables, for course and discussion role assignments.

@dianakhuang I have one question about how the library staff and library admin users are distinguished from the course staff and course admin (aka instructor and staff) roles.
### Date Needed

ASAP. Expected to be included in this weekend's data packages.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: @dianakhuang 
- [x] Subject matter expert: @stroilova 
- [x] Doc team review (copy edit): @edx/doc
- [ ] Product review: @katyw
  FYI: @brianhw 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
