### PR TITLE
Release Notes: Week Ending March 3, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-03-03.rst
+++ b/en_us/release_notes/source/2017/2017-03-03.rst
@@ -1,0 +1,24 @@
+#################################
+Week Ending 3 March 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 3 March 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-03-03.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-03-03
    2017-02-17
    2017-02-10
    2017-02-03

--- a/en_us/release_notes/source/2017/lms/lms_2017-03-03.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-03-03.rst
@@ -1,0 +1,12 @@
+
+================================================
+Accessibility Improvements
+================================================
+
+For screenreader users, elements in the footer of edx.org pages are now appropriately defined
+as unordered lists to streamline discoverability.
+(:jira:`ECOM-6902`)
+
+For screenreader users, the header on edx.org has been updated to improve
+clarity of navigation options and areas within the menus.
+(:jira:`ECOM-6906`)

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 3 March 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-03-03.rst  
+
+*************************
 Week ending 17 Feb 2017
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending March 3, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending March 3, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=158051809)

### Date Needed (optional)

EOD Wednesday March 8, 2017
### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

FYI: @srpearce

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [ ] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-02-10.html

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [x] Squash commits

