### PR TITLE
Release notes for March 17, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-03-17.rst
+++ b/en_us/release_notes/source/2017/2017-03-17.rst
@@ -1,0 +1,25 @@
+#################################
+Week Ending 17 March 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 17 March 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-03-17.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-03-17
    2017-03-10
    2017-03-03
    2017-02-17

--- a/en_us/release_notes/source/2017/lms/lms_2017-03-17.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-03-17.rst
@@ -1,0 +1,8 @@
+Course teams can now target emails to learners in a particular enrollment
+track, for example, audit or verified. (:jira:`TNL-6703`)
+
+To improve accessibility, we have added a notification to our basic problems
+when 'Show Answer' is pressed. The 'Show Answer' button will display a
+notification that indicates the answers to the given problem are available in
+the body of the problem. This banner also includes a link for easy navigation
+to the beginning of the problem.  (:jira:`TNL-6356`)

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 17 March 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-03-17.rst  
+
+*************************
 Week ending 10 March 2017
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending March 17, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending March 17, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=158212641)

### Date Needed (optional)

EOD Monday March 20, 2017
### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

FYI: @srpearce

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [x] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-03-17.html

### Post-review

- [x] Squash commits

