### PR TITLE
Hide note about Need Help link in OE learner's guide

### DIFF
--- a/en_us/shared/students/SFD_introduction.rst
+++ b/en_us/shared/students/SFD_introduction.rst
@@ -17,9 +17,11 @@ completing some of the exercises you may see in your course.
 This guide is continuously being updated and expanded. If you have any comments
 or questions about this guide, select **Feedback** on any page.
 
-.. note::
-  If you have comments or questions about a specific course, select **Need
-  Help?** on any page.
+.. only:: Partners
+
+  .. note::
+    If you have comments or questions about a specific course, select **Need
+    Help?** on any page.
 
 ******************
 Learning in a MOOC


### PR DESCRIPTION
## Amendment to work from [DOC-3575](https://openedx.atlassian.net/browse/DOC-3575)

DOC-3575 removes the link to docs@edx.org from the introduction to the learner's guides and adds a note telling learners who have questions about a particular course to use the "Need Help?" link on every page. This link is only visible for partner learners, so this PR hides that link from the Open edX Learner's Guide.


