### PR TITLE
DOC-3545 Correct "Access" tab to "Advanced" tab

### DIFF
--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -206,7 +206,7 @@ earned a minimum score in a prerequisite subsection, follow these steps.
       indicated.
      :width: 600
 
-#. Select the **Access** tab.
+#. Select the **Advanced** tab.
 
 #. Select **Use as a Prerequisite** > **Make this subsection
    available as a prerequisite to other content**.
@@ -216,7 +216,7 @@ earned a minimum score in a prerequisite subsection, follow these steps.
 #. Select the **Configure** icon for the subsection that
    will be hidden until the prerequisite is met.
 
-#. Select the **Access** tab.
+#. Select the **Advanced** tab.
 
 #. In the **Limit Access** > **Prerequisite** menu, select the name of the
    subsection you want to specify as the prerequisite.


### PR DESCRIPTION
## [DOC-3545](https://openedx.atlassian.net/browse/DOC-3545)

Correct "Access" tab to "Advanced" tab in B&R Guide prereq subsection topic.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check): @srpearce 