### PR TITLE
Update release notes to correct 'not accessible' value

### DIFF
--- a/en_us/release_notes/source/2016/lms/lms_2016-12-05.rst
+++ b/en_us/release_notes/source/2016/lms/lms_2016-12-05.rst
@@ -1,7 +1,8 @@
-* The grade report and the problem grade report now include "Not Attempted" and
-  "Not Accessible" values for assignments or problems that learners have not
-  attempted or did not have access to, respectively. For more information, see
-  :ref:`Access_grades`. (:jira:`TNL-5577`)
+* The grade report and the problem grade report include two new values. "Not
+  Attempted" indicates that a learner has not attempted the problem. "Not
+  Available" indicates that the problem was not available to learners, such as
+  when a problem is available only for a particular cohort. For more
+  information, see :ref:`Access_grades`. (:jira:`TNL-5577`)
 
 * Permissions for the Staff role have been updated. Course team members with
   the Staff role can now access and modify grades for individual learners.


### PR DESCRIPTION
## [DOC-3520](https://openedx.atlassian.net/browse/DOC-3520)

Update release notes to reflect change of value name from "Not Accessible" to "Not Available".

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits


