### PR TITLE
Update Vagrantfile version for devstack

### DIFF
--- a/en_us/install_operations/source/installation/installation_prerequisites.rst
+++ b/en_us/install_operations/source/installation/installation_prerequisites.rst
@@ -43,7 +43,7 @@ Devstack, fullstack, and analytics devstack require the following software.
 
 * `VirtualBox`_ 4.3.12 or later.
 
-* `Vagrant`_ 1.6.5 or later.
+* `Vagrant`_ 1.8.7 or later.
 
 * An NFS (network file system) client, if your operating system does not
   include one. NFS allows devstack and fullstack virtual machines to share a


### PR DESCRIPTION
```
Capturing output to logs/install-20170327-153155.log
Installation started at 2017-03-27 15:31:55
Installing release 'master'
######################################################################## 100.0%
Installing the 'vagrant-vbguest' plugin. This can take a few minutes...
Installed the plugin 'vagrant-vbguest (0.13.0)'!
This Vagrant environment has specified that it requires the Vagrant
version to satisfy the following version requirements:

  >= 1.8.7

You are running Vagrant 1.8.1, which does not satisfy
these requirements. Please change your Vagrant version or update
the Vagrantfile to allow this Vagrant version. However, be warned
that if the Vagrantfile has specified another version, it probably has
good reason to do so, and changing that may cause the environment to
not function properly.
```

I was trying to install devstack and I got the above warning. 
Trying to install using the latest docs in http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/devstack/install_devstack.html