### PR TITLE
Custom pages (tabs) can now be visible to staff only 

### DIFF
--- a/en_us/data/source/internal_data_formats/course_structure.rst
+++ b/en_us/data/source/internal_data_formats/course_structure.rst
@@ -137,14 +137,19 @@ Studio, see :ref:`partnercoursestaff:document index`.
      - This field stores the value entered for **Course Start Date** on the
        Studio **Settings & Details** page.
    * - ``tabs``
-     - This array contains member objects that describe the tabs, or
-       pages, that appear for the course in the learning management system
-       (LMS). Course teams can rename most of the default pages, and add more
+     - This array contains member objects that describe the tabs, or pages,
+       that appear for the course in the learning management system (LMS).
+       Course teams can change the order of the default pages, and add custom
        pages, on the Studio **Pages** page.
 
-       The default **Courseware** page cannot be renamed. This page uses the
-       structure defined by the course building blocks to deliver the content
-       defined by the course components.
+       The default **Course** page uses the structure defined by the course
+       building blocks to deliver the content defined by the course components.
+       Similarly, the default **Home** page delivers the updates that are
+       defined on the Studio **Course Updates** page. You cannot change the
+       order of these pages.
+
+       For more information, see :ref:`partnercoursestaff:Adding Pages to a
+       Course`.
 
 ===================
 Course Data Sample
@@ -176,29 +181,38 @@ Course Data Sample
              "start":"2014-08-10T07:00:00Z",
              "tabs":[
                 {
-                   "name":"Courseware",
-                   "type":"courseware"
+                   "name":"Home",
+                   "type":"course_info",
+                   "course_staff_only": false
                 },
                 {
-                   "name":"Course Info",
-                   "type":"course info"
+                   "name":"Course",
+                   "type":"courseware",
+                   "course_staff_only": false
                 },
+
                 {
                    "name":"Discussion",
-                   "type":"discussion"
+                   "type":"discussion",
+                   "course_staff_only": false
                 },
                 {
                    "name":"edX Community",
                    "type":"static_tab",
-                   "url_slug":"67e8a9e44dde4e97b2bd33a928b9099e"
+                   "url_slug":"67e8a9e44dde4e97b2bd33a928b9099e",
+                   "course_staff_only": true
                 },
                 {
                    "name":"Progress",
+                   "is_hidden": false,
                    "type":"progress"
+                   "course_staff_only": false
                 },
                 {
                    "name":"Wiki",
-                   "type":"wiki"
+                   "is_hidden": true,
+                   "type":"wiki",
+                   "course_staff_only": false
                 }
              ]
           }

--- a/en_us/olx/source/policies/course.rst
+++ b/en_us/olx/source/policies/course.rst
@@ -44,7 +44,7 @@ Course Policy JSON Objects
      * - ``end``
        - The end date for the course.  For example: ``"2012-11-05T12:00"``.
      * - ``end_of_course_survey_url``
-       - The url for an end of course survey. The link is shown after the
+       - The URL for an end of course survey. The link is shown after the
          course is over, next to certificate download links.
      * - ``tabs``
        - Custom pages, or tabs, in the courseware.  See below for details.
@@ -64,9 +64,9 @@ Course Policy JSON Objects
      * - ``days_early_for_beta``
        - The number of days early that students in the beta-testers group can
          access the course.
-     * - `cohort_config`
+     * - ``cohort_config``
        -
-          * ``cohorted`` : boolean.  Set to ``true`` if this course uses
+          * ``cohorted`` : Boolean.  Set to ``true`` if this course uses
             student cohorts.  If so, all inline discussions are automatically
             cohorted, and top-level discussion topics are configurable via the
             ``cohorted_discussions`` list. Default is ``false``, not cohorted).
@@ -79,8 +79,10 @@ Course Policy JSON Objects
        - Have pdf-based textbooks on tabs in the courseware.  See below for
          details.
      * - ``html_textbooks``
-       - Have html-based textbooks on tabs in the courseware.  See below for
-         details.
+       - The addition of HTML-based textbooks on tabs in the courseware has
+         been deprecated.
+
+
 
 .. disable_policy_graph above had "SUPORTED?" after it, moved to this comment 26 Oct 2015 - Alison
 
@@ -88,30 +90,74 @@ Course Policy JSON Objects
 Example Course Policy File
 *******************************
 
+An example with a few of the settings defined in the course policy file
+follows.
+
 .. code-block:: json
 
     {
-      "course/2014":
-          {
-	          "tabs": [{"type": "courseware", "name": "Courseware"},
-	                   {"type": "course_info", "name": "Course Info"},
-	                   {"type": "discussion", "name": "Discussion"},
-	                   {"type": "wiki", "name": "Wiki"},
-	                   {"type": "progress", "name": "Progress"}],
-
-	           "display_name": "edX Demonstration Course",
-	           "discussion_topics": {"General": {"id": "course"}}
-
-                   "user_partitions": [{"id": 0,
-                                        "name": "Two Groups",
-                                        "description": "For 2-group experiments.",
-                                         "version": 1,
-                                         "groups": [{"id": 0,
-                                                     "name": "Group A",
-                                                     "version": 1},
-                                                    {"id": 2,
-                                                     "name": "Group B",
-                                                     "version": 1}]
-                                       }]
-          }
+      "course/course": {
+        "advanced_modules": [
+            "poll",
+            "survey",
+        ],
+        "discussion_blackouts": [],
+        "discussion_topics": {
+            "General": {
+                "id": "course"
+            }
+        "show_calculator": true,
+        "show_reset_button": true,
+        "start": "2017-10-01T00:30:00Z",
+        "tabs": [
+            {
+                "course_staff_only": false,
+                "name": "Home",
+                "type": "course_info"
+            },
+            {
+                "course_staff_only": false,
+                "name": "Course",
+                "type": "courseware"
+            },
+            {
+                "course_staff_only": false,
+                "name": "Discussion",
+                "type": "discussion"
+            },
+            {
+                "course_staff_only": false,
+                "is_hidden": true,
+                "name": "Wiki",
+                "type": "wiki"
+            },
+            {
+                "course_staff_only": false,
+                "name": "Progress",
+                "type": "progress"
+            },
+            {
+                "course_staff_only": true,
+                "name": "Staff only (Alison)",
+                "type": "static_tab",
+                "url_slug": "7cf2fccec33541dc81ce5e0e34e2689c"
+            }
+        ],
+        "user_partitions": [
+            {
+                "active": true,
+                "description": "The groups in this configuration can be mapped to cohort groups in the LMS.",
+                "groups": [
+                    {
+                        "id": 1124782865,
+                        "name": "Group A",
+                        "version": 1
+                    },
+                    {
+                        "id": 254579781,
+                        "name": "Group B",
+                        "version": 1
+                    }
+            }
+        ]
     }

--- a/en_us/shared/course_assets/pages.rst
+++ b/en_us/shared/course_assets/pages.rst
@@ -1,11 +1,11 @@
 .. _Adding Pages to a Course:
 
-###########################
-Adding Pages to a Course
-###########################
+##################################
+Managing the Pages in Your Course
+##################################
 
-This topic describes the pages, or tabs, that are included in your course by
-default, how you can modify them, and how you can add more pages to your
+This topic describes the pages, or tabs, that the LMS includes for your course
+by default, how you can modify them, and how you can add more pages to your
 course.
 
 .. contents::
@@ -30,7 +30,7 @@ In the LMS, learners see these options in the navigation bar at the top of
 every page.
 
 .. image:: ../../../shared/images/page_bar_lms_orig.png
- :width: 600
+ :width: 300
  :alt: The navigation bar in the LMS with all of the default pages.
 
 In addition, if you enable the :ref:`notes tool <Notes Tool>` for your course,
@@ -52,40 +52,53 @@ system adds by default.
 * If you want to change the name of a page that appears for a textbook, you
   can change the name that you entered for the textbook.
 
-You can also add other pages.
+You can also add custom pages.
 
 .. _Add Page:
 
-****************
-Adding Pages
-****************
+***************************
+Adding Custom Pages
+***************************
 
-Each page that you add appears in the navigation bar for your course. For
-example, the navigation bar for a course that includes a textbook named
-**Introduction to Music Theory** and pages for the **Course Schedule** and
-**Supplements** appears as follows.
-
-.. image:: ../../../shared/images/page_bar_lms.png
- :width: 800
- :alt: The navigation bar in the LMS with the default pages, a textbook page,
-  and two additional pages.
-
-You can add pages to your course for the course syllabus, FAQ, or any other
-content. When you add a page, you also add its content using an HTML editor.
+You can customize your course by adding pages. Each page that you add appears
+in the navigation bar for your course. When you add a page, you also add its
+content using an HTML editor.
 
 .. Commenting this sentence out until we can figure out what's wrong with the HTML... For example, you can add a dynamic HTML calendar, using the template in :ref:`Code for Dynamic HTML Schedule`.
 
-==============
-Add a Page
-==============
+An example of the navigation bar for a course that includes a textbook named
+**Introduction to Music Theory** and custom pages for the **Course Schedule**
+and **Supplements** follows.
 
-To add a page, follow these steps.
+.. image:: ../../../shared/images/page_bar_lms.png
+ :width: 800
+ :alt:  ""
 
-#. In Studio, from the **Content** menu select **Pages**. The page that opens
-   lists the pages that appear in the navigation bar for your course.
+When you add a page, you can specify whether it and its content are visible
+only to course team members who have the Admin or Staff role, or to all
+enrolled learners as well as the course team. For more information about
+assigning course team roles, see :ref:`Course_Staffing`.
 
-#. Select **Add a New Page**. The system adds a page named **Empty** to the
-   end of the list.
+===================
+Add a Custom Page
+===================
+
+If you add a custom page to a course after its start date, the page is visible
+in the LMS as soon as you save your work. As a best practice, be sure to
+prepare the following aspects of your page design before you add a page.
+
+*  The content for the page, which can include HTML markup.
+*  The name of the page.
+*  The audience for the page (everyone, or course team members with the Admin
+   or Staff roles only).
+
+To add a custom page and its content to your course, follow these steps.
+
+#. In Studio, from the **Content** menu select **Pages**. A list of the pages
+   that appear in the navigation bar for your course appears.
+
+#. Select **Add a New Page**. The system adds a page named **Empty** to the end
+   of the list.
 
 #. In the row for the new page, select **Edit**. The :ref:`visual editor <The
    Visual Editor>` opens.
@@ -96,20 +109,24 @@ To add a page, follow these steps.
    editor<The Raw HTML Editor>`. For more information about entering content,
    see :ref:`Options for Editing HTML Components`.
 
-   .. note::
-    If you copy text from another source and paste it into the visual editor,
-    be sure to proofread the result carefully. Some applications automatically
-    change quotation marks and apostrophes from the "straight" version to the
-    "smart" or "curly" version. The raw HTML editor requires "straight"
-    quotation marks and apostrophes.
+   .. note:: If you copy text from another source and paste it into the visual
+    editor, be sure to proofread the result carefully. Some applications
+    automatically change quotation marks and apostrophes from the "straight"
+    version to the "smart" or "curly" version. The raw HTML editor requires
+    "straight" quotation marks and apostrophes.
 
 #. To rename the page, select **Settings**, and then enter a  **Display Name**.
-   The display name is the navigation option that is visible to learners in the
-   course.
+   The display name is the label that course participants use in the course
+   navigation bar.
+
+#. To change the audience for the page, select **Settings**, and then enter
+   **Hide Page from Learners**. By default, pages are visible to all course
+   participants.
 
 #. Select **Save**.
 
-The new page is immediately available to learners if the course has started.
+The new page is immediately available to the specified audience if the course
+has started.
 
 .. _Show or Hide the Course Wiki Page:
 
@@ -121,9 +138,10 @@ By default, your course includes a **Wiki** page and a **Progress** page. For
 more information about how you can use these pages in a course, see
 :ref:`Course_Wiki` or :ref:`A Students View`.
 
-As part of your course design, you can decide whether you want learners to
-have access to these pages. You can hide the pages, and if you change your
-mind, you can show the pages again.
+As part of your course design, you can decide whether you want learners to have
+access to one or both of these pages. While you cannot delete these pages
+completely, you can hide them so that they do not appear in the navigation bar
+in the LMS. If you change your mind, you can show the pages again.
 
 .. note:: The information on the **Progress** page can be motivating for
   learners, particularly in courses that include graded subsections, but also
@@ -135,11 +153,14 @@ As a best practice, you should avoid changing the visibility of these pages
 after your course starts. For example, your course includes the **Wiki** page
 when it starts. A learner adds a page to the course wiki, and adds a browser
 bookmark to that page. If you later hide the **Wiki** page, the learner's
-bookmark will continue to provide access to the entire course wiki.
+browser bookmark will continue to provide access to the entire course wiki.
 
 =======================================
 Hide or Show the Wiki or Progress Pages
 =======================================
+
+If you hide or show a page after the course start date, note that the
+visibility of the page in the LMS changes immediately.
 
 To hide or show the **Wiki** or **Progress** pages, follow these steps.
 
@@ -152,24 +173,20 @@ To hide or show the **Wiki** or **Progress** pages, follow these steps.
     :alt: The list of default course pages, with a show/hide icon for the Wiki
       and Progress pages only.
 
-   .. note:: The options to show or hide a page are available only for the
-     **Wiki** and **Progress** pages.
+#. Select the **Show/hide page** icon to hide a page. The icon changes to
+   indicate that the page is hidden, as shown in this example.
 
-#. Select the **Show/hide page** icon to hide a page. The appearance of the
-   icon changes to indicate that the page is now hidden, as shown in this
-   example.
-
-   .. image:: ../../../shared/images/pages_wiki_off.png
-    :alt: The default wiki page on the list of course pages, with the show/hide
-     icon indicating that the page is currently hidden.
+  .. image:: ../../../shared/images/pages_wiki_off.png
+   :alt: The default wiki page on the list of course pages, with the show/hide
+       icon indicating that the page is currently hidden.
 
 #. Select the **Show/hide page** icon again to make the page visible.
 
 .. _Reorder Pages:
 
-****************
-Reorder a Page
-****************
+*****************
+Reorder the Pages
+*****************
 
 You can reorder the pages in your course in the same way that you
 :ref:`reorganize the course outline<Reorganize the Course Outline>`: you drag a
@@ -178,7 +195,11 @@ page to different location in the list of pages and drop it there.
 .. note:: You cannot change the order of the **Home** or **Course** pages,
   which are always presented in the first and second positions.
 
-To reorder a page, follow these steps.
+If you change the order of the pages after the course start date, note that the
+change immediately affects the sequence of the options on the navigation bar in
+the LMS.
+
+To reorder the pages, follow these steps.
 
 #. In Studio, from the **Content** menu select **Pages**.
 
@@ -192,12 +213,12 @@ To reorder a page, follow these steps.
 
 .. _Delete a Page:
 
-****************
-Delete a Page
-****************
+*********************
+Delete a Custom Page
+*********************
 
-You can delete a page that a member of the course team previously added to
-the course.
+You can delete any of the custom pages that were previously added to the
+course.
 
 * You cannot delete any of the :ref:`default pages<Default Pages>`. However,
   you can :ref:`hide<Show or Hide the Course Wiki Page>` the **Wiki** and the
@@ -205,7 +226,10 @@ the course.
 
 * To delete a page that appears for a textbook, you delete the textbook.
 
-To delete a page, follow these steps.
+If you delete a page after the course start date, note that the
+visibility of the page in the LMS changes immediately.
+
+To delete a custom page, follow these steps.
 
 #. In Studio, from the **Content** menu select **Pages**.
 


### PR DESCRIPTION
## [DOC-3184](https://openedx.atlassian.net/browse/DOC-3184)

[OSPR-1327](https://openedx.atlassian.net/browse/OSPR-1327) adds the ability to prevent a custom page from being visible to learners. They are only visible to Admin or Staff users. 
### Date Needed

21 Oct 2016
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @cahrens 
- [ ] Subject matter expert:
- [x] Doc team review (copy edit): @edx/doc
- [x] Product review: @sstack22 
- [ ] Partner support: 
- [ ] PM review: @mmacfarlane (for possible implications at MIT)

FYI: @katymw @stroilova this change will have an (extremely minor) impact on data exports
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
### Post-review
- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
