### PR TITLE
Update edx-platform GitHub wiki links

### DIFF
--- a/en_us/developers/source/environment/pycharm_ecommerce.rst
+++ b/en_us/developers/source/environment/pycharm_ecommerce.rst
@@ -8,8 +8,8 @@ visually debugging an instance of E-Commerce on devstack.
 
 Before following the steps below, you should already have PyCharm Professional
 Edition installed and set up PyCharm to remotely debug LMS following `these
-instructions <https://github.com/edx/edx-platform/wiki/Setting-up-PyCharm-for-
-edX-development>`_ in the edx-platform wiki.
+instructions <https://openedx.atlassian.net/wiki/display/ENG/Working+with+devstack+and+PyCharm>`_
+in the edX wiki.
 
 #. If the 'ecommerce' user on devstack currently has no password, SSH into the
    devstack box and set one.

--- a/en_us/developers/source/process/contributor.rst
+++ b/en_us/developers/source/process/contributor.rst
@@ -41,9 +41,8 @@ list of requirements to be sure that your pull request is ready to be reviewed:
    GitHub.
 
 #. The code should be clear and understandable. Comments in code, detailed
-   docstrings, and good variable naming conventions are expected. The
-   `edx-platform GitHub wiki`_ contains many great links to style guides for
-   Python, Javascript, and internationalization (i18n) conventions.
+   docstrings, and good variable naming conventions are expected. See the
+   :doc:`../style_guides/index` for more details.
 
 #. The pull request should be as small as possible. Each pull request should
    encompass only one idea: one bugfix, one feature, etc. Multiple features (or
@@ -142,9 +141,8 @@ following links:
 * :doc:`../testing/jenkins`
 * :doc:`../testing/code-coverage`
 * :doc:`../testing/code-quality`
-* `Python Guidelines <https://github.com/edx/edx-platform/wiki/Python-Guidelines>`_
-* `Javascript Guidelines <https://github.com/edx/edx-platform/wiki/Javascript-Guidelines>`_
+* :doc:`../style_guides/python_guidelines`
+* :doc:`../style_guides/javascript_guidelines`
 
-.. _edx-platform GitHub wiki: https://github.com/edx/edx-platform/wiki#development
 .. _contributor's agreement with edX: http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf
-.. _compatible licenses: https://github.com/edx/edx-platform/wiki/Licensing
+.. _compatible licenses: https://open.edx.org/open-edx-licensing

--- a/en_us/install_operations/source/ecommerce/test_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/test_ecommerce.rst
@@ -110,7 +110,7 @@ these tests, place your tests in the ``ecommerce/static/js/test/specs``
 directory, and add a ``_spec`` suffix. For example, your test name may be
 ``ecommerce/static/js/test/specs/course_list_view_spec.js``.
 
-All JavaScript code must adhere to the `edX JavaScript standards`_. These
+All JavaScript code must adhere to the `edX JavaScript Style Guide`_. These
 standards are enforced using `JSHint`_ and `jscs`_.
 
 * To run all JavaScript unit tests and linting checks, run the following

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -152,7 +152,7 @@
 
 .. _Devstack wiki: https://github.com/edx/configuration/wiki/edX-Developer-Stack
 
-.. _Developing on Devstack: https://github.com/edx/edx-platform/wiki/Developing-on-the-edX-Developer-Stack
+.. _Developing on Devstack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack
 
 .. _forum migration described on the Open edX wiki: https://openedx.atlassian.net/wiki/display/TNL/Migrating+the+Discussion+Forums+to+Support+Teams+Discussion+Filtering
 
@@ -240,7 +240,7 @@
 .. _Testing in Django: https://docs.djangoproject.com/en/1.8/topics/testing/
 .. _Django sites framework: https://docs.djangoproject.com/en/1.8/ref/contrib/sites
 .. _Jasmine: http://jasmine.github.io/2.3/introduction.html
-.. _edX JavaScript standards: https://github.com/edx/edx-platform/wiki/Javascript-standards-for-the-edx-platform
+.. _edX JavaScript Style Guide: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/style_guides/javascript_guidelines.html
 .. _JSHint: http://www.jshint.com/
 .. _jscs: https://www.npmjs.org/package/jscs
 .. _Waffle: http://waffle.readthedocs.org/en/latest


### PR DESCRIPTION
I've updated legacy links to the edx-platform GitHub wiki and replaced them with better links either to the developer's guide or to the edX Confluence wiki.

@benpatterson @srpearce @catong this is my first attempt at a documentation PR so let me know what the next steps should be. How should I be testing these changes?