### PR TITLE
DOC-2487 Add info and link in CA timed exam doc re learner experience

### DIFF
--- a/en_us/shared/course_features/timed_exams.rst
+++ b/en_us/shared/course_features/timed_exams.rst
@@ -18,16 +18,23 @@ You can configure a :ref:`subsection <Developing Course Subsections>`
 in your course so that learners have a set amount of time to complete and
 submit all problems in that subsection.
 
-If a learner goes over the time limit you set, she can no longer submit
-answers to problems in that subsection. The learner does not receive points for
-unsubmitted problems.
+When learners take a timed exam, a timer on the exam page counts down and
+provides alerts as the time limit approaches. When no time remains, learners
+can no longer access additional exam content, or submit additional responses
+to the subsection. All problems that were completed are graded. No points are
+awarded for unsubmitted problems.
 
 Course teams can grant individual learners more time to complete problems in
-the subsection.
+the subsection, but only if learners request additional time **before** starting a
+timed exam.
+
+To better understand the learner's experience of timed exams, see
+:ref:`learners:taking_timed_exams` in the *edX Learner's Guide* or
+:ref:`openlearners:taking_timed_exams` in the *Open edX Learner's Guide*.
 
 .. note::
   Although you can configure an ungraded subsection to be timed, typically
-  you would set a time limit on graded subsections, such as for mid-term or
+  you set a time limit on graded subsections, such as for mid-term or
   final exams.
 
 .. only:: Partners
@@ -35,6 +42,7 @@ the subsection.
   Timed exams are different than :ref:`proctored exams<CA_ProctoredExams>`.
   While both types of exams have a time limit, learners are only monitored
   during proctored exams.
+
 
 *******************
 Enable Timed Exams


### PR DESCRIPTION
## [DOC-2487](https://openedx.atlassian.net/browse/DOC-2487)

Add more info and links in CA timed exam doc to "Taking Timed Exams" section in learner's guides. (Replaces OS https://github.com/edx/edx-documentation/pull/1324)

### Reviewers

- [x] Doc team review: @srpearce 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

