### PR TITLE
Copy edits to course team ORA doc

### DIFF
--- a/en_us/shared/subsections/open_response_assessments/Manage_ORA_Assignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/Manage_ORA_Assignment.rst
@@ -5,15 +5,15 @@ Managing Open Response Assessment Assignments
 ##############################################
 
 After you publish an open response assessment and learners start to submit
-responses and perform assessments, there are various actions you can take as a
-member of the course staff.
+responses and perform assessments, members of the course team can take the
+following actions.
 
 .. contents::
   :local:
   :depth: 1
 
-In addition, see these other topics about different aspects of open response
-assessments.
+In addition, the following topics provide information about other aspects of
+open response assessments.
 
 * Components of an open response assessment: :ref:`Open Response Assessments 2`
 
@@ -23,7 +23,6 @@ assessments.
 * Viewing metrics and learner responses for released open response assessments:
   :ref:`Accessing ORA Assignment Information`
 
-
 .. _Access Information for a Specific Learner:
 
 ****************************************************
@@ -31,7 +30,7 @@ View a Specific Learner's Response and Assessments
 ****************************************************
 
 You can view the following information about an individual learner's
-performance in the open response assessment assignment.
+performance in an open response assessment assignment.
 
 * The text of the learner's response, including any files that the learner
   uploaded.
@@ -56,23 +55,25 @@ set for the open response assessment assignment in Studio. For more
 information about these settings, see :ref:`Specify Step Settings<PA Specify
 Step Settings>`.
 
-
 .. _Access Learner Information:
 
 =======================================
 Access a Specific Learner's Information
 =======================================
 
-Before you can access information about a specific learner's assignment, you
-need the learner's username or email address. For more information, see
+In order to access information about a specific learner's assignment, you
+need that learner's username or email address. For more information, see
 :ref:`View and download student data`.
 
-#. In the course, go to the ORA assignment.
+To access information about a specific learner, follow these steps.
 
-#. Scroll to the bottom of the problem, then select **Manage Individual
+#. View the live version of your course in the LMS, and then go to the ORA
+   assignment.
+
+#. Scroll to the end of the problem, and then select **Manage Individual
    Learners**.
 
-#. Enter the learner's username or email address, then select **Submit**.
+#. Enter the learner's username or email address, and then select **Submit**.
 
    The **Manage Individual Learners** dialog updates with expandable sections
    for each of the assessment steps in the assignment and other actions you
@@ -94,20 +95,25 @@ need the learner's username or email address. For more information, see
 Perform Staff Assessments in an ORA Assignment
 *************************************************
 
-When a staff assessment step is included in an open response assessment
-assignment, course team members see a **Grade Available Responses** button at
-the bottom of the assignment in the course, and learners see a **Staff
-Assessment** step in their assignment.
+When a staff assessment is included in an open response assessment assignment,
+course team members see a **Grade Available Responses** option at the end of
+the assignment in the course, and learners see a **Staff Assessment** step in
+their assignment.
 
-.. note:: The scores that you give learners in staff assessment steps override
-   scores from any other assessment type in the assignment, including peer
-   assessments that are completed after the staff assessment.
+Submitting a staff assessment has the following results.
 
-To perform staff assessments in an assignment, complete these steps.
+* The score that you give a learner in a staff assessment overrides scores from
+  any other assessment type in the assignment.
 
-#. In the course, go to the ORA assignment.
+* Peer assessments that are completed before or after your staff assessment
+  have no effect on the learner's final assignment grade.
 
-#. Scroll to the bottom of the problem, then select **Grade Available
+To perform a staff assessment in an assignment, follow these steps.
+
+#. View the live version of your course in the LMS, and then go to the ORA
+   assignment.
+
+#. Scroll to the end of the problem, and then select **Grade Available
    Responses**.
 
    In the dialog that opens, the number of available and checked out responses
@@ -123,50 +129,53 @@ To perform staff assessments in an assignment, complete these steps.
    dialog. Alternatively, select **Submit assessment and continue grading** to
    submit the assessment and immediately grade another submission.
 
-   The grade that you have given this learner's response overrides scores from
-   any other assessment type in the assignment. Peer assessments performed on
-   this response after a staff grade has been given have no effect on the
-   learner's final assignment grade.
-
-
 .. _Override a learner assessment grade:
 
 ************************************************
 Override a Learner's Assessment Grade
 ************************************************
 
-For any open response assessment, whether or not a staff assessment step is
-already included, you might want to override a learner's final grade for the
-assignment. The ability to override the final grade is particularly useful in
-assignments without staff assessment steps, for example, if a learner's
-submission was inappropriately or inadequately graded by peers, or if there
-are not enough peer reviewers to complete the required number of peer
+For any open response assessment, whether or not a staff assessment is
+already included, you can override a learner's final grade for the assignment.
+The ability to override the final grade can be useful if, for example, a
+learner's submission was inappropriately or inadequately graded by peers, or if
+there are not enough peer reviewers to complete the required number of peer
 assessments.
 
-Course staff can perform an assessment of an individual learner's response
-that acts as an override to the learner's existing grade. The grade given by
-staff in the override assessment immediately replaces any other calculated
-grade as the final grade for the learner.
+Submitting an override assessment has the following results.
+
+* The score that you give a learner in an override assessment overrides scores
+  from any other assessment type in the assignment.
+
+* Any steps that the learner did not complete for the assignment are marked as
+  complete.
+
+* Peer assessments that are completed before or after your staff assessment
+  have no effect on the learner's final assignment grade.
 
 .. note:: You can perform override assessments more than once on the same
    response, regardless of the due date of the assignment. The learner's
    final grade on the assessment is updated to reflect the most recent staff
    override assessment grade.
 
-Learners who have override grades for their submissions see a **Staff
+Learners who receive override grades for their submissions see a **Staff
 Assessment** step in their assignments, where they can view the rubric and any
 comments provided in the staff assessments.
-
 
 =======================================
 Perform an Override Assessment
 =======================================
 
-To perform an override assessment for a particular learner, complete these steps.
+In order to perform an override assessment for a learner, you need that
+learner's username or email address. For more information, see
+:ref:`View and download student data`.
 
-#. In the course, go to the ORA assignment.
+To perform an override assessment, follow these steps.
 
-#. Scroll to the bottom of the problem, then select **Manage Individual
+#. View the live version of your course in the LMS, and then go to the ORA
+   assignment.
+
+#. Scroll to the end of the problem, then select **Manage Individual
    Learners**.
 
 #. Enter the learner's username or email, then select **Submit**.
@@ -195,49 +204,48 @@ To perform an override assessment for a particular learner, complete these steps
    final grade on the assessment is updated to reflect the most recent staff
    override assessment grade.
 
-
 .. _Remove a learner response from peer grading:
 
-************************************************
-Remove a Learner's Response from Peer Grading
-************************************************
+****************************
+Remove a Learner's Response
+****************************
 
 In a course that contains assignments with peer assessment steps, learners
-might alert you to vulgar, abusive, or otherwise inappropriate responses that
-they have seen while performing peer assessments. In such a situation you can
-:ref:`locate<Locate a specific ORA submission>` and remove the submission.
-Doing so removes the inappropriate response from peer assessments so that it
-is no longer shown to other learners.
+might alert you to inappropriate responses that they have seen while performing
+peer assessments. In such a situation you can
+:ref:`locate<Locate a specific ORA submission>` and remove the response. Doing
+so removes the response so that it is no longer shown to other learners for
+peer assessment.
 
-.. note:: Removing a learner's submission is an irreversible action.
+.. note:: Removing a learner's response is an irreversible action.
 
-When you remove an inappropriate submission, the response is immediately taken
-out of the pool of submissions available for peer assessment. If the
-inappropriate response has already been sent to other learners for peer
-assessment, it is also removed from their queue. However, if any learner has
-already graded the inappropriate response, it is counted as one of the
-submissions they have graded.
+When you remove a response, the response is immediately taken out of the pool
+of submissions available for peer assessment. If the inappropriate response has
+already been sent to other learners for peer assessment, it is also removed
+from their queues. However, if any learner has already graded the inappropriate
+response, it is counted as one of the submissions they have graded.
 
-.. note:: After you remove an inappropriate response from peer assessment, you
-   decide whether the learner who submitted that response is allowed to submit a
-   replacement response. If you do not want to allow the learner to submit a
-   replacement response, you do not need to take any additional action. The
-   learner receives a grade of zero for the entire submission. To allow the
-   learner to resubmit a response for a cancelled submission, you must delete
-   the learner's state for the problem. For more information, see
+.. note:: After you remove an inappropriate response, you can decide whether
+   the learner who submitted that response is allowed to submit a replacement
+   response. If you do not want to allow the learner to submit a replacement
+   response, you do not need to take any additional action. The learner
+   receives a grade of zero for the entire submission. To allow the learner to
+   resubmit a response for a cancelled submission, you must delete the
+   learner's state for the problem. For more information, see
    :ref:`delete_state`.
 
-To remove a submission from peer assessment, complete these steps.
+To remove a submitted response, follow these steps.
 
 #. Identify the learner who submitted the inappropriate response by following
    the steps in the :ref:`Locate a specific ORA submission` topic.
 
-#. In the course, go to the ORA assignment that contains the submission you want
-   to remove.
+#. View the live version of your course in the LMS, and then go to the ORA
+   assignment that contains the submission you want to remove.
 
-#. Scroll to the bottom of the problem, then select **Manage Individual Learners**.
+#. Scroll to the end of the problem, and then select **Manage Individual
+   Learners**.
 
-#. Enter the learner's username or email, and select **Submit**.
+#. Enter the learner's username or email, and then select **Submit**.
 
    The **Manage Individual Learners** dialog updates with expandable sections
    for each of the assessment steps in the assignment and other actions you
@@ -245,39 +253,40 @@ To remove a submission from peer assessment, complete these steps.
 
 #. Select **Remove Submission from Peer Grading**.
 
-#. Enter a comment to explain the removal. This comment appears to the learner
+#. Enter a comment to explain the removal. The learner sees this comment
    when she views her response in the open response assessment problem.
 
-.. image:: ../../../../shared/images/ORA_RemoveSubmission.png
-    :alt: Dialog allowing comments to be entered when removing a learner
+   .. image:: ../../../../shared/images/ORA_RemoveSubmission.png
+     :alt: Dialog allowing comments to be entered when removing a learner
        submission.
 
-6. Select **Remove submission**.
+#. Select **Remove submission**.
 
-   The inappropriate submission is removed from peer assessment. Removed
-   submissions are also removed from the list of Top Responses if they were
-   previously listed.
+   The inappropriate submission is permanently removed from peer assessment.
+   Removed submissions are also removed from the list of Top Responses if they
+   were previously listed.
+
+#. Optionally, delete the learner's state for the problem. This step allows the
+   learner to submit another response. For more information, see
+   :ref:`delete_state`.
 
 When you access this learner's information again by selecting **Manage
 Individual Learners**, instead of the response, you see a note showing the date
 and time that the submission was removed, and the comments that you entered.
 
 .. image:: ../../../../shared/images/ORA_StaffViewCancelledResponse.png
-   :alt: In "Manage Individual Learners", the date, time and comment for removal
+   :alt: In Manage Individual Learners, the date, time and comment for removal
     of a learner response is shown instead of the original response.
 
-
 When the learner views the assignment in the course, she sees that all steps in
-the assignment have a status of "Cancelled". Under **Your Response**, instead of
-the text of their response, she sees the date and time that their response was
-cancelled, and the comments relating to the removal of their submission.
-
+the assignment have a status of "Cancelled". Under **Your Response**, instead
+of the text of their response, she sees the date and time that their response
+was cancelled, and the comments relating to the removal of their submission.
 
 .. image:: ../../../../shared/images/ORA_LearnerViewCancelledResponse.png
    :alt: In a learner's view of the assignment, all steps have a status of
     Cancelled, and the learner sees the date, time and comment given for the
     removal of his submission.
-
 
 .. _Locate a specific ORA submission:
 


### PR DESCRIPTION
## [DOC-3368](https://openedx.atlassian.net/browse/DOC-3368)

When a course team member overrides the grade that a learner has received through peer assessment, all of the steps in the assignment are now set to "complete". This change is addressed in the second commit.

Since this section was written, we've agreed on several style choices. I also tried to reduce word count where it seemed feasible. These changes are addressed in the first commit.
### Date Needed

18 Oct 16
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @efischer19 
- [x] Doc team review (sanity check): @edx/doc
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add to release notes
- [x] Squash commits
