### PR TITLE
Changed readthedocs.org to readthedocs.io

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/in_course_reverification.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/in_course_reverification.rst
@@ -253,4 +253,4 @@ requirements on their **Progress** pages.
 
 For more information about the in-course identity reverification experience for
 the learner, see `In-Course Identity Reverification
-<http://edx-guide-for-students.readthedocs.org/en/latest/SFD_credit_courses/SFD_in_course_ID_reverification.html>`_.
+<http://edx-guide-for-students.readthedocs.io/en/latest/SFD_credit_courses/SFD_in_course_ID_reverification.html>`_.

--- a/en_us/developers/source/analytics.rst
+++ b/en_us/developers/source/analytics.rst
@@ -34,7 +34,7 @@ Emitting from client-side coffee script::
 
 .. note::
     The client-side API currently uses a deprecated library (the ``track``
-     djangoapp) instead of the event-tracking library. Eventually, event-tracking 
+     djangoapp) instead of the event-tracking library. Eventually, event-tracking
      will publish a client-side API of its own: when available, that
      API should be used instead of the ``track``-based solution. See
      :ref:`deprecated_api`.
@@ -316,14 +316,14 @@ comments that identify the purpose of the event and its fields. Your
 descriptions and examples can help assure that researchers and other members
 of the open edX community understand your intent and use the events correctly.
 
-You might find the following references helpful as you prepare your PR. 
+You might find the following references helpful as you prepare your PR.
 
 * The *edX Platform Developer's Guide* provides guidelines for `contributing
-  to open edX <http://edx.readthedocs.org/projects/edx-developer-
+  to open edX <http://edx.readthedocs.io/projects/edx-developer-
   guide/en/latest/process/index.html>`_.
 
 * The `edX Research
-  Guide <http://edx.readthedocs.org/projects/devdata/en/latest/>`_ is a
+  Guide <http://edx.readthedocs.io/projects/devdata/en/latest/>`_ is a
   reference for information about emitted events that are included in the edX
   tracking logs.
 
@@ -378,11 +378,11 @@ Segment
 A selection of events can be transmitted to `Segment`_ in order to take
 advantage of a wide variety of analytics-related third party services such as
 Mixpanel and Chartbeat. It is enabled in the LMS if the ``SEGMENT_KEY``
-key is set to a valid Segment API key in the ``lms.auth.json`` file. Additionally, 
-the setting ``EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST`` in the ``lms.auth.json`` 
-file can be used to specify event names that should be emitted to Segment 
-from normal ``tracker.emit()`` calls. Events specified in this whitelist will be 
-sent to both the tracking logs and Segment.  Similarly, it is enabled in Studio 
+key is set to a valid Segment API key in the ``lms.auth.json`` file. Additionally,
+the setting ``EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST`` in the ``lms.auth.json``
+file can be used to specify event names that should be emitted to Segment
+from normal ``tracker.emit()`` calls. Events specified in this whitelist will be
+sent to both the tracking logs and Segment.  Similarly, it is enabled in Studio
 if the ``SEGMENT_KEY`` key is set to a valid Segment API key in the
 ``cms.auth.json`` file.
 
@@ -406,7 +406,7 @@ handling do not currently have a suitable alternative approach, so they
 continue to be supported.
 
 .. _event-tracking: https://github.com/edx/event-tracking
-.. _event-tracking documentation: http://event-tracking.readthedocs.org/en/latest/overview.html#event-tracking
+.. _event-tracking documentation: http://event-tracking.readthedocs.io/en/latest/overview.html#event-tracking
 .. _data dog: http://www.datadoghq.com/
 .. _dogapi: http://pydoc.datadoghq.com/en/latest/
 .. _Segment: https://segment.com/

--- a/en_us/developers/source/extending_platform/javascript.rst
+++ b/en_us/developers/source/extending_platform/javascript.rst
@@ -29,11 +29,11 @@ See :ref:`The Custom JavaScript Display and Grading Example Template` for
 information about the template application built in to edX Studio.
 
 Course teams should see the following sections of the `Building and Running an
-edX Course <http://edx.readthedocs.org/projects/ca/en/latest/>`_ guide.
+edX Course <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/>`_ guide.
 
-* `Custom JavaScript Display and Grading <http://edx.readthedocs.org/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_
+* `Custom JavaScript Display and Grading <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_javascript.html>`_
 
-* `Establishing a Grading Policy <http://edx.readthedocs.org/projects/ca/en/latest/building_course/establish_grading_policy.html>`_
+* `Establishing a Grading Policy <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/grading/index.html>`_
 
 The rest of this section provides more information for developers who are
 creating JavaScript applications for courses on the edX platform.
@@ -77,7 +77,7 @@ optionally to provide feedback as a formative assessment.
 #. In edX Studio, upload an HTML file that contains the JavaScript you want to
    show learners.
 #. Copy the **Embed URL** of the file.
-#. `Create a Custom JavaScript Display and Grading Problem <http://edx.readthedocs.org/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_. The template
+#. Create a `Custom JavaScript Display and Grading <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_javascript.html>`_  problem. The template
    for the problem contains the definition for a sample JavaScript application
    that requires and grades learner interaction.
 #. Edit the XML of the component to remove grading information and refer to the

--- a/en_us/developers/source/extending_platform/js_template_example.rst
+++ b/en_us/developers/source/extending_platform/js_template_example.rst
@@ -4,7 +4,7 @@
 The Custom JavaScript Display and Grading Example Template
 ###########################################################
 
-As referred to in `course team documentation <http://edx.readthedocs.org/projects/ca/en/latest/problems_tools/advanced_problems.html#custom-javascript-display-and-grading>`_, there is a built-in template in edX Studio that uses a sample JavaScript application.
+As referred to in `course team documentation <http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_javascript.html>`_, there is a built-in template in edX Studio that uses a sample JavaScript application.
 
 This sample application has learners select two different shapes, a cone and a
 cube. The correct state is when the cone is selected and the cube is not
@@ -13,7 +13,7 @@ selected.
 .. image:: ../images/JavaScriptInputExample.png
   :alt: Image of the sample JavaScript application, with the cone selected
 
-You can `download files for that application <http://files.edx.org/JSInput.zip>`_.
+You can `download files for that application <http://files.edx.io/JSInput.zip>`_.
 You must upload these files in Studio to use them in a problem.
 
 The following information steps through this example to demonstrate how to apply
@@ -189,7 +189,7 @@ The XML problem for the sample template is as follows.
             set_statefn="WebGLDemo.setState"
             width="400"
             height="400"
-            html_file="https://studio.edx.org/c4x/edX/DemoX/asset/webGLDemo.html"
+            html_file="https://studio.edx.io/c4x/edX/DemoX/asset/webGLDemo.html"
             sop="false"/>
         </customresponse>
     </problem>

--- a/en_us/developers/source/extending_platform/xblocks.rst
+++ b/en_us/developers/source/extending_platform/xblocks.rst
@@ -2,7 +2,7 @@ Integrating XBlocks with edx-platform
 =====================================
 
 The edX LMS and Studio have several features that are extensions of the core
-XBlock libraries (https://xblock.readthedocs.org). These features are listed
+XBlock libraries (https://xblock.readthedocs.io). These features are listed
 below.
 
 * `LMS`_

--- a/en_us/developers/source/process/code-considerations.rst
+++ b/en_us/developers/source/process/code-considerations.rst
@@ -282,6 +282,6 @@ you have questions, please contact us at docs@edx.org.
 
 
 
-.. _cover letter: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/cover-letter.html
+.. _cover letter: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/process/cover-letter.html
 .. _GitHub repository: https://github.com/edx/edx-documentation
 .. _edX documentation: http://docs.edx.org

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -84,10 +84,10 @@ questions or concerns.
 For XBlocks you intend to install on edx.org, please also read the `XBlock
 Review Guidelines`_.
 
-.. _Internationalization Coding Guidelines: https://openedx.atlassian.net/wiki/edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _Internationalization Coding Guidelines: https://openedx.atlassian.net/wiki/edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/i18n.html
 .. _RTL UI Best Practices: https://github.com/edx/edx-platform/wiki/RTL-UI-Best-Practices
-.. _Accessibility Guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/accessibility.html
-.. _Analytics Guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/analytics.html
+.. _Accessibility Guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/accessibility.html
+.. _Analytics Guidelines: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/analytics.html
 .. _Eventing Design and Review Process: https://openedx.atlassian.net/wiki/display/AN/Eventing+Design+and+Review+Process
 .. _XBlock Review Guidelines: https://openedx.atlassian.net/wiki/display/OPEN/XBlock+review+guidelines
 

--- a/en_us/developers/source/style_guides/python_guidelines.rst
+++ b/en_us/developers/source/style_guides/python_guidelines.rst
@@ -137,7 +137,7 @@ Note: there is one exception. REST APIs created using Django REST Framework (DRF
 
 See:
 
-* http://sphinxcontrib-napoleon.readthedocs.org/en/latest/example_google.html
+* http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
 * https://google-styleguide.googlecode.com/svn/trunk/pyguide.html?showone=Comments#Comments
 
 Here's how you write documentation in a mostly "Google Style" manner::
@@ -206,7 +206,7 @@ References
 * `PEP 8`_
 * `PEP 257`_
 * https://docs.djangoproject.com/en/1.5/internals/contributing/writing-code/coding-style/
-* https://python-guide.readthedocs.org/en/latest/
+* https://python-guide.readthedocs.io/en/latest/
 * http://google-styleguide.googlecode.com/svn/trunk/pyguide.html
 * http://www.nilunder.com/blog/2013/08/03/pythonic-sensibilities/
 

--- a/en_us/landing_page/source/index.rst
+++ b/en_us/landing_page/source/index.rst
@@ -36,4 +36,4 @@ If you use or host an Open edX site
   Platform`.
 
 .. _docs.edx.org: https://docs.edx.org
-.. _edX Release Notes: http://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -12,11 +12,11 @@
 
 .. _Coming Soon Programs Page: https://open.edx.org/announcements/coming-soon-xseries-programs-page
 
-.. _Using edX Insights: http://edx.readthedocs.org/projects/edx-insights/en/latest/
+.. _Using edX Insights: http://edx.readthedocs.io/projects/edx-insights/en/latest/
 
-.. _Review Answers to Graded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Answers.html#review-answers-to-graded-problems
+.. _Review Answers to Graded Problems: http://edx.readthedocs.io/projects/edx-insights/en/latest/performance/Performance_Answers.html#review-answers-to-graded-problems
 
-.. _Review Answers to Ungraded Problems: http://edx.readthedocs.org/projects/edx-insights/en/latest/performance/Performance_Ungraded.html#review-answers-to-ungraded-problems
+.. _Review Answers to Ungraded Problems: http://edx.readthedocs.io/projects/edx-insights/en/latest/performance/Performance_Ungraded.html#review-answers-to-ungraded-problems
 
 .. _Open edX Analytics wiki: http://edx-wiki.atlassian.net/wiki/display/OA/Open+edX+Analytics+Home
 
@@ -24,7 +24,7 @@
 
 .. _Entity Relationship Diagram for ORA Data: https://openedx.atlassian.net/wiki/display/AN/Entity+Relationship+Diagram+for+ORA+Data
 
-.. _edX Enrollment API: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/enrollment/index.html
+.. _edX Enrollment API: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/enrollment/index.html
 
 .. _course-data: http://groups.google.com/a/edx.org/forum/#!forum/course-data
 
@@ -108,7 +108,7 @@
 
 .. _VirtualEnv Installation: https://virtualenv.pypa.io/en/latest/installation.html
 
-.. _VirtualEnvWrapper: http://virtualenvwrapper.readthedocs.org/en/latest
+.. _VirtualEnvWrapper: http://virtualenvwrapper.readthedocs.io/en/latest
 
 .. _XBlock SDK: https://github.com/edx/xblock-sdk
 
@@ -232,8 +232,8 @@
 .. _E-Commerce service: https://github.com/edx/ecommerce
 .. _Transifex: https://www.transifex.com/
 .. _configure the Transifex client: http://docs.transifex.com/client/config/
-.. _Communications API: http://django-oscar.readthedocs.org/en/latest/howto/how_to_customise_oscar_communications.html#communications-api
-.. _django-compressor: http://django-compressor.readthedocs.org/
+.. _Communications API: http://django-oscar.readthedocs.io/en/latest/howto/how_to_customise_oscar_communications.html#communications-api
+.. _django-compressor: http://django-compressor.readthedocs.io/
 .. _RequireJS: http://requirejs.org/
 .. _OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html
 .. _devstack: https://github.com/edx/configuration/wiki/edX-Developer-Stack
@@ -243,8 +243,8 @@
 .. _edX JavaScript standards: https://github.com/edx/edx-platform/wiki/Javascript-standards-for-the-edx-platform
 .. _JSHint: http://www.jshint.com/
 .. _jscs: https://www.npmjs.org/package/jscs
-.. _Waffle: http://waffle.readthedocs.org/en/latest
-.. _Waffle documentation: http://waffle.readthedocs.org/en/latest
+.. _Waffle: http://waffle.readthedocs.io/en/latest
+.. _Waffle documentation: http://waffle.readthedocs.io/en/latest
 .. _Segment: https://segment.com
 .. _CourseTalk: https://www.coursetalk.com/
 .. _Google Play: https://play.google.com/store/apps/details?id=org.edx.mobile
@@ -355,7 +355,7 @@
 
 .. _Microsoft Azure: https://azure.microsoft.com/en-us/pricing/free-trial/
 
-.. _python-social-auth backend documentation: http://python-social-auth.readthedocs.org/en/latest/backends/index.html#social-backends
+.. _python-social-auth backend documentation: http://python-social-auth.readthedocs.io/en/latest/backends/index.html#social-backends
 
 .. _IMS LTI 1.1 Consumer Launch: http://www.imsglobal.org/developers/LTI/test/v1p1/lms.php
 
@@ -406,7 +406,7 @@
 
 .. _Dogwood blog post: https://open.edx.org/blog/newest-open-edx-release-dogwood-now-available
 
-.. _Adding E-Commerce to the Open edX Platform (Dogwood): http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-dogwood.rc/ecommerce/index.html
+.. _Adding E-Commerce to the Open edX Platform (Dogwood): http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-dogwood.rc/ecommerce/index.html
 
 .. _Open edX Conference: http://con.openedx.org/
 

--- a/en_us/olx/source/about/overview.rst
+++ b/en_us/olx/source/about/overview.rst
@@ -79,7 +79,7 @@ Replace the placeholders in the following template with your information.
       <article class="response">
         <h3>What web browser should I use?</h3>
         <p>The Open edX platform works best with the current versions of Chrome, Firefox, Safari, and Microsoft Edge.</p>
-        <p>See our <a href="http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
+        <p>See our <a href="http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
       </article>
       <article class="response">
         <h3>Question 2?</h3>

--- a/en_us/open_edx_course_authors/source/course_features/lti/index.rst
+++ b/en_us/open_edx_course_authors/source/course_features/lti/index.rst
@@ -32,5 +32,5 @@ You use the topics in this section to prepare your course for reuse.
 You can also include content from an LTI provider in your Open edX courses. For
 more information, see :ref:`LTI Component`.
 
-.. _Configuring an edX Instance as an LTI Tool Provider: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/configuration/lti/index.html
+.. _Configuring an edX Instance as an LTI Tool Provider: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/lti/index.html
 

--- a/en_us/open_edx_release_notes/source/links.rst
+++ b/en_us/open_edx_release_notes/source/links.rst
@@ -7,37 +7,37 @@
 
 .. Latest Doc Links
 
-.. _edX Release Notes: http://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/
 
-.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/
+.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/
 
-.. _Open edX Developer's Guide: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/
+.. _Open edX Developer's Guide: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/
 
-.. _Open edX Data Analytics API: http://edx.readthedocs.org/projects/edx-data-analytics-api/en/latest/index.html
+.. _Open edX Data Analytics API: http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/index.html
 
-.. _EdX XBlock Tutorial: http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/
+.. _EdX XBlock Tutorial: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/
 
-.. _EdX XBlock API Guide: http://edx.readthedocs.org/projects/xblock/en/latest/
+.. _EdX XBlock API Guide: http://edx.readthedocs.io/projects/xblock/en/latest/
 
-.. _EdX Open Learning XML Guide: http://edx.readthedocs.org/projects/edx-open-learning-xml/en/latest/
+.. _EdX Open Learning XML Guide: http://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/
 
-.. _Open edX Platform APIs: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
+.. _Open edX Platform APIs: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
 
-.. _Mobile API: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
+.. _Mobile API: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
 
-.. _Enrollment API: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
+.. _Enrollment API: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
 
-.. _Course Structure API Version 0: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/course_structure/index.html
+.. _Course Structure API Version 0: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/course_structure/index.html
 
-.. _Building and Running an Open edX Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/index.html
+.. _Building and Running an Open edX Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/index.html
 
-.. _Open edX Learner's Guide: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/index.html
+.. _Open edX Learner's Guide: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/index.html
 
-.. _Events in Tracking Logs: http://edx.readthedocs.org/projects/devdata/en/latest/internal_data_formats/tracking_logs.html
+.. _Events in Tracking Logs: http://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs.html
 
-.. _User API Version 1.0: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/user/index.html
+.. _User API Version 1.0: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/user/index.html
 
-.. _Profile Images API Version 1.0: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/profile_images/index.html
+.. _Profile Images API Version 1.0: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/profile_images/index.html
 
 .. Eucalyptus doc links
 
@@ -53,17 +53,17 @@
 
 .. _Installing, Configuring, and Running the Open edX Platform Dogwood Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-dogwood.rc/platform_releases/dogwood.html
 
-.. _Building and Running an Open edX Course for Dogwood: http://edx.readthedocs.org/projects/open-edx-ca/en/dogwood/
+.. _Building and Running an Open edX Course for Dogwood: http://edx.readthedocs.io/projects/open-edx-ca/en/dogwood/
 
-.. _Open edX Learner's Guide for Dogwood: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/dogwood/
+.. _Open edX Learner's Guide for Dogwood: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/dogwood/
 
 .. Cypress Doc Links
 
-.. _Enabling Badges: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_badging.html
+.. _Enabling Badges: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_badging.html
 
-.. _Enable or Disable Badges for Your Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html?highlight=badges#enable-or-disable-badges-for-your-course
+.. _Enable or Disable Badges for Your Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html?highlight=badges#enable-or-disable-badges-for-your-course
 
-.. _Upload a Badge to Mozilla Backpack: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/SFD_certificates.html?highlight=badges#upload-a-badge-to-mozilla-backpack
+.. _Upload a Badge to Mozilla Backpack: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/SFD_certificates.html?highlight=badges#upload-a-badge-to-mozilla-backpack
 
 .. _base.py: https://github.com/edx/edx-ora2/blob/a4ce7bb00190d7baff60fc90fb613229565ca7ef/openassessment/fileupload/backends/base.py
 
@@ -73,75 +73,75 @@
 
 .. _Version 3 of the YouTube API: https://developers.google.com/youtube/v3/
 
-.. _Set YouTube API Key: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/youtube_api.html
+.. _Set YouTube API Key: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/youtube_api.html
 
-.. _Enabling Third Party Authentication: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/tpa/index.html
+.. _Enabling Third Party Authentication: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/tpa/index.html
 
-.. _Enabling Course and Video Licensing: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_licensing.html
+.. _Enabling Course and Video Licensing: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_licensing.html
 
-.. _Enabling Custom Courses: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_ccx.html
+.. _Enabling Custom Courses: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/enable_ccx.html
 
-.. _Searching the Course: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/SFD_course_search.html
+.. _Searching the Course: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/SFD_course_search.html
 
-.. _Installing, Configuring, and Running the Open edX Platform Cypress Release: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/
+.. _Installing, Configuring, and Running the Open edX Platform Cypress Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/
 
-.. _Building and Running an Open edX Course for Cypress: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/index.html
+.. _Building and Running an Open edX Course for Cypress: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/index.html
 
-.. _Open edX Learner's Guide for Cypress: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/index.html
+.. _Open edX Learner's Guide for Cypress: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/index.html
 
-.. _Open Response Assessments: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/open_response_assessments/index.html
+.. _Open Response Assessments: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/open_response_assessments/index.html
 
-.. _Adding Feedback and Hints to a Problem: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/create_problem.html#adding-feedback-and-hints-to-a-problem
+.. _Adding Feedback and Hints to a Problem: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/create_problem.html#adding-feedback-and-hints-to-a-problem
 
-.. _Poll Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/poll_question.html
+.. _Poll Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/poll_question.html
 
-.. _Survey Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/survey.html
+.. _Survey Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/exercises_tools/survey.html
 
-.. _Licensing a Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/licensing_course.html
+.. _Licensing a Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/licensing_course.html
 
-.. _Course and Video Licenses: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/SFD_licensing.html
+.. _Course and Video Licenses: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/SFD_licensing.html
 
-.. _Working with Libraries: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/libraries.html
+.. _Working with Libraries: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/creating_content/libraries.html
 
-.. _Exploring the Profile Page: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/getting_started/dashboard_acctsettings_profile.html#exploring-the-profile-page
+.. _Exploring the Profile Page: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/getting_started/dashboard_acctsettings_profile.html#exploring-the-profile-page
 
-.. _Exploring the Profile Page for Learners: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/named-release-cypress/sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-profile-page
+.. _Exploring the Profile Page for Learners: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/named-release-cypress/sfd_dashboard_profile/SFD_dashboard_settings_profile.html#exploring-the-profile-page
 
-.. _Including Learner Cohorts: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/cohorts/index.html
+.. _Including Learner Cohorts: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/cohorts/index.html
 
-.. _Setting Up Course Certificates: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html
+.. _Setting Up Course Certificates: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/creating_course_certificates.html
 
-.. _Interpret the Grade Report: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#interpret-the-problem-grade-report
+.. _Interpret the Grade Report: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#interpret-the-problem-grade-report
 
-.. _Generate a Problem Grade Report for Enrolled Students: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#generate-a-problem-grade-report-for-enrolled-students-all-courses
+.. _Generate a Problem Grade Report for Enrolled Students: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_grades.html#generate-a-problem-grade-report-for-enrolled-students-all-courses
 
-.. _Enrollment: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_enrollment.html
+.. _Enrollment: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/running_course/course_enrollment.html
 
-.. _Creating a Custom Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/custom_courses.html
+.. _Creating a Custom Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/custom_courses.html
 
-.. _Enable Course Search: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/edx_search.html
+.. _Enable Course Search: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/named-release-cypress/configuration/edx_search.html
 
-.. _Course Search: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/search_course.html
+.. _Course Search: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-cypress/building_course/search_course.html
 
 .. Birch Links
 
-.. _Building and Running an Open edX Course for Birch: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/index.html
+.. _Building and Running an Open edX Course for Birch: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/index.html
 
-.. _Including Student Cohorts: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/cohorts/index.html
+.. _Including Student Cohorts: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/cohorts/index.html
 
-.. _Working with Content Libraries: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/creating_content/libraries.html
+.. _Working with Content Libraries: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/creating_content/libraries.html
 
-.. _Specify Prerequisite Courses: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#specify-prerequisite-courses
+.. _Specify Prerequisite Courses: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#specify-prerequisite-courses
 
-.. _Require an Entrance Exam: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#require-an-entrance-exam
+.. _Require an Entrance Exam: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/provide_overview.html#require-an-entrance-exam
 
-.. _Student Notes Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/student_notes.html
+.. _Student Notes Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/student_notes.html
 
-.. _Rerunning a Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/course_rerun.html
+.. _Rerunning a Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/building_course/course_rerun.html
 
-.. _Google Calendar Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_calendar.html
+.. _Google Calendar Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_calendar.html
 
-.. _Google Drive Files Tool: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_docs.html
+.. _Google Drive Files Tool: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/named-release-birch/exercises_tools/google_docs.html
 
 
 .. _Sphinx: http://sphinx-doc.org/

--- a/en_us/shared/accessibility/best_practices_course_content_dev.rst
+++ b/en_us/shared/accessibility/best_practices_course_content_dev.rst
@@ -672,7 +672,7 @@ you use MathJax to author your math content. MathJax renders math in a variety
 of formats on the client side, offering the end user the ability to consume
 math content in their preferred format. EdX Studio supports authoring math
 directly in LaTeX using the `LaTeX Source Compiler
-<https://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/creating_content/create_html_component.html#import-latex-code>`_ to transform LaTeX into MathJax.
+<https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_components/create_html_component.html#import-latex-code>`_ to transform LaTeX into MathJax.
 
 ======================================================
 Accessible Mathematical Content Resources

--- a/en_us/shared/course_components/create_preroll_video.rst
+++ b/en_us/shared/course_components/create_preroll_video.rst
@@ -275,7 +275,7 @@ To remove the pre-roll file from your course, follow these steps.
 #. Select **Save Changes**.
 
 
-.. _Processing Video Files: http://processing-video-files.readthedocs.org/en/latest/
-.. _Specifications for Successful Video Files: http://processing-video-files.readthedocs.org/en/latest/video_uploads.html#specifications-for-successful-video-files
-.. _Upload Video Files: http://processing-video-files.readthedocs.org/en/latest/video_uploads.html#upload-video-files
+.. _Processing Video Files: http://processing-video-files.readthedocs.io/en/latest/
+.. _Specifications for Successful Video Files: http://processing-video-files.readthedocs.io/en/latest/video_uploads.html#specifications-for-successful-video-files
+.. _Upload Video Files: http://processing-video-files.readthedocs.io/en/latest/video_uploads.html#upload-video-files
 .. _ISO 639-1 codes: http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

--- a/en_us/shared/developing_course/course_components.rst
+++ b/en_us/shared/developing_course/course_components.rst
@@ -252,7 +252,7 @@ You develop parent and child components in XML, then import the XML course into
 Studio to verify that the structure is as you intended.
 
 For more information about working with your course's XML files, including
-information about terminology, see the `EdX Open Learning XML Guide <https://edx.readthedocs.org/projects/edx-open-learning-xml/en/latest/>`_.
+information about terminology, see the `EdX Open Learning XML Guide <https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/>`_.
 
 The following examples show the XML used to create the unit and components
 shown in Studio above.

--- a/en_us/shared/preface.rst
+++ b/en_us/shared/preface.rst
@@ -461,9 +461,9 @@ is available.
  limitation.
 
 
-.. _Building and Running an edX Course: http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/
-.. _Building and Running an Open edX Course: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/
-.. _Building and Running an Open edX Course - latest: http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/
+.. _Building and Running an edX Course: http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/
+.. _Building and Running an Open edX Course: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/
+.. _Building and Running an Open edX Course - latest: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/
 .. _docs@edx.org: docs@edx.org
 .. _edx101: https://www.edx.org/course/overview-creating-edx-course-edx-edx101#.VIIJbWTF_yM
 .. _StudioX: https://www.edx.org/course/creating-course-edx-studio-edx-studiox#.VRLYIJPF8kR
@@ -473,35 +473,35 @@ is available.
 .. _edX Partner Support: https://partners.edx.org/edx_zendesk
 .. _edx-code: http://groups.google.com/forum/#!forum/edx-code
 .. _edx/configuration: http://github.com/edx/configuration/wiki
-.. _edX Data Analytics API: http://edx.readthedocs.org/projects/edx-data-analytics-api/en/latest/index.html
+.. _edX Data Analytics API: http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/index.html
 .. _docs.edx.org: http://docs.edx.org
 .. _edx/edx-analytics-dashboard: https://github.com/edx/edx-analytics-dashboard
 .. _edx/edx-platform: https://github.com/edx/edx-platform
-.. _EdX Learner's Guide: http://edx-guide-for-students.readthedocs.org/en/latest/
-.. _edX Open Learning XML Guide: http://edx-open-learning-xml.readthedocs.org/en/latest/index.html
+.. _EdX Learner's Guide: http://edx-guide-for-students.readthedocs.io/en/latest/
+.. _edX Open Learning XML Guide: http://edx-open-learning-xml.readthedocs.io/en/latest/index.html
 .. _edX Partner Portal: https://partners.edx.org
 .. _forums: https://partners.edx.org/forums/partner-forums
-.. _edX Platform APIs: http://edx.readthedocs.org/projects/edx-platform-api/en/latest/
-.. _edX Platform Developer's Guide: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/
-.. _edX Research Guide: http://edx.readthedocs.org/projects/devdata/en/latest/
-.. _edX Release Notes: http://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Platform APIs: http://edx.readthedocs.io/projects/edx-platform-api/en/latest/
+.. _edX Platform Developer's Guide: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/
+.. _edX Research Guide: http://edx.readthedocs.io/projects/devdata/en/latest/
+.. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/
 .. _edX Status: http://status.edx.org/
 .. _edx-tools: https://github.com/edx/edx-tools/wiki
 .. _frequently asked questions: http://www.edx.org/student-faq
-.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/
+.. _Installing, Configuring, and Running the Open edX Platform: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/
 .. _meetup: http://www.meetup.com/edX-Global-Community/
 .. _openedx-analytics: http://groups.google.com/forum/#!forum/openedx-analytics
 .. _Open edX Analytics: http://edx-wiki.atlassian.net/wiki/display/OA/Open+edX+Analytics+Home
-.. _Open edX Learner's Guide: http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/
+.. _Open edX Learner's Guide: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/
 .. _openedx-ops: http://groups.google.com/forum/#!forum/openedx-ops
 .. _Open edX Portal: https://open.edx.org
 .. _open.edx.org/user/register: https://open.edx.org/user/register
-.. _Open edX Release Notes: http://edx.readthedocs.org/projects/open-edx-release-notes/en/latest/
+.. _Open edX Release Notes: http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/
 .. _openedx-studio: http://groups.google.com/forum/#!forum/openedx-studio
 .. _openedx-translation: http://groups.google.com/forum/#!forum/openedx-translation
 .. _open Confluence wiki: http://openedx.atlassian.net/wiki/
 .. _partners.edx.org: https://partners.edx.org
 .. _Twitter:  http://twitter.com/edXstatus
-.. _Using edX Insights: http://edx-insights.readthedocs.org/en/latest/
-.. _Open EdX XBlock API Guide: http://edx.readthedocs.org/projects/xblock/en/latest/
-.. _Open edX XBlock Tutorial: http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/index.html
+.. _Using edX Insights: http://edx-insights.readthedocs.io/en/latest/
+.. _Open EdX XBlock API Guide: http://edx.readthedocs.io/projects/xblock/en/latest/
+.. _Open edX XBlock Tutorial: http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/index.html

--- a/en_us/shared/set_up_course/search_course.rst
+++ b/en_us/shared/set_up_course/search_course.rst
@@ -26,7 +26,7 @@ When the search engine returns results, either for an individual course or
 across all courses, learners can select any search result to view that result
 in the course body.
 
-For more information about the student experience, see `Searching the Course <http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/SFD_course_search.html>`_.
+For more information about the student experience, see `Searching the Course <http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/SFD_course_search.html>`_.
 
 .. note::
  Studio indexes most content that learners see on the **Course** page. However,

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -7,7 +7,7 @@ import urllib
 
 import edx_theme
 
-# on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
+# on_rtd is whether we are on readthedocs.io, this line of code grabbed from docs.readthedocs.io
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # OK, this is gross: I don't know of a way to find out what builder is running,
@@ -83,7 +83,7 @@ DEVELOPERS = object()
 HELP_LINKS = {
     (PARTNER, COURSE_TEAMS): None, #"https://partners.edx.org/forums/partner-forums",
     (PARTNER, LEARNERS): "https://support.edx.org",
-    (PARTNER, RESEARCHERS): "http://edx.readthedocs.org/projects/devdata/en/latest/front_matter/preface.html#resources-for-researchers",
+    (PARTNER, RESEARCHERS): "http://edx.readthedocs.io/projects/devdata/en/latest/front_matter/preface.html#resources-for-researchers",
     (PARTNER, DEVELOPERS): "https://open.edx.org/resources/e-mail-lists",
     (OPENEDX, COURSE_TEAMS): "https://open.edx.org/resources/e-mail-lists",
     (OPENEDX, DEVELOPERS): "https://open.edx.org/resources/e-mail-lists",
@@ -114,22 +114,22 @@ copyright = '{year}, edX Inc.'.format(year=datetime.datetime.now().year)
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'opencoursestaff' : ('http://edx.readthedocs.org/projects/open-edx-building-and-running-a-course/en/latest/', None),
-    'data' : ('http://edx.readthedocs.org/projects/devdata/en/latest/', None),
-    'partnercoursestaff': ('http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/', None),
-    'insights' : ('http://edx.readthedocs.org/projects/edx-insights/en/latest/', None),
-    'xblockapi' : ('http://edx.readthedocs.org/projects/xblock/en/latest/', None),
-    'xblocktutorial' : ('http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/', None),
-    'installation' : ('http://edx.readthedocs.org/projects/edx-installing-configuring-and-running/en/latest/', None),
-    'olx' : ('http://edx.readthedocs.org/projects/edx-open-learning-xml/en/latest/', None),
-    'learners' : ('http://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/', None),
-    'openlearners' : ('http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/', None),
-    'opendevelopers' : ('http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/', None),
-    'openplatformapi' : ('http://edx.readthedocs.org/projects/edx-platform-api/en/latest/', None),
-    'opendataapi' : ('http://edx.readthedocs.org/projects/edx-data-analytics-api/en/latest/', None),
-    'openreleasenotes' : ('http://edx.readthedocs.org/projects/open-edx-release-notes/en/latest/', None),
-    'partnerreleasenotes': ('http://edx.readthedocs.org/projects/edx-release-notes/en/latest/', None),
-    '2014releasenotes' : ('http://edx.readthedocs.org/projects/edx-2013-2014-release-notes/en/latest/', None)
+    'opencoursestaff' : ('http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/', None),
+    'data' : ('http://edx.readthedocs.io/projects/devdata/en/latest/', None),
+    'partnercoursestaff': ('http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/', None),
+    'insights' : ('http://edx.readthedocs.io/projects/edx-insights/en/latest/', None),
+    'xblockapi' : ('http://edx.readthedocs.io/projects/xblock/en/latest/', None),
+    'xblocktutorial' : ('http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/', None),
+    'installation' : ('http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/', None),
+    'olx' : ('http://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/', None),
+    'learners' : ('http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/', None),
+    'openlearners' : ('http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/', None),
+    'opendevelopers' : ('http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/', None),
+    'openplatformapi' : ('http://edx.readthedocs.io/projects/edx-platform-api/en/latest/', None),
+    'opendataapi' : ('http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/', None),
+    'openreleasenotes' : ('http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/', None),
+    'partnerreleasenotes': ('http://edx.readthedocs.io/projects/edx-release-notes/en/latest/', None),
+    '2014releasenotes' : ('http://edx.readthedocs.io/projects/edx-2013-2014-release-notes/en/latest/', None)
 }
 
 extlinks = {


### PR DESCRIPTION
## [DOC-3574](https://openedx.atlassian.net/browse/DOC-3574)

Changed readthedocs.org to readthedocs.io in files from PR 1308 as well as 5 additional files found through search.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

