### PR TITLE
DOC-3489: Restore "Need Help?" link in edX Learner's Guide

### DIFF
--- a/shared/conf.py
+++ b/shared/conf.py
@@ -83,7 +83,7 @@ DEVELOPERS = object()
 
 HELP_LINKS = {
     (PARTNER, COURSE_TEAMS): None, #"https://partners.edx.org/forums/partner-forums",
-    (PARTNER, LEARNERS): None, #"https://support.edx.org",
+    (PARTNER, LEARNERS): "https://support.edx.org",
     (PARTNER, RESEARCHERS): "http://edx.readthedocs.org/projects/devdata/en/latest/front_matter/preface.html#resources-for-researchers",
     (PARTNER, DEVELOPERS): "https://open.edx.org/resources/e-mail-lists",
     (OPENEDX, COURSE_TEAMS): "https://open.edx.org/resources/e-mail-lists",


### PR DESCRIPTION
## [DOC-3489](https://openedx.atlassian.net/browse/DOC-3489)

This PR restores the "Need Help?" link in the header of the edX Learner's Guide. This link leads to the Zendesk FAQs page. Previously, without such a link, learners were posting support requests and questions in the documentation feedback form, even though it was clearly indicated to be an anonymous form from which they could not expect replies.

This change does not affect the Open edX Learner's Guide.

Screenshot of Learner's Guide header with this change:
![addedhelplink](https://cloud.githubusercontent.com/assets/9041399/20193297/64bc60d4-a75b-11e6-83cc-7e5aebf94835.png)


### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Dev: @nedbat  
- [ ] Student support: @dhixonedx
- [x] Doc team review (sanity check): @srpearce 

FYI: @marcotuts @sstack22 @nasthagiri 





### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits


