### PR TITLE
Client side checkout basket

### DIFF
--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -286,9 +286,9 @@ steps.
      the Django administration panel in the LMS. For more information about
      configuring the OIDC client, see :ref:`Configure OIDC`.
 
-*****************************************
+**************************************
 Switch from ShoppingCart to E-Commerce
-*****************************************
+**************************************
 
 By default, the ShoppingCart service is enabled when you install an Open edX
 instance. To use the E-Commerce service to handle ecommerce-related tasks
@@ -314,6 +314,33 @@ instead of ShoppingCart, follow these steps.
 #. Select the site for which you want to enable the E-Commerce service.
 
 #. Select **Save**.
+
+**********************************
+Enable Client Side Checkout Basket
+**********************************
+
+The client side checkout basket enables filling out the payment form directly
+in the basket, without the need to go to the payment processor website to
+complete a purchase.
+Currently only CyberSource is supported as a client-side payment processor.
+The form requires information about the billing client (name, address etc.) and
+credit card information. Currently only AmEx, Visa, MasterCard, Diners,
+Discover, JCB and Maestro credit card types are supported.
+(note: we should probably tell the users that the credit card information is
+never saved and that it's safe to enter that data).
+
+If you want to enable client side checkout basket you need to:
+
+#. Activate the client side payment processor (eg. CyberSource) switch in the
+   admin panel.
+
+#. Set a value for the client side payment processor in the site configuration
+   (if you use CyberSource, enter 'cybersource' in the **Client-side payment
+   processor** input field).
+
+#. Edit the **enable_client_side_checkout** waffle flag to the values that you
+   need.
+
 
 .. _Development Outside Devstack:
 

--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -297,7 +297,8 @@ instead of ShoppingCart, follow these steps.
 #. Sign in to the Django administration console for your base URL. For example,
    ``http://{your_URL}/admin``.
 
-#. In the **Commerce** section, next to **Commerce configuration**, select **Add**. 
+#. In the **Commerce** section, next to **Commerce configuration**, select
+   **Add**.
 
 #. Select **Enabled**.
 
@@ -315,28 +316,42 @@ instead of ShoppingCart, follow these steps.
 
 #. Select **Save**.
 
-**********************************
-Enable Client Side Checkout Basket
-**********************************
+**************************************
+Enable the Client-Side Checkout Basket
+**************************************
 
-The client side checkout basket enables filling out the payment form directly
-in the basket, without the need to go to the payment processor website to
-complete a purchase.
-Currently only CyberSource is supported as a client-side payment processor.
-The form requires information about the billing client (name, address etc.) and
-credit card information. Currently only AmEx, Visa, MasterCard, Diners,
-Discover, JCB and Maestro credit card types are supported.
-(note: we should probably tell the users that the credit card information is
-never saved and that it's safe to enter that data).
+The client-side checkout basket enables users to complete the payment form and
+make a purchase directly in the basket. Users do not have to visit the payment
+processor website.
 
-If you want to enable client side checkout basket you need to:
+.. note::
+  Currently, only CyberSource is supported as a client-side payment processor.
+
+The payment form requires information about the billing client, such as the
+client's name and address, as well as credit card information. The following
+credit card types are supported.
+
+* American Express
+* Diners Club
+* Discover
+* JCB
+* Maestro
+* MasterCard
+* Visa
+
+.. note::
+  The payment processor does not save credit card information.
+
+To enable the client-side checkout basket, follow these steps.
+
+#. Sign in to the Django administration console for your base URL. For example,
+   ``http://{your_URL}/admin``.
 
 #. Activate the client side payment processor (eg. CyberSource) switch in the
    admin panel.
 
-#. Set a value for the client side payment processor in the site configuration
-   (if you use CyberSource, enter 'cybersource' in the **Client-side payment
-   processor** input field).
+#. On the **Site Configuration** page, locate the **Client-side payment
+   processor** field, and then enter ``cybersource``.
 
 #. Edit the **enable_client_side_checkout** waffle flag to the values that you
    need.


### PR DESCRIPTION
## New client-side checkout basket documentation.
The feature was introduced in https://github.com/edx/ecommerce/pull/1048
It enables users to fill out the billing information directly in the basket page and pay for their products without the need to go to a 3rd party payment processor website and return back. This is basically how to looks like:
![screenshot from 2016-12-21 09-45-59](https://cloud.githubusercontent.com/assets/2808092/21382691/53aebb94-c762-11e6-8a99-981155ac9ade.png)

We need to document a description of it and steps necessary to enable it. I've started with adding a very rough documentation that probably needs polishing, also the waffle flag options should probably be described as well, in a table perhaps? These are the options:
![screenshot from 2016-12-21 09-49-17](https://cloud.githubusercontent.com/assets/2808092/21382790/c521c0a0-c762-11e6-9276-459be28cc14d.png)


### Reviewers

- [ ] Subject matter expert: @clintonb 
- [ ] Subject matter expert: @mjfrey 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

