### PR TITLE
DOC: Remove mention of practice proctored exam in DemoX

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/online_proctoring_rules_students.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/online_proctoring_rules_students.rst
@@ -15,12 +15,11 @@ exam, your course staff will let you know. If you are not told about any
 different proctoring exam rules, make sure you adhere to the "Closed Book
 Exam" rules that are described in the following sections.
 
-Students are responsible for testing their systems with the proctoring
-software well in advance of all online proctored exams in their courses, so
-that any troubleshooting that is required can be accomplished. Students might
-be able to take practice proctored exams in their course, or can refer to the
-free Demo Course on edX.org, where they can experience a sample proctored
-exam.
+Learners are responsible for testing their systems with the proctoring software
+well in advance of all online proctored exams in their courses, so that any
+troubleshooting that is required can be accomplished. Some courses include
+practice proctored exams, so that learners can experience an example proctored
+exam, including the software download and system check steps.
 
 As with other ID-verified assessments and exams, learners will be asked to
 establish their identity during the proctored exam process by supplying a

--- a/en_us/students/source/completing_assignments/online_proctoring_rules_students.rst
+++ b/en_us/students/source/completing_assignments/online_proctoring_rules_students.rst
@@ -26,12 +26,11 @@ exam, your course staff will let you know. If you are not told about any
 different proctoring exam rules, make sure you adhere to the "Closed Book
 Exam" rules that are described in the following sections.
 
-Learners are responsible for testing their systems with the proctoring
-software well in advance of all online proctored exams in their courses, so
-that any troubleshooting that is required can be accomplished. Learners might
-be able to take practice proctored exams in their course, or can refer to the
-free Demo Course on edX.org, where they can experience a sample proctored
-exam.
+Learners are responsible for testing their systems with the proctoring software
+well in advance of all online proctored exams in their courses, so that any
+troubleshooting that is required can be accomplished. Some courses include
+practice proctored exams, so that learners can experience an example proctored
+exam, including the software download and system check steps.
 
 As with other ID-verified assessments and exams, learners will be asked to
 establish their identity during the proctored exam process by supplying a


### PR DESCRIPTION
Removes mention of a practice proctored exam being in DemoX from the "online proctoring rules" topic that appears both in the _Learner's Guide_ and in the _Building and Running an edX Course_ guide.
FYI @jaakana