### PR TITLE
DOC-3479 - Ability to remove opt-out for proctored exams

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
@@ -430,6 +430,41 @@ To specify custom proctored exam rules and rule exceptions, follow these steps.
    attempts. Use uncomplicated sentences and words that a global English-
    speaking audience will understand.
 
+.. _Allow Opting Out of Proctored Exams:
+
+*************************************************************
+Allowing Verified Learners to Opt Out of Proctored Exams
+*************************************************************
+
+By default, verified learners can choose to take proctored exams without
+online proctoring, and accept that they are no longer eligible for course
+credit if they make this choice.
+
+If you do not want to give verified learners in your course the choice of
+taking proctored exams without proctoring, you can change a setting on the
+**Advanced Settings** page in Studio.
+
+==============================================================
+Do Not Allow Verified Learners to Opt Out of Proctored Exams
+==============================================================
+
+To remove the option for verified learners to opt out of proctored exams in
+your course, follow these steps.
+
+#. In Studio, select **Settings**, then select **Advanced Settings**.
+
+#. Locate the **Allow Opting Out of Proctored Exams** policy key. The default
+   value is ``true``, which gives verified learners the option of taking
+   proctored exams without proctoring.
+
+#. Change the value of the setting to ``false``.
+
+#. Select **Save Changes**.
+
+After you enable this setting for your course, options for taking exams
+without proctoring are no longer available to verified learners.
+
+
 .. _Respond to Learner Concerns about Proctored Exams:
 
 **********************************************************


### PR DESCRIPTION
## [DOC-3479](https://openedx.atlassian.net/browse/DOC-3479)

This PR adds a topic to the course author's guide to explain the new ability to remove opt-out options for proctored exams.

### Date Needed: Nov 8 release

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @andy-armstrong 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @srpearce 
- [ ] Product review: @marcotuts 

FYI
@jaakana, @dhixonedx, @jhendersonedx, @mmacfarlane

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits


