### PR TITLE
Adding VBox and Vagrant max versions

### DIFF
--- a/en_us/install_operations/source/installation/installation_prerequisites.rst
+++ b/en_us/install_operations/source/installation/installation_prerequisites.rst
@@ -41,9 +41,9 @@ Software Prerequisites
 
 Devstack, fullstack, and analytics devstack require the following software.
 
-* `VirtualBox`_ 4.3.12 or later.
+* `VirtualBox`_ 4.3.12 through 5.0. VirtualBox 5.1 and above currently have known issues.
 
-* `Vagrant`_ 1.6.5 or later.
+* `Vagrant`_ 1.6.5 through 1.7. Vagrant 1.8 and above currently have known issues.
 
 * An NFS (network file system) client, if your operating system does not
   include one. NFS allows devstack and fullstack virtual machines to share a


### PR DESCRIPTION
Ran into some issues with setting up devstack on the most recent Vagrant and VirtualBox versions. Looks like they are known issues, so just updating the docs to clarify working versions of those requirements.

## [OPEN-1658] (https://openedx.atlassian.net/browse/OPEN-1658)

### Reviewers

- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [x] Product review: @jmbowman 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits


