### PR TITLE
Updates the release dates for the two new role tables

### DIFF
--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -916,7 +916,7 @@ A separate table, ``django_comment_client_role_users``, identifies privileges
 for course discussions. For more information, see
 :ref:`django_comment_client_role_users`.
 
-**History**: Added 15 Oct 2016.
+**History**: Added 22 Oct 2016.
 
 The ``student_courseaccessrole`` table has the following columns.
 
@@ -982,8 +982,6 @@ role
   :ref:`partnercoursestaff:Add Course Team Members` and
   :ref:`partnercoursestaff:Give Other Users Access to Your Library`.
 
-.. Diana, are the library admin and library staff access levels identified separately from the course instructor (aka staff) and course staff (aka admin) roles? See http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/libraries.html#give-other-users-access-to-your-library
-
 .. _django_comment_client_role_users:
 
 =========================================================
@@ -997,7 +995,7 @@ A separate table, ``student_courseaccessrole``, identifies users who have
 privileged roles for a course. For more information, see
 :ref:`student_courseaccessrole`.
 
-**History**: Added 15 Oct 2016.
+**History**: Added 22 Oct 2016.
 
 The ``django_comment_client_role_users`` table has the following columns.
 


### PR DESCRIPTION
## [DOC-3437](https://openedx.atlassian.net/browse/DOC-3437)

Tables will be included in the exports this weekend instead of next.

@dianakhuang  you were out last week when the original PR merged (I thought it was needed earlier than in fact it was) and had one question for you, commented in the text but also duplicated here....
are the library admin and library staff access levels identified separately from the course instructor (aka staff) and course staff (aka admin) roles? See http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/libraries.html#give-other-users-access-to-your-library
### Date Needed

as soon as you get a chance
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @stroilova 
- [x] Subject matter expert: @dianakhuang 
- [x] Doc team review (sanity check): @edx/doc
- [x] Product review: @katymyw
- [ ] Partner support: 
- [ ] PM review: 

FYI: @brianhw 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
