### PR TITLE
DOC-3480: Release Notes for week of Nov 8, 2016

### DIFF
--- a/en_us/release_notes/source/2016/2016-11-08.rst
+++ b/en_us/release_notes/source/2016/2016-11-08.rst
@@ -1,0 +1,46 @@
+#########################
+Week of 7 November 2016
+#########################
+
+The following information summarizes what is new in the edX platform this week.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+Studio
+*************
+
+.. include:: studio/studio_2016-11-08.rst
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2016-11-08.rst
+
+
+*************
+Analytics
+*************
+
+.. include:: analytics/analytics_2016-11-08.rst
+
+
+*************
+Open edX
+*************
+
+.. include:: studio/studio_2016-11-08.rst
+
+
+
+.. include:: ../../../links/links.rst

--- a/en_us/release_notes/source/2016/analytics/analytics_2016-11-08.rst
+++ b/en_us/release_notes/source/2016/analytics/analytics_2016-11-08.rst
@@ -1,0 +1,16 @@
+In Insights, the Weekly Student Engagement chart and the Content Engagement
+Breakdown report now include discussion participation counts for each week.
+Learners who added a post, a response, or a comment are included in this count.
+The "Participated in Discussions Last Week" metric reports the number of unique
+users who added a post, response, or comment to any course discussion topic in
+the last week, and also provides this value as a percentage of currently
+enrolled students.
+
+For more information, see the `Engagement Activity`_ section in the *Using edX
+Insights* guide.
+
+.. _Engagement Activity: http://edx.readthedocs.io/projects/edx-insights/en/latest/engagement/Engagement_Content.html
+
+
+
+

--- a/en_us/release_notes/source/2016/index.rst
+++ b/en_us/release_notes/source/2016/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2016.
 .. toctree::
    :maxdepth: 1
 
+   2016-11-08
    2016-10-31
    2016-10-24
    2016-10-18

--- a/en_us/release_notes/source/2016/lms/lms_2016-11-08.rst
+++ b/en_us/release_notes/source/2016/lms/lms_2016-11-08.rst
@@ -1,0 +1,4 @@
+This release resolves an issue where tasks that were in progress on the **Data
+Download** tab in the Instructor Dashboard (such as generating problem
+reports) did not display in the table of pending tasks. The **Pending Tasks**
+table now correctly displays tasks that are in progress. (:jira:`TNL-5858`)

--- a/en_us/release_notes/source/2016/openedx/openedx_2016-11-08.rst
+++ b/en_us/release_notes/source/2016/openedx/openedx_2016-11-08.rst
@@ -1,0 +1,5 @@
+EdX has updated Django, the web framework that edX uses to develop Studio and
+the LMS, from version 1.8.15 to version 1.8.16. This update reflects a Django
+security release and does not result in any user-visible changes. For more
+information about Django versions, see
+https://www.djangoproject.com/weblog/2016/nov/01/security-releases/.

--- a/en_us/release_notes/source/2016/studio/studio_2016-11-08.rst
+++ b/en_us/release_notes/source/2016/studio/studio_2016-11-08.rst
@@ -1,0 +1,14 @@
+* Course teams that use proctored exams in their courses can now use a new
+  option on the **Advanced Settings** page in Studio to control whether verified
+  learners must take proctored exams with online proctoring. Previously,
+  verified learners could opt out of taking proctored exams with online
+  proctoring, with the understanding that this choice made them ineligible for
+  course credit. Now, when course teams set the **Allow Opting Out of
+  Proctored Exams** option to ``false``, verified learners no longer have the
+  ability to choose to take proctored exams without online proctoring.
+  (:jira:`TNL-5084`) For more information, see :ref:`partnercoursestaff:Allow
+  Opting Out of Proctored Exams` in the *Building and Running an edX Course* guide.
+
+* On the **Certificates** settings page in Studio, the Help text in the sidebar
+  now correctly indicates that activation of configured certificates is done by
+  edX partner managers rather than by course team members.

--- a/en_us/release_notes/source/analytics_index.rst
+++ b/en_us/release_notes/source/analytics_index.rst
@@ -11,6 +11,12 @@ The following information describes what is new in edX analytics.
   :depth: 2
 
 **************************
+Week of 8 November 2016
+**************************
+
+.. include:: 2016/analytics/analytics_2016-11-08.rst
+
+**************************
 Week of 24 October 2016
 **************************
 

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week of 7 November 2016
+*************************
+
+.. include:: 2016/lms/lms_2016-11-08.rst
+
+*************************
 Week of 31 October 2016
 *************************
 

--- a/en_us/release_notes/source/openedx_index.rst
+++ b/en_us/release_notes/source/openedx_index.rst
@@ -12,6 +12,12 @@ The following information summarizes what is new in Open edX.
 
 
 *************************
+Week of 7 November 2016
+*************************
+
+.. include:: 2016/openedx/openedx_2016-11-08.rst
+
+*************************
 Week of 3 October 2016
 *************************
 

--- a/en_us/release_notes/source/studio_index.rst
+++ b/en_us/release_notes/source/studio_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in edX Studio.
   :depth: 2
 
 *************************
+Week of 7 November 2016
+*************************
+
+.. include:: 2016/studio/studio_2016-11-08.rst
+
+*************************
 Week of 24 October 2016
 *************************
 


### PR DESCRIPTION
## [DOC-3480](https://openedx.atlassian.net/browse/DOC-3480)

See https://openedx.atlassian.net/wiki/display/ENG/2016-11-08+Release for items identified as release note content. 

### Date Needed: End of day, Monday November 7, 2016

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @alisan617 for TNL-5858
- [x] Subject matter expert: @andy-armstrong for proctoring option
- [x] Subject matter expert: @jibsheet for Django upgrade
- [x]  Subject matter expert: @dsjen or @katymyw for Insights
- [x] Doc team review (copy edit): @srpearce 
- [x] Product review: @sstack22 or @marcotuts

FYI: @mmacfarlane, @jaakana, @dhixonedx, @scottrish 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors - Tests will fail due to known issue with new anchors introduced.

### Post-review

- [x] Squash commits