### PR TITLE
Add documentation for E-Commerce service receipt page

### DIFF
--- a/en_us/install_operations/source/ecommerce/enable_receipt_page.rst
+++ b/en_us/install_operations/source/ecommerce/enable_receipt_page.rst
@@ -1,0 +1,44 @@
+.. _Enable the ECommerce Receipt Page:
+
+##########################################
+Enable the E-Commerce Service Receipt Page
+##########################################
+
+The E-Commerce service includes a receipt page that you can display to users
+after their orders are complete.
+
+.. contents::
+   :depth: 1
+   :local:
+
+.. _Enable the Receipt Page:
+
+***********************
+Enable the Receipt Page
+***********************
+
+To enable the default receipt page for the E-Commerce service, follow these
+steps.
+
+#. Sign in to the LMS Django administration console for your base URL. For
+   example, ``http://{your_URL}/admin``.
+
+#. On the **Site Administration** page, locate **Site_Configuration**.
+
+#. In the **Site_Configuration** section, next to **Site configurations**,
+   select **Change**.
+
+#. On the **Change site configuration** page, locate the **Values** field, and
+   then add the following JSON format value.
+
+   ::
+
+     {
+      "ECOMMERCE_RECEIPT_PAGE_URL":"/checkout/receipt/?order_number="
+      }
+
+#. Select **Save**.
+
+
+
+.. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/ecommerce/index.rst
+++ b/en_us/install_operations/source/ecommerce/index.rst
@@ -16,6 +16,7 @@ use the E-Commerce service with the Open edX platform.
    install_ecommerce
    manage_assets
    create_products/index
+   enable_receipt_page
    manage_orders
    test_features
    test_ecommerce


### PR DESCRIPTION
## [DOC-3436](https://openedx.atlassian.net/browse/DOC-3436)

Add documentation to enable the receipt page in the E-Commerce service.

This documentation is based on the work in [SOL-2082](https://openedx.atlassian.net/browse/SOL-2082).
### Date Needed (optional)

Date for feature release is still uncertain, but is expected around the end of October.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @marjev 
- [ ] Subject matter expert: @mjfrey 

@marjev and @mjfrey , I've taken a stab at adding documentation for the receipt page, but I'm missing some information. Please review this PR and add comments with the missing information, and let me know if the introductory sentence ("The E-Commerce service includes a receipt page that you can display to users after their orders are complete.") is accurate.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
