### PR TITLE
DOC-2164 Video Upload

### DIFF
--- a/en_us/course_authors/source/video/video_course.rst
+++ b/en_us/course_authors/source/video/video_course.rst
@@ -15,6 +15,11 @@ process.
 This section also describes how you :ref:`add a transcript<Add a Video
 Transcript>` and associate it with the video file in a video component.
 
+.. contents::
+  :local:
+  :depth: 1
+
+
 .. _Copy the edX Video ID:
 
 ************************

--- a/en_us/course_authors/source/video/video_overview.rst
+++ b/en_us/course_authors/source/video/video_overview.rst
@@ -27,6 +27,10 @@ multiple playback and download needs.
  courses that run on the edx.org site. For information about adding video files
  to courses that run on Edge, see :ref:`Working with Video Components`.
 
+.. contents::
+  :local:
+  :depth: 1
+
 ************************************
 Course Team Video Upload Overview
 ************************************
@@ -56,8 +60,8 @@ accounts to ensure optimal playback quality for course videos.
      video ID and then transcoding it into four formats and transferring the
      results to two host sites
 
-.. important:: The automated encoding and hosting process takes **24 hours**
- to complete.
+.. important:: The automated encoding and hosting process takes up to **24
+   hours** to complete.
 
 If a step fails to complete successfully the process includes multiple
 automated retries.

--- a/en_us/course_authors/source/video/video_prereqs.rst
+++ b/en_us/course_authors/source/video/video_prereqs.rst
@@ -7,11 +7,9 @@ Getting Started with Video
 Before your course teams can begin to upload videos in Studio, you work with
 edX partner support to make sure that these preparatory tasks are complete.
 
-* :ref:`Identify Video Administrators`
-
-* :ref:`Establish Access to YouTube Account`
-
-* :ref:`Create YouTube Channels`
+.. contents::
+  :local:
+  :depth: 1
 
 After these tasks are complete, your course teams can :ref:`upload original
 video files<Uploading Videos in Studio>` in .mp4 or .mov format to Studio, and
@@ -205,7 +203,7 @@ Course team members who complete the activation process are channel managers.
 When they log in to YouTube at https://www.youtube.com using the email address
 that has channel manager privileges, they can manage course content.
 
-.. important:: It takes 24 hours to complete the automated encoding and
+.. important:: It takes up to 24 hours to complete the automated encoding and
  hosting process for each video file that a course team uploads in Studio.
  Channel managers cannot use YouTube to work with the resulting hosted file
  until after the process is complete.

--- a/en_us/course_authors/source/video/video_uploads.rst
+++ b/en_us/course_authors/source/video/video_uploads.rst
@@ -13,11 +13,9 @@ at edX.
 
 .. removed "how course teams enable the video upload process in Studio", which is commented out below in this file.
 
-* :ref:`Specifications for Successful Video Files`
-
-* :ref:`Upload Video Files`
-
-* :ref:`Monitor Video Processing`
+.. contents::
+  :local:
+  :depth: 2
 
 The result of video processing is additional file formats that are transferred
 to multiple hosting services (YouTube CMS and Amazon AWS), ready for learners
@@ -175,10 +173,13 @@ partner support team. See :ref:`Create YouTube Channels`.
 .. important:: You must leave the **Video Uploads** page open in your
    browser until the upload process is complete for all files.
 
-When the status of an uploaded file changes to "Ready", the file upload
-process is successful. If the status of an upload is "Failed", the file upload
-process was not successful. You can monitor file progress on the **Video
-Uploads** page or download a report.
+When the status of an uploaded file changes to "Ready", the file upload process
+is successful. If the status of an upload is "Failed", the file upload process
+was not successful. The duration of a video is listed as "Pending" until the
+process determines the duration.
+
+You can monitor file progress by checking statuses on the **Video Uploads**
+page or by :ref:`downloading a report<Reporting Video Status>`.
 
 
 .. _Delete Videos from Upload Page:
@@ -217,7 +218,7 @@ Monitor Video Processing
 After your video files successfully reach the edX servers, automated
 processing begins.
 
-.. note:: Automated processing takes 24 hours to complete.
+.. note:: Automated processing takes up to 24 hours to complete.
 
 A list of every file that you attempt to upload to the edX servers appears in
 the **Previous Uploads** section of the **Video Uploads** page. The list
@@ -239,10 +240,10 @@ The encoding and hosting process assigns these statuses to video files.
   processing. See :ref:`Specifications for Successful Video Files`. Then try
   uploading the file (or its replacement) again.
 
-* **Uploaded** files have successfully completed uploading to the edX servers.
-
 * **In Progress** files are undergoing processing to create additional file
   formats or waiting for successful transfer to the host sites.
+
+* **Uploaded** files have successfully completed uploading to the edX servers.
 
 * **Ready** files are ready for inclusion in your course and for learners to
   view. See :ref:`Adding Videos to a Course`. When you click the names of
@@ -257,25 +258,28 @@ The encoding and hosting process assigns these statuses to video files.
   processing fails more than once for a file, contact edX partner support at
   partner-support@edx.org.
 
-Statuses of **Invalid Token** or **Unknown** indicate a configuration
-problem. Inform edX partner support if these statuses appear.
+* **Failed Duplicate** is the status for files that failed to upload because
+  the system identified them as duplicates.
+
+* **Invalid Token** or **Unknown** indicate a configuration problem. Inform edX
+  partner support if these statuses appear.
 
 For more information, see :ref:`Video Encoding and Hosting Overview`.
 
 .. _Reporting Video Status:
 
-================================
-Reporting Video Statuses
-================================
+==========================================
+Downloading the Available Encodings Report
+==========================================
 
-View detailed information about the video files that you upload in the
-available encodings report. The available encodings report includes the status
-of the encoding and hosting process for each video file that you upload, the
-identifier for the video, and the URLs for each encoding format. The available
-encodings report is a comma separated values (.csv) file that you can view in a
+The Available Encodings report provides detailed information about the video
+files that you have uploaded. This report includes the status of the encoding
+and hosting process for each video file that you have uploaded, the identifier
+for the video, and the URLs for each encoding format. The Available Encodings
+report is a comma separated values (.csv) file that you can view in a
 spreadsheet application or text editor.
 
-To download the available encodings report, follow these steps.
+To download the Available Encodings report, follow these steps.
 
 #. Open the course in Studio.
 
@@ -290,7 +294,7 @@ The .csv file includes the following columns.
 * The file **Name**.
 
 * The file **Duration**. If the upload process has not yet determined how long
-  the file is, **Pending** appears.
+  the file is, **Pending** appears in the **Duration** column for a video.
 
 * The **Date Added**, which shows the date and time that you uploaded the
   video file.


### PR DESCRIPTION

## [DOC-2164](https://openedx.atlassian.net/browse/DOC-2164)

Improve video upload/processing doc. Added mention of "Failed Duplicate" status, added TOCs to topic overviews for easier navigation, some cleanup (renamed "Reporting Video Statuses" to "Downloading the Available Encodings Report"). 

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @mushtaqak or @muhammad-ammar 
- [x] Doc team review: @srpearce  

FYI: @yro, @sstack22 @jaakana

### HTML Version

- [x] http://draft-ca-videoupload.readthedocs.io/en/latest/video/video_uploads.html#uploading-videos-in-studio

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

