### PR TITLE
Add support for GNU coreutils date in script

### DIFF
--- a/utilities/add-upcoming-release-notes-file.sh
+++ b/utilities/add-upcoming-release-notes-file.sh
@@ -9,6 +9,16 @@
 #    ./add-upcoming-release-notes-file.sh
 #
 
+platform='unknown'
+unamestr=`uname`
+if [[ "$unamestr" == 'Linux' ]]; then
+    platform='linux'
+elif [[ "$unamestr" == 'Darwin' ]]; then
+    platform='darwin'
+elif [[ "$unamestr" == 'FreeBSD' ]]; then
+    platform='freebsd'
+fi
+
 # These are the categories of release notes. If we add a new category,
 # for example, certificates, add a label to this list.
 NOTE_CATEGORIES="analytics documentation lms mobile openedx studio website"
@@ -66,13 +76,23 @@ POSSIBLE_UPCOMING_MONDAY_OFFSET=0
 while [[ -z ${UPCOMING_MONDAY_DATE} ]]
 do
     
-    POSSIBLE_UPCOMING_MONDAY_DAY_OF_WEEK=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%a`
+    if [[ $platform == 'linux' || $platform == 'unknown' ]]; then
+        POSSIBLE_UPCOMING_MONDAY_DAY_OF_WEEK=`date -d "+${POSSIBLE_UPCOMING_MONDAY_OFFSET} days" +%a`
+    else
+        POSSIBLE_UPCOMING_MONDAY_DAY_OF_WEEK=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%a`
+    fi
     
     if [[ ${POSSIBLE_UPCOMING_MONDAY_DAY_OF_WEEK} == "Mon" ]]
     then
         # This is where we set the date string format.
-        UPCOMING_MONDAY_DATE=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%Y-%m-%d`
-        UPCOMING_MONDAY_YEAR=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%Y`
+        if [[ $platform == 'linux' || $platform == 'unknown' ]]; then
+            UPCOMING_MONDAY_DATE=`date -d "+${POSSIBLE_UPCOMING_MONDAY_OFFSET} days" +%Y-%m-%d`
+            UPCOMING_MONDAY_YEAR=`date -d "+${POSSIBLE_UPCOMING_MONDAY_OFFSET} days" +%Y`
+        else
+            UPCOMING_MONDAY_DATE=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%Y-%m-%d`
+            UPCOMING_MONDAY_YEAR=`date -v +${POSSIBLE_UPCOMING_MONDAY_OFFSET}d +%Y`
+        fi
+
     else
         POSSIBLE_UPCOMING_MONDAY_OFFSET=`expr ${POSSIBLE_UPCOMING_MONDAY_OFFSET} + 1`
     fi


### PR DESCRIPTION
The `./utilities/add-upcoming-release-notes-file.sh` was not working for me because I develop on Ubuntu and it ships with the GNU coreutils date command whereas macOS machines have a BSD flavor of date and the script was designed for that. The options to the command are different, but they provide essentially the same functionality.

My change checks the platform the script is running on and uses the BSD options if it detects mac (or freebsd) and the GNU options if it detects linux (or can't figure out the platform).
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Subject matter expert: @rlucioni 
- [x] Subject matter expert: @lamagnifica 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [x] Ran ./run_tests.sh without warnings or errors
- [x] Ran the script on my machine (Ubuntu 16.04)
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Sandbox (optional)
- [ ] Point to or build a sandbox for the software change and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
