### PR TITLE
DOC-3495 Upgrade to Sphinx 1.3.5

### DIFF
--- a/shared/travis_requirements.txt
+++ b/shared/travis_requirements.txt
@@ -1,5 +1,5 @@
 # Used for documentation gathering
 edx-sphinx-theme==1.0.2
-sphinx==1.1.3
+sphinx==1.3.5
 sphinx_rtd_theme==0.1.5
 sphinxcontrib-napoleon==0.2.6


### PR DESCRIPTION
## [DOC-3495](https://openedx.atlassian.net/browse/DOC-3495)

Upgrade Sphinx to the current default version used by Read the Docs (which has been used for most recent builds anyway, since we didn't specify otherwise until today).  The version which had been in our requirements file was too old to support the ``-T`` parameter that Read the Docs passes to ``sphinx-build``.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check): @edx/doc
- [x] Product review: @nedbat 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits


