### PR TITLE
DOC-3497 - Course teams can remove previously uploaded videos from list

### DIFF
--- a/en_us/course_authors/source/video/video_uploads.rst
+++ b/en_us/course_authors/source/video/video_uploads.rst
@@ -11,7 +11,7 @@ Studio. This section describes the specifications met by successful video
 files, the steps to upload the files, and how you monitor video processing
 at edX.
 
-.. removed "how course teams enable the video upload process in Studio, "
+.. removed "how course teams enable the video upload process in Studio", which is commented out below in this file.
 
 * :ref:`Specifications for Successful Video Files`
 
@@ -175,10 +175,38 @@ partner support team. See :ref:`Create YouTube Channels`.
 .. important:: You must leave the **Video Uploads** page open in your
    browser until the upload process is complete for all files.
 
-When the status of an uploaded file changes to Ready, the file upload process
-is successful. If the status changes to Failed, the file upload process is not
-successful. You can monitor file progress on the **Video Uploads** page or
-download a report.
+When the status of an uploaded file changes to "Ready", the file upload
+process is successful. If the status of an upload is "Failed", the file upload
+process was not successful. You can monitor file progress on the **Video
+Uploads** page or download a report.
+
+
+.. _Delete Videos from Upload Page:
+
+==================================================
+Remove Videos from the Video Uploads Page
+==================================================
+
+A list of every file that you uploaded to the edX servers appears in the
+**Previous Uploads** section of the **Video Uploads** page. You can remove
+videos from the **Previous Uploads** list without affecting course content
+that uses the video ID of successfully uploaded videos.
+
+To remove a video from the **Previous Uploads** list, follow these steps.
+
+#. Open the course in Studio.
+
+#. Select **Content**, then **Video Uploads**.
+
+#. In the **Previous Uploads** list, locate the row for the video that you
+   want to remove, then select the "X" icon in the **Action** column.
+
+#. In the confirmation dialog box that appears, select **Remove** to remove
+   the video.
+
+   The selected video is removed from the **Previous Uploads** list. Course
+   content that uses the video ID of the removed video is not affected.
+
 
 .. _Monitor Video Processing:
 


### PR DESCRIPTION
## [DOC-3497](https://openedx.atlassian.net/browse/DOC-3497)

Adds a topic to the B&R guide with steps for removing videos from the "Previous Uploads" list in Studio > Content > Video Uploads. Removing a video in this way is a "soft" delete - there is no impact to videos whose IDs are already in use in video components.
Reflects the code changes in TNL-5899.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @muhammad-ammar 
- [x] Doc team review: @srpearce 
- [x] Product review: @sstack22 

FYI: @jaakana 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits


