### PR TITLE
Updated curl commands to be single line

### DIFF
--- a/en_us/course_catalog_api_user_guide/source/authentication/index.rst
+++ b/en_us/course_catalog_api_user_guide/source/authentication/index.rst
@@ -215,12 +215,7 @@ the edX API authentication endpoint.
 
 .. code-block:: bash
 
-    curl -X POST \
-    -d "grant_type=client_credentials&client_id=VB1AkrAE28ArNnOizi4OEKq03UGu9oI
-    0h9DPbvwe&client_secret=wFMUqjZKQzboPEQSBLxERatup7r772hzg98xLu6fr6s7vIta5Xj
-    3MPmrKEZbfPdPjagkBdmLjQXlqu2IMC2TnaMutVLZF9AGXn9LqZv9P9oE73pAV6L4iZxzpuQBuT
-    mk&token_type=jwt" \
-    https://api.edx.org/oauth2/v1/access_token
+    curl -X POST -d "grant_type=client_credentials&client_id=VB1AkrAE28ArNnOizi4OEKq03UGu9oI0h9DPbvwe&client_secret=wFMUqjZKQzboPEQSBLxERatup7r772hzg98xLu6fr6s7vIta5Xj3MPmrKEZbfPdPjagkBdmLjQXlqu2IMC2TnaMutVLZF9AGXn9LqZv9P9oE73pAV6L4iZxzpuQBuTmk&token_type=jwt" https://api.edx.org/oauth2/v1/access_token
 
 .. _authentication_endpoint_response:
 
@@ -278,14 +273,6 @@ in the ``Authorization`` HTTP header field.
 
 .. code-block:: bash
 
-  curl -X GET \
-  -H "Authorization: JWT 4IHZlbCB2aXZlcnJhIGdyYXZpZGEsIHJpc3V.TG9yZW0gaXBzdW0gZ
-  G9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRXRpYW0gdGluY2lkdW
-  50IG9kaW8gZWdldCB0aW5jaWR1bnQgcG9ydGEuIEZ1c2NlIHZlaGljdWxhIGFyY3UgdGVsbHVzLCB
-  zaXQgYW1ldCBmcmluZ2lsbGEgZXN0IHByZXRpdW0gc2VkLiBDdXJhYml0dXIgY29uc2VxdWF0IHVs
-  dHJpY2llcyB0cmlzdGlxdWUuIEluIGVzdCBwdXJ1cywgZmFjaWxpc2lzIGFjIGxlY3R1cyBxdWlzL
-  CBsdWN0dXMgdGVtcG9yIG9yY2kuIEludGVnZXIgdml0.YWUgbmVxdWUgbGlndWxhLiBVdCBjb25zZ
-  XF1YXQsIGV" \
-  https://api.edx.org/catalog/v1/catalogs/
+  curl -X GET -H "Authorization: JWT 4IHZlbCB2aXZlcnJhIGdyYXZpZGEsIHJpc3V.TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRXRpYW0gdGluY2lkdW50IG9kaW8gZWdldCB0aW5jaWR1bnQgcG9ydGEuIEZ1c2NlIHZlaGljdWxhIGFyY3UgdGVsbHVzLCBzaXQgYW1ldCBmcmluZ2lsbGEgZXN0IHByZXRpdW0gc2VkLiBDdXJhYml0dXIgY29uc2VxdWF0IHVsdHJpY2llcyB0cmlzdGlxdWUuIEluIGVzdCBwdXJ1cywgZmFjaWxpc2lzIGFjIGxlY3R1cyBxdWlzLCBsdWN0dXMgdGVtcG9yIG9yY2kuIEludGVnZXIgdml0.YWUgbmVxdWUgbGlndWxhLiBVdCBjb25zZXF1YXQsIGV" https://api.edx.org/catalog/v1/catalogs/
 
 .. include:: ../../../links/links.rst

--- a/en_us/course_catalog_api_user_guide/source/course_catalog/catalog.rst
+++ b/en_us/course_catalog_api_user_guide/source/course_catalog/catalog.rst
@@ -41,9 +41,7 @@ Example Request
 
 .. code-block:: bash
 
-   curl -X GET \
-   -H "Authorization: JWT {access token}" \
-   https://api.edx.org/catalog/v1/catalogs/
+   curl -X GET -H "Authorization: JWT {access token}" https://api.edx.org/catalog/v1/catalogs/
 
 =====================
 Response Values
@@ -166,9 +164,7 @@ Example Request
 
 .. code-block:: bash
 
-   curl -X GET \
-   -H "Authorization: JWT {access token}" \
-   https://api.edx.org/catalog/v1/catalogs/1/
+   curl -X GET -H "Authorization: JWT {access token}" https://api.edx.org/catalog/v1/catalogs/1/
 
 =====================
 Response Values
@@ -250,9 +246,7 @@ Example Request
 
 .. code-block:: bash
 
-   curl -X GET \
-   -H "Authorization: JWT {access token}" \
-   https://api.edx.org/catalog/v1/catalogs/1/courses/
+   curl -X GET -H "Authorization: JWT {access token}" https://api.edx.org/catalog/v1/catalogs/1/courses/
 
 =====================
 Response Values
@@ -783,5 +777,3 @@ many courses.
           }
        ]
     }
-
-


### PR DESCRIPTION
Users have been copying these commands incorrectly, and reporting issues to the API support list. Displaying the command on a single line should eliminate these issues.

ECOM-6490

### Date Needed (optional)

This is already in production. I would like to update the documentation as soon as possible.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @clintonb
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

FYI @edx/ecommerce @efagin 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits


