### PR TITLE
DOC-3536 Add Enrollment Track to Student Profile Report columns

### DIFF
--- a/en_us/shared/student_progress/course_student.rst
+++ b/en_us/shared/student_progress/course_student.rst
@@ -133,6 +133,26 @@ team member and the following columns.
        optional and was supplied only at registration.
    * - goals
      - This value is optional and is supplied only at registration.
+   * - enrollment_mode
+     - Indicates the enrollment track that the learner is enrolled in, such as
+       "audit" or "verified".
+   * - verification_status
+
+     - Indicates whether learners who are enrolled in course tracks that require
+       ID verification have successfully verified their identities to edX by
+       submitting an official photo ID via webcam. The value in this column is
+       "N/A" for learners enrolled in course tracks that do not require ID
+       verification.
+
+       A value of "Not ID Verified" in this column indicates that the learner is
+       enrolled in a course track that requires ID verification (such as
+       "verified") but she has not attempted ID verification, or the ID
+       verification has failed or expired.
+
+       A value of "ID Verified" indicates that the learner is enrolled in a
+       course track that requires ID verification, and her ID verification is
+       current and valid.
+
    * - cohort
      - This column is included only if the course has cohorts enabled. For
        courses that include learner cohorts, shows the name of the cohort group
@@ -147,6 +167,7 @@ team member and the following columns.
    * - country
      - Learners are required to specify **Country** during registration, and can
        update this value on the **Account Settings** page.
+
 
 
 .. _View and download student data:


### PR DESCRIPTION
## [DOC-3536](https://openedx.atlassian.net/browse/DOC-3536)

Adds enrollment track information to the Student Profile Report, per TNL-6214

### Date Needed:
Jan 3/ASAP - the code PR has already merged.

### Reviewers

- [x] Subject matter expert: @sanfordstudent 
- [x] Doc team review: @srpearce 
- [x] Product review: @sstack22 

FYI: @jaakana @dhixonedx 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

