### PR TITLE
DOC-3546 Support track-based bulk email groups

### DIFF
--- a/en_us/shared/manage_live_course/bulk_email.rst
+++ b/en_us/shared/manage_live_course/bulk_email.rst
@@ -61,9 +61,12 @@ The following preset recipient groups are available.
   does not include learners who have not activated their accounts, or who
   have opted out of receiving email communications.
 
-In addition, if you have cohorts enabled in your course, each cohort is
-available as a separate recipient group. For more information, see :ref:`Bulk
-Email Cohorts`.
+If you have more than one enrollment track in your course, each enrollment
+track is available as a separate recipient group. For more information, see
+:ref:`Enrollment Track Recipient Groups`.
+
+If you have cohorts enabled in your course, each cohort is available as a
+separate recipient group. For more information, see :ref:`Bulk Email Cohorts`.
 
 
 .. _Bulk Email Who Is Included or Excluded:
@@ -104,6 +107,21 @@ should be aware of who is included in each group.
    learners, select both **Staff and Administrators** and **All Learners**.
    Recipients who are in both groups will receive only one copy of the email
    message.
+
+
+.. _Enrollment Track Recipient Groups:
+
+==================================================================
+Sending Email Messages to Learners in Different Enrollment Tracks
+==================================================================
+
+If you have more than one enrollment track in your course, each enrollment
+track is available as a separate recipient group. If your course includes only
+a single enrollment track, you will not have a track-based recipient group.
+
+For example, if your course includes an audit track and a verified certificate
+track, you have two additional recipient groups: **Learners in the Audit
+Track** and **Learners in the Verified Certificate Track**.
 
 
 .. _Bulk Email Cohorts:


### PR DESCRIPTION
## [DOC-3546](https://openedx.atlassian.net/browse/DOC-3546)

Updates the topic about bulk email in the "Building and Running an edX Course" guide to include mention of track-based recipient groups. (Added in TNL-6162, https://github.com/edx/edx-platform/pull/14118)

### Date Needed: Jan 19
Should be live in Production on Jan 19

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @efischer19 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @srpearce 
- [x] Product review: @sstack22 @marcotuts 

FYI: @jaakana, @mmacfarlane, @dhixonedx

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

