### PR TITLE
Describe assignment type average as weighted

### DIFF
--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -184,11 +184,13 @@ columns that provide the following information.
   that assignment type: for example, "Homework (Avg)". This column is not
   included if a particular assignment type has only one assignment.
 
-  Note that this assignment type average takes into account dropped
-  assignments. For example, if the course includes five homework assignments
-  and the course grading policy allows one homework assignment with the lowest
-  score to be dropped, the homework assignment average in this grade report is
-  calculated over four homework assignments rather than five.
+  This assignment type average takes both dropped assignments and the assignment
+  weight into account. For example, if the course includes five homework
+  assignments and the course grading policy allows one homework assignment with
+  the lowest score to be dropped, the homework assignment average in this grade
+  report is calculated over four homework assignments rather than five. This
+  average is then multiplied by the assignment weight to calculate the
+  assignment type average.
 
 * If :ref:`cohorts<Cohorts Overview>` are used in the course, a **Cohort Name**
   column indicates the name of the cohort that each learner belongs to,
@@ -373,7 +375,7 @@ The gradebook includes the following features.
 
 * For assignment types that include more than one assignment, an **{assignment
   type} Avg** column displays each learner's current average score for that
-  assignment type.
+  assignment type, modified by the assignment weight.
 
 * The **Total** column presents the total score that each learner has currently
   attained in the course. This value is expressed as a whole number: a learner


### PR DESCRIPTION
## [DOC-3596](https://openedx.atlassian.net/browse/DOC-3596)

The instructor's grade report includes average grades by assignment type. This average is now weighted by the assignment type weight, so I mentioned that at the two points we discuss the average.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @sstack22 : 
- [x] Doc team review (copy edit): @edx/doc

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

