### PR TITLE
Fix include link in Nov 8 RN

### DIFF
--- a/en_us/release_notes/source/2016/2016-11-08.rst
+++ b/en_us/release_notes/source/2016/2016-11-08.rst
@@ -39,7 +39,7 @@ Analytics
 Open edX
 *************
 
-.. include:: studio/studio_2016-11-08.rst
+.. include:: openedx/openedx_2016-11-08.rst
 
 
 


### PR DESCRIPTION
This PR fixes an incorrect "include" link for the open edx section of the Nov 8 release notes.
Error is in https://github.com/edx/edx-documentation/pull/1339
