### PR TITLE
Release notes week of 31 Oct 2016

### DIFF
--- a/en_us/release_notes/source/2016/2016-10-31.rst
+++ b/en_us/release_notes/source/2016/2016-10-31.rst
@@ -1,0 +1,29 @@
+#########################
+Week of 31 October 2016
+#########################
+
+The following information summarizes what is new in the edX platform this week.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2016-10-31.rst
+
+
+
+
+
+
+
+.. include:: ../../../links/links.rst

--- a/en_us/release_notes/source/2016/index.rst
+++ b/en_us/release_notes/source/2016/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2016.
 .. toctree::
    :maxdepth: 1
 
+   2016-10-31
    2016-10-24
    2016-10-18
    2016-10-10

--- a/en_us/release_notes/source/2016/lms/lms_2016-10-31.rst
+++ b/en_us/release_notes/source/2016/lms/lms_2016-10-31.rst
@@ -1,0 +1,15 @@
+* This release updates the course **Progress** page to improve the
+  accessibility of the page for learners who use screen readers. This page now
+  has a logical and meaningful HTML structure, and heading levels and
+  indentation are now consistently applied. (:jira:`AC-582`)
+
+* Course team members who use the bulk email feature can now
+  :ref:`review details <partnercoursestaff:Review Sent Messages>` for the
+  messages they send by selecting **Instructor**, **Email**, **Email Task
+  History**, and then **Show Sent Email History**. Previously, the message
+  did not open as expected in a dialog box. (:jira:`TNL-5840`)
+
+* When you view your course as a student,
+  :ref:`custom pages <partnercoursestaff:Add Page>` that you defined to be
+  hidden from students no longer appear in the LMS. (:jira:`OSPR-1528`)
+

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week of 31 October 2016
+*************************
+
+.. include:: 2016/lms/lms_2016-10-31.rst
+
+*************************
 Week of 24 October 2016
 *************************
 


### PR DESCRIPTION
## [DOC-3467](https://openedx.atlassian.net/browse/DOC-3467)

See https://openedx.atlassian.net/wiki/display/ENG/2016-11-01+Release for items identified as release note content. 

### Date Needed 

EOD 31 Oct 2016

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @cptvitamin 
- [x] Subject matter expert: @cahrens 
- [x] Subject matter expert: @alisan617 
- [x] Doc team review (copy edit): @edx/doc
- [x] Product review: @sstack22 or @marcotuts ?
- [ ] Partner support: 
- [ ] PM review: 

FYI: @mmacfarlane

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

