### PR TITLE
Update info about Staff course team role

### DIFF
--- a/en_us/shared/set_up_course/course_staffing.rst
+++ b/en_us/shared/set_up_course/course_staffing.rst
@@ -32,6 +32,8 @@ and discussion team members must be enrolled in your course, but they do not
 need to have the Staff or Admin role. For more information, see
 :ref:`Beta_Testing` and :ref:`Assigning_discussion_roles`.
 
+.. _Administrative Team Roles:
+
 ****************************
 Administrative Team Roles
 ****************************
@@ -45,7 +47,8 @@ Team members with the **Staff** role can complete these tasks.
 
 * Enroll and unenroll learners.
 
-* Access learner grades.
+* Access and modify grades for individual learners. For example, users with the
+  Staff role can reset an individual learner's attempt to answer a question.
 
 * See course HTML errors.
 
@@ -55,7 +58,8 @@ Team members with the **Admin** role have access to all of the same options for
 running the course as team members with the Staff role. They can also complete
 these tasks.
 
-* Reset learner attempts to answer a question correctly.
+* Access and modify grades for all learners in a course. For example, users
+  with the Admin role can reset all learners' attempts to answer a question.
 
 * Add and remove Staff.
 


### PR DESCRIPTION
## [DOC-3508](https://openedx.atlassian.net/browse/DOC-3508)

Add that users with the Staff role can update individual learners' grades, such as resetting an individual learner's attempts for a problem, and that Admin users can update all learners' grades.

### Date Needed (optional)

6 December 2016

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @efischer19 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @catong 
- [ ] Product review: @sstack22 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits


