### PR TITLE
Release Notes: Week Ending March 10, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-03-10.rst
+++ b/en_us/release_notes/source/2017/2017-03-10.rst
@@ -1,0 +1,36 @@
+#################################
+Week Ending 10 March 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 10 March 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+*************
+Analytics
+*************
+
+.. include:: analytics/analytics_2017-03-10.rst
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-03-10.rst
+
+*************
+Studio
+*************
+
+.. include:: studio/studio_2017-03-10.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/analytics/analytics_2017-03-10.rst
+++ b/en_us/release_notes/source/2017/analytics/analytics_2017-03-10.rst
@@ -1,0 +1,6 @@
+We have added a csv download to the Insights Courses Page, including the data
+presented in the UI as well as enrollment data for all additional tracks.
+(:jira:`AN-8229`)
+
+For more information, see :ref:`insights:Courses_Page` in the *Using edX Insights*
+guide.

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-03-10
    2017-03-03
    2017-02-17
    2017-02-10

--- a/en_us/release_notes/source/2017/lms/lms_2017-03-10.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-03-10.rst
@@ -1,0 +1,8 @@
+For a few weeks, discussion posts marked as anonymous would still expose the
+post author's name. A fix was merged to prevent this from happening in the
+future. Any posts that were intended to be anonymous authored between February
+8 2017 and March 7 2017 will still show the author's username to other students.
+(:jira:`TNL-6648`)
+
+We have extended the "view as a specific learner" functionality to the
+progress page.  (:jira:`TNL-5047`)

--- a/en_us/release_notes/source/2017/studio/studio_2017-03-10.rst
+++ b/en_us/release_notes/source/2017/studio/studio_2017-03-10.rst
@@ -1,0 +1,7 @@
+The *Video ID* field has been added to the "Basic" tab of the video component to simplify authoring. (:jira:`TNL-6489`)
+
+
+
+
+
+

--- a/en_us/release_notes/source/analytics_index.rst
+++ b/en_us/release_notes/source/analytics_index.rst
@@ -11,6 +11,12 @@ The following information describes what is new in edX analytics.
   :depth: 2
 
 *************************
+Week ending 10 March 2017
+*************************
+
+.. include:: 2017/analytics/analytics_2017-03-10.rst
+
+*************************
 Week ending 10 Feb 2017
 *************************
 

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 10 March 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-03-10.rst  
+
+*************************
 Week ending 3 March 2017
 *************************
 

--- a/en_us/release_notes/source/studio_index.rst
+++ b/en_us/release_notes/source/studio_index.rst
@@ -10,6 +10,11 @@ The following information summarizes what is new in edX Studio.
   :local:
   :depth: 2
 
+*************************
+Week ending 10 March 2017
+*************************
+
+.. include:: 2017/studio/studio_2017-03-10.rst
 
 *************************
 Week ending 3 Feb 2017


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending March 10, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending March 10, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=158212466)

### Date Needed (optional)

EOD Monday March 20, 2017
### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [ ] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-03-10.html

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [x] Squash commits

