### PR TITLE
DOC-3551 Remove FERPA mention from confidentiality note

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
@@ -626,8 +626,7 @@ To generate and download a file of proctoring session results, follow these
 steps.
 
 .. important:: Because the proctoring session results file contains
-   confidential, personally identifiable data which might be subject to the
-   Family Educational Rights and Privacy Act (FERPA), be sure to follow your
+   confidential, personally identifiable data, be sure to follow your
    institution's data stewardship policies when you open or save this file.
 
 #. View the live version of your course.

--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -92,9 +92,8 @@ To generate and download the grade report for the learners who are currently
 enrolled in your course, follow these steps.
 
 .. important:: Because the grade report file contains confidential, personally
-   identifiable data which might be subject to the Family Educational Rights
-   and Privacy Act (FERPA), be sure to follow your institution's data
-   stewardship policies when you open or save this file.
+   identifiable data, be sure to follow your institution's data stewardship
+   policies when you open or save this file.
 
 #. View the live version of your course.
 
@@ -257,9 +256,8 @@ To generate and download the problem grade report for the learners who are
 currently enrolled in your course, follow these steps.
 
 .. important:: Because the problem grade report file contains confidential,
-   personally identifiable data which might be subject to the Family
-   Educational Rights and Privacy Act (FERPA), be sure to follow your
-   institution's data stewardship policies when you open or save this file.
+   personally identifiable data, be sure to follow your institution's data
+   stewardship policies when you open or save this file.
 
 #. View the live version of your course.
 


### PR DESCRIPTION
## [DOC-3551](https://openedx.atlassian.net/browse/DOC-3551)

Remove mention of FERPA from notes about confidentiality of student records in reports.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check): @srpearce 

FYI: @jaakana

### Testing
- [x] Ran ./run_tests.sh without warnings or errors

### Post-review
- [ ] Squash commits
