### PR TITLE
DOC-3560 Add the ENABLE_CREATOR_GROUP flag

### DIFF
--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -86,6 +86,9 @@ platform.
    * - ENABLE_COURSEWARE_SEARCH
      - Supported
      - FALSE
+   * - ENABLE_CREATOR_GROUP
+     - Supported
+     - FALSE
    * - ENABLE_CREDIT_API
      - Supported
      - FALSE


### PR DESCRIPTION
## [DOC-3560](https://openedx.atlassian.net/browse/DOC-3560)

Adding the `ENABLE_CREATOR_GROUP` flag for https://github.com/edx/edx-platform/pull/14378, which makes it affect libraries.

This PR can be merged even without that PR, since [the flag already exists](https://github.com/edx/edx-platform/blob/12c595f80d2527803112ecb039ed3ecfb90bdae2/cms/envs/common.py#L128-L130). It controls whether or not any user on the system can create courses/libraries (the default, FALSE), or only users in the course creator group (TRUE).

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: me
- [x] Doc team review (sanity check): @srpearce @catong

FYI: @ziafazal @jagonzalr

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

