### PR TITLE
Release notes for March 24, 2017

### DIFF
--- a/en_us/release_notes/source/2016/documentation/doc_0328_2016.rst
+++ b/en_us/release_notes/source/2016/documentation/doc_0328_2016.rst
@@ -20,7 +20,7 @@ Building and Running an edX Course
   (ORA) problems.
 
 * A clarification about using the edx.org website during a proctored exam has
-  been added to the :ref:`partnercoursestaff:Online Proctoring Rules` topic.
+  been added to the :ref:`learners:Online Proctoring Rules` topic.
 
 edX Learner's Guide
 **********************************

--- a/en_us/release_notes/source/2017/2017-03-24.rst
+++ b/en_us/release_notes/source/2017/2017-03-24.rst
@@ -1,0 +1,32 @@
+#################################
+Week Ending 24 March 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 24 March 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-03-24.rst
+
+
+*************
+Website
+*************
+
+.. include:: website/website_2017-03-24.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-03-24
    2017-03-17
    2017-03-10
    2017-03-03

--- a/en_us/release_notes/source/2017/lms/lms_2017-03-24.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-03-24.rst
@@ -1,0 +1,12 @@
+Previously, learners and course teams could not enter a line break between
+paragraphs in the discussion forum. This issue has been resolved.
+(:jira:`TNL-6231`)
+
+On the Programs page of learners' dashboards, each program card clearly
+displays the number of courses completed, enrolled in, and remaining in the
+program.  (:jira:`ECOM-6601`)
+
+Program certificates now include social sharing buttons so that learners can
+share their achievement on LinkedIn, Facebook, and Twitter.
+(:jira:`ECOM-6578`)
+ 

--- a/en_us/release_notes/source/2017/website/website_2017-03-24.rst
+++ b/en_us/release_notes/source/2017/website/website_2017-03-24.rst
@@ -1,0 +1,5 @@
+From a course or program's About page, learners can now enroll in any of the
+course's available course runs. (:jira:`ECOM-7262`)
+
+In course search results on edx.org, if a course has multiple runs, only one
+course card is returned.  (:jira:`ECOM-6815`)

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 24 March 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-03-24.rst  
+
+*************************
 Week ending 17 March 2017
 *************************
 

--- a/en_us/release_notes/source/website_index.rst
+++ b/en_us/release_notes/source/website_index.rst
@@ -9,6 +9,12 @@ The following information describes what is new on edx.org and Edge.
   :depth: 1
 
 *************************
+Week of 24 September 2017
+*************************
+
+.. include:: 2017/website/website_2017-03-24.rst
+
+*************************
 Week of 19 September 2016
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending March 24, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending March 24, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=158212699)

### Date Needed (optional)

EOD Wednesday March 29, 2017
### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

FYI: @sstack22 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [x] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-03-17.html

### Post-review

- [x]  Squash commits

