### PR TITLE
Remove references to ALLOW_ALL_ADVANCED_COMPONENTS

### DIFF
--- a/en_us/developers/source/extending_platform/xblocks.rst
+++ b/en_us/developers/source/extending_platform/xblocks.rst
@@ -148,13 +148,6 @@ steps.
         # from xmodule.x_module import prefer_xmodules
         # XBLOCK_SELECT_FUNCTION = prefer_xmodules
 
-    #.  In ``edx-platform/cms/envs/common.py``, change::
-
-            'ALLOW_ALL_ADVANCED_COMPONENTS': False,
-
-        to::
-
-            'ALLOW_ALL_ADVANCED_COMPONENTS': True,
 
 #.  Add the block to your courses' advanced settings in Studio.
 

--- a/en_us/xblock-tutorial/source/edx_platform/devstack.rst
+++ b/en_us/xblock-tutorial/source/edx_platform/devstack.rst
@@ -59,10 +59,6 @@ Enable the XBlock in the edX Platform
      from xmodule.x_module import prefer_xmodules
      XBLOCK_SELECT_FUNCTION = prefer_xmodules
 
-#. In ``edx-platform/cms/envs/common.py``, change the
-   ``'ALLOW_ALL_ADVANCED_COMPONENTS'`` value to ``True``.::
-
-     'ALLOW_ALL_ADVANCED_COMPONENTS': True,
 
 ************************
 Start the LMS and Studio


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

The current documentation instructs the developer to set the ALLOW_ALL_ADVANCED_COMPONENTS settings variable to true when using XBLocks. See : http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/devstack.html

However, it looks like this flag was removed earlier this year. Removed from cms/envs/common.py : https://github.com/edx/edx-platform/commit/6b6248b44a8dbedd02cbe01ec1e17282cb1bb3c2

So shouldn't this step be removed from the documentation? This PR removes two mentions of this flag. 

### Date Needed (optional)

n/a
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
