### PR TITLE
Release Notes: Week Ending Feb 10, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-02-10.rst
+++ b/en_us/release_notes/source/2017/2017-02-10.rst
@@ -1,0 +1,45 @@
+#################################
+Week Ending 10 February 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 10 February 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-02-10.rst
+
+
+*************
+Analytics
+*************
+
+.. include:: analytics/analytics_2017-02-10.rst
+
+
+*************
+Mobile
+*************
+
+.. include:: mobile/mobile_2017-02-10.rst
+
+
+*************
+Open edX
+*************
+
+.. include:: openedx/openedx_2017-02-10.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/analytics/analytics_2017-02-10.rst
+++ b/en_us/release_notes/source/2017/analytics/analytics_2017-02-10.rst
@@ -1,0 +1,4 @@
+Search was added to the Insights Courses Page so that course instructors can search by course ID or course name. (:jira:`AN-7933`)
+
+For more information, see :ref:`insights:Courses_Page` in the *Using edX Insights*
+guide.

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-02-10
    2017-02-03
    2017-01-27
    2017-01-20

--- a/en_us/release_notes/source/2017/lms/lms_2017-02-03.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-02-03.rst
@@ -1,11 +1,3 @@
-When the **Show Answer** setting is active for a checkbox or multiple choice
-problem, a correct answer is now indicated not only by being rendered in green,
-but also with a check mark beside it. (TNL-6357)
+When the **Show Answer** setting is active for a checkbox or multiple choice problem, a correct answer is now indicated not only by being rendered in green, but also with a check mark beside it. (TNL-6357)
 
-Several accessibility improvements were made to discussions. To provide a
-better experience for screen reader users, only actual headings in discussions
-are now tagged as heading elements (TNL-6363). Fields that are required when
-learners add new posts now have asterisks next to their names as visual
-indicators of being required fields. Required fields were already indicated as
-such in screen reader attributes (TNL-6364).
-
+Several accessibility improvements were made to discussions. To provide a better experience for screen reader users, only actual headings in discussions are now tagged as heading elements (TNL-6363). Fields that are required when learners add new posts now have asterisks next to their names as visual indicators of being required fields. Required fields were already indicated as such in screen reader attributes (TNL-6364).

--- a/en_us/release_notes/source/2017/lms/lms_2017-02-10.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-02-10.rst
@@ -1,0 +1,16 @@
+
+================================================
+Accessibility Improvements
+================================================
+
+For screen reader users of the discussion forum, focus is now sent to the
+correct place after a response/comment is added. (:jira:`TNL-6170`)
+
+The post type options for a new discussion post now use standard radio button
+visuals so that learners who use high contrast mode can identify which post type
+is selected. (:jira:`TNL-6366`)
+
+The course tools area used for Notes and Calculator is no longer announced to
+screen readers when no tools are enabled. (:jira:`TNL-6349`)
+
+The filter control in the wiki now has a visible field label. (:jira:`TNL-6440`)

--- a/en_us/release_notes/source/2017/mobile/mobile_2017-02-10.rst
+++ b/en_us/release_notes/source/2017/mobile/mobile_2017-02-10.rst
@@ -1,0 +1,18 @@
+Additional screen reader text was added to the learner profile controls to
+provide screen reader users with more information about available actions.
+(:jira:`MA-3131`)
+
+In the next iOS version of the edX mobile app (v.2.8), learners will be able to
+see a clickable video transcript when they view videos in portrait mode.
+(:jira:`MA-2899`)
+
+Closed captions now correctly render for videos on the mobile app.
+(:jira:`MA-2551`)
+
+Android mobile app users can now manage their video downloads through Android's
+native downloads panel area outside of the edX app. (:jira:`MA-1961`)
+
+For answers to frequently asked questions about the mobile app, see the
+:ref:`learners:SFD Mobile` section in the *EdX Learner's Guide*, or, for
+Open edX installations, see the :ref:`openlearners:SFD Mobile` section in
+the *Open edX Learner's Guide*.

--- a/en_us/release_notes/source/2017/openedx/openedx_2017-02-10.rst
+++ b/en_us/release_notes/source/2017/openedx/openedx_2017-02-10.rst
@@ -1,0 +1,5 @@
+An initial version of the web fragments framework was merged. This
+architectural improvement should enable greater flexibility in changes to the
+LMS user interface moving forward. As part of this effort a python package was
+created and a separate repository was set up for the initial release as well.
+(:jira:`TNL-6168`)

--- a/en_us/release_notes/source/analytics_index.rst
+++ b/en_us/release_notes/source/analytics_index.rst
@@ -11,6 +11,12 @@ The following information describes what is new in edX analytics.
   :depth: 2
 
 *************************
+Week ending 10 Feb 2017
+*************************
+
+.. include:: 2017/analytics/analytics_2017-02-10.rst
+
+*************************
 Week ending 3 Feb 2017
 *************************
 

--- a/en_us/release_notes/source/openedx_index.rst
+++ b/en_us/release_notes/source/openedx_index.rst
@@ -12,6 +12,12 @@ The following information summarizes what is new in Open edX.
 
 
 *************************
+Week of 10 February 2017
+*************************
+
+.. include:: 2017/openedx/openedx_2017-02-10.rst
+
+*************************
 Week of 7 November 2016
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending February 10, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending Feb 10, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=157653086)

### Date Needed (optional)

EOD Wednesday Feb 15, 2017
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong
- [x] Product review: @sstack22

FYI: @srpearce 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [x] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-02-10.html

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

