### PR TITLE
DOC-3483: Mark student verification status table deprecated in Research Guide

### DIFF
--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -1565,10 +1565,12 @@ last_activity_at
 Columns in the ``verify_student_verificationstatus`` Table
 ==========================================================
 
+.. note:: This table is deprecated.
+
 The ``verify_student_verificationstatus`` table shows learner re-verification
 attempts and outcomes.
 
-**History**: Added 5 Aug 2015.
+**History**: Added 5 Aug 2015. Deprecated.
 
 A sample of the heading row and a data row in the
 ``verify_student_verificationstatus`` table follow.


### PR DESCRIPTION
## [DOC-3483](https://openedx.atlassian.net/browse/DOC-3483)
This PR adds a note to the `verify_student_verificationstatus`` table section in the Research guide indicating that this table is deprecated.


### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @stroilova
- [x] Doc team review (sanity check, copy edit, or dev edit?): @srpearce
- [x] Product review: @sstack22

FYI: @mmacfarlane, @jaakana

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits


