### PR TITLE
Release Notes: Week Ending Feb 17, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-02-17.rst
+++ b/en_us/release_notes/source/2017/2017-02-17.rst
@@ -1,0 +1,24 @@
+#################################
+Week Ending 17 February 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 17 February 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-02-17.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-02-17
    2017-02-10
    2017-02-03
    2017-01-27

--- a/en_us/release_notes/source/2017/lms/lms_2017-02-17.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-02-17.rst
@@ -1,0 +1,22 @@
+
+================================================
+Special Exams
+================================================
+
+Learners who complete a proctored exam now receive emails to confirm their
+exam submission as well as when proctoring review results are available. The
+text in these emails is now more descriptive and helps learners understand
+when their exams will be reviewed, and why they have passed or failed
+proctoring (:jira:`TNL-6482`)
+
+For special exams, the student exam attempts table and proctored exam report
+now correctly assign the "finished at" column timestamp. Previously this
+column made it seem like some learners were unfairly receiving more time to
+complete their exam. (:jira:`TNL-6111`)
+
+================================================
+Open Response Assessments
+================================================
+
+Deadlines for open response assessments now correctly display in the learner's
+time zone. (:jira:`TNL-6501`)

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,18 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 17 Feb 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-02-17.rst  
+
+*************************
+Week ending 10 Feb 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-02-10.rst 
+
+*************************
 Week ending 3 Feb 2017
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending February 17, 2017

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending Feb 17, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=157653086)

### Date Needed (optional)

EOD Tuesday Feb 22, 2017
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

FYI: @srpearce , @sstack22 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [x] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-02-17.html

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [x] Squash commits
