### PR TITLE
DOC-3383: Course authors can duplicate sections, subsections, or units

### DIFF
--- a/en_us/shared/developing_course/course_outline.rst
+++ b/en_us/shared/developing_course/course_outline.rst
@@ -126,19 +126,10 @@ Units>`.
 Add Content in the Course Outline
 ************************************************
 
-You add sections, subsections, and units directly in the outline.
+You can add content in the course outline by creating a new section,
+subsection, or unit, or by duplicating an existing unit, subsection, or
+section.
 
-* To add a section to the outline, select **New Section**. This option appears
-  at both the top of the page and below the current sections in the outline.
-  For more information, see :ref:`Create a Section`.
-
-*  To add a subsection to the end of the section, expand the section and select
-   **New Subsection**.
-
-* To add a unit to the end of a subsection, expand the subsection and select
-  **New Unit**.
-
-  The :ref:`unit<Developing Course Units>` page opens.
 
 .. the following note is for prerequisite exams, which are currently released in open edx only and not on edx.org.  when they are available on edx.org, this note should no longer be conditionalized.
 
@@ -149,6 +140,40 @@ You add sections, subsections, and units directly in the outline.
       the exam in the course outline. Before you can create an exam, you must
       set your course to require an entrance exam in Studio. For more
       information, see :ref:`Require an Entrance Exam`.
+
+
+==========================================
+Adding New Sections, Subsections, or Units
+==========================================
+
+* To add a section to the outline, select **New Section**. This option appears
+  at both the top of the page and below the current sections in the outline.
+  For more information, see :ref:`Create a Section`.
+
+*  To add a subsection to the end of the section, expand the section and select
+   **New Subsection**.
+
+* To add a unit to the end of a subsection, expand the subsection and select
+  **New Unit**. The :ref:`unit<Developing Course Units>` page opens.
+
+
+=======================================================
+Duplicating Existing Sections, Subsections, or Units
+=======================================================
+
+To add a section, subsection, or unit by duplicating content that already exists
+in the course outline, select the **Duplicate** icon for the item that you want
+to duplicate. You see a **Duplicating** indicator at the bottom of the Studio
+page.
+
+Duplicated items are added to the course outline immediately below the
+original item, with the name "Duplicate of <original item name>".
+
+.. note:: Duplicated items inherit the release date of the item that they are
+   duplicated from, but you must explicitly publish duplicated subsections and
+   units before they are visible to learners. For more information about
+   release statuses and visibility of sections to learners, see :ref:`Sections
+   and Visibility to Learners`.
 
 .. _Modify Settings for Objects in the Course Outline:
 

--- a/en_us/shared/developing_course/course_sections.rst
+++ b/en_us/shared/developing_course/course_sections.rst
@@ -42,6 +42,8 @@ are circled, and the third one is expanded to show its subsections.
  :width: 600
  :alt: The learner view of the course with three sections circled.
 
+.. _Sections and Visibility to Learners:
+
 ************************************************
 Sections and Visibility to Learners
 ************************************************


### PR DESCRIPTION
## [DOC-3383](https://openedx.atlassian.net/browse/DOC-3383)

This PR adds details about duplicating course content in Studio to the "Building and Running an edX/Open edX Course" guide. (TNL-5797)

Currently available for testing on stage.

### Date Needed
Will be on edx.org in the Nov 29, 2016 release.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @mushtaqak 
- [ ] Doc team review: @srpearce 
- [x] Product review: @sstack22 

FYI:
@jaakana, @mmacfarlane

### Testing
- [x] Ran ./run_tests.sh without warnings or errors


### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits


