### PR TITLE
DOC-2848 - prerequisite course subsection settings are not retained o…

### DIFF
--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -246,3 +246,6 @@ earned a minimum score in a prerequisite subsection, follow these steps.
 
 #. In the course outline, if a subsection has a prerequisite, the prerequisite
    name appears under the subsection name.
+
+  .. note:: Prerequisite course subsection settings are not retained when
+     you :ref:`export or import a course<Exporting and Importing a Course>`, or when you :ref:`re-run a course<Rerun a Course>`.

--- a/en_us/shared/releasing_course/export_import_course.rst
+++ b/en_us/shared/releasing_course/export_import_course.rst
@@ -55,6 +55,7 @@ The following data is not exported with your course.
 * Course team data
 * Discussion data
 * Certificates
+* Prerequisite course subsection settings
 
 To export your course, follow these steps.
 

--- a/en_us/shared/rerun_course/course_rerun.rst
+++ b/en_us/shared/rerun_course/course_rerun.rst
@@ -37,9 +37,11 @@ Data Duplicated When You Re-Run a Course
      - Yes.
    * - Pages added to the course
      - Yes, including all page content and the defined page order.
-   * - Course Updates
+   * - Course updates
      - Yes.
-   * - Advanced Settings
+   * - Prerequisite course subsection settings
+     - No.
+   * - Advanced settings
      - Yes.
    * - Grading policy
      - Yes.
@@ -205,6 +207,9 @@ who enroll in the new course run.
   For more information about the updates that you can make to improve the
   accessibility of these problem types, see the `Release Notes
   <http://edx.readthedocs.io/projects/edx-release-notes/en/latest/studio_index.html#updates-to-capa-problem-types>`_.
+
+* If your course uses prerequisite course subsections to hide course
+  subsections until learners complete other, prerequisite subsections, configure the prerequisite course subsections. See :ref:`configuring_prerequisite_content`.
 
 * If your course includes instructions for learners, verify that the
   instructions reflect the current user interface of the LMS.


### PR DESCRIPTION
…n import, export, or re-run of a course.

## [DOC-2848](https://openedx.atlassian.net/browse/DOC-2848)

Add a description of your changes with links to any relevant material.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @douglashall 
- [ ] Subject matter expert: @jaakana
- [x] Doc team review (sanity check): @edx/doc


### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

