### PR TITLE
Update information about viewing learner Progress page

### DIFF
--- a/en_us/shared/developing_course/testing_courseware.rst
+++ b/en_us/shared/developing_course/testing_courseware.rst
@@ -93,7 +93,7 @@ the selected group would see it.
 
 For more information about each view, see :ref:`Staff View`, :ref:`Student
 View`, or :ref:`Specific Student View`. For more information about viewing
-cohort- specific course content, see :ref:`Viewing Cohort Specific Courseware`.
+cohort-specific course content, see :ref:`Viewing Cohort Specific Courseware`.
 
 
 .. _Preview Unpublished Content:
@@ -268,8 +268,9 @@ Specific Student View
 .. note:: This view is available only if your course has started, and only for
    content that has a status of :ref:`Published and Live`.
 
-Specific student view displays published content in your live course as
-the learner that you specify experiences it.
+Specific student view displays published content in your live course as the
+learner that you specify experiences it. When you view the **Progress** page,
+the page displays grades and progress for the learner that you have specified.
 
 When you view your course content as **Specific student**, be aware of the
 following limitations.

--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -416,7 +416,7 @@ grade report, the total score appears before the individual assignment scores.
 View a Specific Learner's Progress Page
 =======================================
 
-To view a specific learner's **Progress** page, you supply their email
+To view a specific learner's **Progress** page, you need their email
 address or username. You can check the progress for learners who are either
 enrolled in, or who have unenrolled from, the course.
 
@@ -427,12 +427,12 @@ To view the **Progress** page for a specific learner, follow these steps.
 
 #. View the live version of your course.
 
-#. Select **Instructor**, and then select **Student Admin**.
+#. Next to **View this course as**, select **Specific student**.
 
-#. In the **View a specific learner's grades and progress** section, enter the
-   learner's email address or username.
+#. In the **Username or email** field that appears, enter the learner's
+   username or email address, and then press the Enter key on your keyboard.
 
-#. Select **View Progress Page**.
+#. Select the **Progress** page.
 
    The **Progress** page for the learner displays a chart with the grade for
    each homework, lab, midterm, final, and any other assignment types in your


### PR DESCRIPTION
## [DOC-3563](https://openedx.atlassian.net/browse/DOC-3563)

Update the instructions for viewing a specific learner's **Progress** page per [TNL-5047](https://openedx.atlassian.net/browse/TNL-5047].

### Date Needed (optional)

ASAP; feature is now live.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (copy edit): @edx/doc
- [ ] Product review: @sstack22 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

