### PR TITLE
DOC-3544 Learners allowed to skip entrance exam 

### DIFF
--- a/en_us/shared/set_up_course/course_prerequisites.rst
+++ b/en_us/shared/set_up_course/course_prerequisites.rst
@@ -59,7 +59,7 @@ Require an Entrance Exam
 
 You can require your learners to pass an entrance exam before they access your
 course materials. If you include an entrance exam, learners who enroll in your
-course can only access the **Entrance Exam** page until they pass the exam.
+course can access only the **Entrance Exam** page until they pass the exam.
 After learners pass the exam, they can access all released materials in your
 course.
 
@@ -69,7 +69,7 @@ To require an entrance exam, follow these steps.
 #. On the **Settings** menu, select **Schedule & Details**.
 #. On the **Schedule & Details** page, locate the **Requirements** section.
 #. Select the **Require students to pass an exam before accessing course
-   materials** check box.
+   materials** option.
 #. Select **Save Changes**.
 
 After you save your changes, Studio automatically creates an **Entrance Exam**
@@ -100,8 +100,8 @@ learners have a positive experience with entrance exams.
   * To begin the course entrance exam, learners select **Entrance Exam**.
 
   * After learners complete the entrance exam, they must select
-    **Entrance Exam** again or refresh the page in their browsers. When the
-    page refreshes, learners can see all currently available course content.
+    **Entrance Exam** again or refresh the page in their browsers. After the
+    page refreshes, learners can access all currently available course content.
 
 ================================================
 Create an Entrance Exam from the Course Outline

--- a/en_us/shared/students/SFD_prerequisites.rst
+++ b/en_us/shared/students/SFD_prerequisites.rst
@@ -60,13 +60,17 @@ Entrance Exam
 **************************
 
 If you enroll in a course that requires an entrance exam, the course appears on
-your Student Dashboard. However, you cannot access all released course content
-immediately.
+your dashboard. However, you cannot access all released course content before
+passing the entrance exam.
 
-The first time that you access the course, the course opens to the **Entrance
-Exam** page. At the top of the page, you can see a message that lists your
-current score and the minimum score that is required to pass the entrance
-exam. You can begin the exam immediately.
+.. note:: The course team can allow learners to skip the entrance exam. If a
+   course team member allows you to skip the entrance exam, you can access all
+   released course content without having to take the entrance exam.
+
+If you are required to take the entrance exam, the first time that you access
+the course, the course opens to the **Entrance Exam** page. At the top of the
+page, you can see a message that lists your current score and the minimum score
+that is required to pass the entrance exam. You can begin the exam immediately.
 
 .. image:: ../../shared/students/Images/EntEx_LandingPage.png
   :width: 500
@@ -84,8 +88,6 @@ After you pass the entrance exam, in addition to the message at the top of the
 page, you can see all of the currently available course sections in the course
 navigation pane, and you can access all available course materials.
 
-The course team can allow learners to skip the entrance exam. If a course team
-member allows you to skip the entrance exam, you do not see the entrance exam
-when you access the course.
+
 
 .. include:: ../../links/links.rst


### PR DESCRIPTION
Reword misleading doc that seems to indicate that learners who are allowed to skip a course entrance exam do not see the entrance exam in the course outline.

## [DOC-3544](https://openedx.atlassian.net/browse/DOC-3544)

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @noraiz-anwar 
- [x] Doc team review: @srpearce 

FYI @marcotuts @jaakana @dhixonedx

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

