### PR TITLE
Use the magic word unsubscribe

### DIFF
--- a/en_us/shared/getting_started/Section_dashboard_settings_profile.rst
+++ b/en_us/shared/getting_started/Section_dashboard_settings_profile.rst
@@ -88,7 +88,7 @@ This section describes how you update course-specific settings.
 Change a Course Email Preference
 =================================
 
-To change your email preference for a course, follow these steps.
+To subscribe or unsubscribe to emails from a course, follow these steps.
 
 #. On your dashboard, locate the course.
 
@@ -100,7 +100,7 @@ To change your email preference for a course, follow these steps.
      :alt: The course settings icon next to the View Course button on the
            learner dashboard.
 
-#. Select **Course emails**.
+#. Select **Email Settings**.
 
 #. Select or clear the **Receive course emails** check box, and then select
    **Save Settings**.


### PR DESCRIPTION
## [DOC-3572](https://openedx.atlassian.net/browse/DOC-3572)

I changed the opening of "Change a Course Email Preference" to use the magic word 'unsubscribe' so that users are more likely to find it with search. I also noticed that a UI label had changed from what was in the doc.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (copy edit): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

