### PR TITLE
DOC-3539 Video upload process

### DIFF
--- a/en_us/course_authors/source/video/video_uploads.rst
+++ b/en_us/course_authors/source/video/video_uploads.rst
@@ -239,6 +239,8 @@ The encoding and hosting process assigns these statuses to video files.
   processing. See :ref:`Specifications for Successful Video Files`. Then try
   uploading the file (or its replacement) again.
 
+* **Uploaded** files have successfully completed uploading to the edX servers.
+
 * **In Progress** files are undergoing processing to create additional file
   formats or waiting for successful transfer to the host sites.
 


### PR DESCRIPTION
## [DOC-3539](https://openedx.atlassian.net/browse/DOC-3539)

Reflects improved video upload error handling (TNL-4777) but does not depend on that PR merging. Minor changes to clarify upload statuses in the "Building and Running an edX Course" guide.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @muhammad-ammar 
- [x] Doc team review: @srpearce 
- [ ] Product review: @sstack22 

FYI: @jaakana

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Sandbox

https://studio-upload-error-message.sandbox.edx.org/videos/course-v1:edX+DemoX+Demo_Course

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
