### PR TITLE
Updated documentation for email opt-in file.

### DIFF
--- a/en_us/data/source/internal_data_formats/institution_data.rst
+++ b/en_us/data/source/internal_data_formats/institution_data.rst
@@ -31,8 +31,23 @@ The file contains data in these columns.
 
 ::
 
-  email,full_name,course_id,is_opted_in_for_email,preference_set_datetime
+  user_id,username,email,full_name,course_id,is_opted_in_for_email,preference_set_datetime
 
+
+=========
+user_id
+=========
+
+The unique system generated id for the student. For more information, see 
+the ``auth_user.id`` :ref:`column<auth_user>`.
+
+=========
+username
+=========
+
+The unique username supplied by the student while registering. For more 
+information, see the ``auth_user.username``
+:ref:`column<auth_user>`.
 
 =========
 email

--- a/en_us/data/source/internal_data_formats/institution_data.rst
+++ b/en_us/data/source/internal_data_formats/institution_data.rst
@@ -38,8 +38,8 @@ The file contains data in these columns.
 user_id
 =========
 
-The learner's id in ``auth_user.id``. For more information, see 
-:ref:`column<auth_user>`.
+The learner's ID in ``auth_user.id``. For more information, see 
+:ref:`auth_user`.
 
 **History**: This column was added in Jan 2017.
 
@@ -48,7 +48,7 @@ username
 =========
 
 The learner's username in ``auth_user.username``. For more information, see 
-:ref:`column<auth_user>`. 
+:ref:`auth_user`. 
 
 **History**: This column was added in Jan 2017.
 

--- a/en_us/data/source/internal_data_formats/institution_data.rst
+++ b/en_us/data/source/internal_data_formats/institution_data.rst
@@ -38,16 +38,19 @@ The file contains data in these columns.
 user_id
 =========
 
-The unique system generated id for the student. For more information, see 
-the ``auth_user.id`` :ref:`column<auth_user>`.
+The learner's id in ``auth_user.id``. For more information, see 
+:ref:`column<auth_user>`.
+
+**History**: This column was added in Jan 2017.
 
 =========
 username
 =========
 
-The unique username supplied by the student while registering. For more 
-information, see the ``auth_user.username``
-:ref:`column<auth_user>`.
+The learner's username in ``auth_user.username``. For more information, see 
+:ref:`column<auth_user>`. 
+
+**History**: This column was added in Jan 2017.
 
 =========
 email


### PR DESCRIPTION
## [ECOM-2963](https://openedx.atlassian.net/browse/ECOM-2963)

Added user_id and username fields to the email opt-in file in the regular research exports.

**Docs reference:** http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/institution_data.html#email-opt-in-report


### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @schenedx 
- [x] Subject matter expert: @stroilova
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc @catong 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @katymyway 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

