### PR TITLE
DOC-1897 Image uploads require description unless decorative

### DIFF
--- a/en_us/shared/students/sfd_discussions/add_post.rst
+++ b/en_us/shared/students/sfd_discussions/add_post.rst
@@ -99,12 +99,18 @@ topics on the **Discussion** page.
 #. Enter the text of your post. To format the text or to add links or
    images, use the formatting options above the text box.
 
+   .. note:: If you include an image with your post, include a description so
+      that learners who use screen readers to access the course can understand
+      the image's content and purpose. The description also displays in place
+      of the image if problems occur with the image file. If the image has no
+      functional purpose, leave the **Description** field empty and select
+      **This image is for decorative purposes only and does not require a
+      description**.
+
    .. only:: Partners
 
      .. note::
        The maximum size for an uploaded file is 1 MB.
-
-
 
 
    .. only:: Open_edX
@@ -158,6 +164,15 @@ The following steps apply only to content-specific discussions.
 
 #. Enter the text of your post. Select the buttons above the text field to see
    options for formatting the text and for adding links or images.
+
+   .. note:: If you include an image with your post, include a description so
+      that learners who use screen readers to access the course can understand
+      the image's content and purpose. The description also displays in place
+      of the image if problems occur with the image file. If the image has no
+      functional purpose, leave the **Description** field empty and select
+      **This image is for decorative purposes only and does not require a
+      description**.
+
 
    .. only:: Partners
 


### PR DESCRIPTION
## [DOC-1897](https://openedx.atlassian.net/browse/DOC-1897)

Adds a note about image descriptions to the Learner's Guide topics on adding discussion posts.


### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc


### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits


