### PR TITLE
Improve JavaScript style guide

### DIFF
--- a/en_us/developers/source/style_guides/javascript_guidelines.rst
+++ b/en_us/developers/source/style_guides/javascript_guidelines.rst
@@ -5,77 +5,38 @@ EdX JavaScript Style Guide
 ##########################
 
 This section describes the requirements and conventions used to contribute
-JavaScript programming to the edX platform.
+JavaScript programming to the edX platform. The majority of edX JavaScript code
+is written as `ES5`_, but is starting to move to `ES2015`_.
 
 .. contents::
  :local:
  :depth: 2
 
-****************
-Google Standards
-****************
-
-In general, edX JavaScript style follows the `Google JavaScript Style Guide`_.
-In particular, the section `JavaScript Language Rules`_ includes useful advice.
-
-EdX JavaScript style is defined by the linters for JavaScript code in each
-repository. Following Google JavaScript style will bring your code close to the
-standards set by edX linters.
-
 **********
 Code Style
 **********
 
-Use four spaces for indenting. An example follows.
+EdX JavaScript style generally follows the `Airbnb JavaScript Style Guide`_,
+with a few custom rules that can be seen in the `eslint-config-edx repository`_.
+EdX recommends using ESLint for JavaScript linting, and provides configurations
+for both ES2015 and ES5.
 
-.. code-block:: javascript
-
-    function renderElements(state) {
-        var youTubeId;
-
-        if (state.videoType === 'html5') {
-            state.videoPlayer.player = new HTML5Video.Player(state.el, {
-                playerVars: state.videoPlayer.playerVars,
-                videoSources: state.html5Sources,
-                events: {
-                    onReady: state.videoPlayer.onReady,
-                    onStateChange: state.videoPlayer.onStateChange
-                }
-            });
-        }
-    }
-
-****************
-Linting
-****************
-
-EdX repositories include linters such as ESLint, JSHint, and JSCS that enforce
-coding style according to the requirements of the repository and the history of
-the code. The development team at edX is working to make the
-JavaScript linters consistent across edX repositories, you must adhere to the
-requirements of the linters for the repository that you are working in.
-
-********************
-RequireJS
-********************
-
-EdX uses RequireJS to help manage JavaScript dependencies and integrate our
-pattern library more efficiently into our main platform, since it too uses
-RequireJS. You should have some familiarity with using RequireJS so that your
-scripts are not only included, but efficient.
-
-For more information, see the `RequireJS site`_.
-
-****************
+*******
 Testing
-****************
+*******
 
-For information about testing JavaScript UI code, see the `description of
+All JavaScript code should be tested using `Jasmine`_. In addition, there are a
+number of Jasmine-based helper classes provided by the `edX UI Toolkit`_.
+
+JavaScript tests are run with `Karma`_, along with `karma-coverage`_ to
+provide code coverage reporting.
+
+For more information about testing JavaScript, see the `description of
 testing for the edx-platform repository`_.
 
-****************
+*************
 Documentation
-****************
+*************
 
 All JavaScript code should be documented using JSDoc. For detailed information
 about using JSDoc, see the `JSDOC site`_.
@@ -89,6 +50,7 @@ produces HTML documentation for it. An example follows.
     var util = {
         /**
          * Repeat <tt>str</tt> several times.
+         *
          * @param {string} str The string to repeat.
          * @param {number} [times=1] How many times to repeat the string.
          * @returns {string}
@@ -103,12 +65,14 @@ produces HTML documentation for it. An example follows.
 
 .. Link targets
 
-.. _JSDOC site: http://usejsdoc.org/
-
+.. _Airbnb JavaScript Style Guide: https://github.com/airbnb/javascript
 .. _description of testing for the edx-platform repository: https://github.com/edx/edx-platform/blob/master/docs/en_us/internal/testing.rst
-
-.. _RequireJS site: http://requirejs.org/
-
-.. _JavaScript Language Rules: https://google.github.io/styleguide/jsguide.html#language-features
-
-.. _Google JavaScript Style Guide: https://google.github.io/styleguide/jsguide.html
+.. _edX UI Toolkit: http://ui-toolkit.edx.org/
+.. _ES5: https://www.ecma-international.org/ecma-262/5.1/
+.. _ES2015: http://www.ecma-international.org/ecma-262/6.0/
+.. _eslint-config-edx repository: https://github.com/edx/eslint-config-edx
+.. _Jasmine: http://jasmine.github.io/
+.. _jasmine-jquery: https://github.com/velesin/jasmine-jquery
+.. _JSDOC site: http://usejsdoc.org/
+.. _Karma: https://karma-runner.github.io/
+.. _karma-coverage: https://www.npmjs.com/package/karma-coverage

--- a/en_us/developers/source/testing/index.rst
+++ b/en_us/developers/source/testing/index.rst
@@ -7,7 +7,7 @@ Testing is something that we take very seriously at edX: we even have a
 infrastructure even more awesome.
 
 This file is currently a stub: to find out more about our testing infrastructure,
-check out the `testing.md`_ file on GitHub.
+check out the `testing.rst`_ file on GitHub.
 
 .. toctree::
     :maxdepth: 2
@@ -16,4 +16,4 @@ check out the `testing.md`_ file on GitHub.
     code-coverage
     code-quality
 
-.. _testing.md: https://github.com/edx/edx-platform/blob/master/docs/en_us/internal/testing.md
+.. _testing.rst: https://github.com/edx/edx-platform/blob/master/docs/en_us/internal/testing.rst


### PR DESCRIPTION
This change updates the Developer's Guide's JavaScript style guide to adopt the best practices from [OEP-8](https://github.com/edx/open-edx-proposals/pull/22).

While I was here, I also fixed the testing link to be to the new location, not to the old GitHub wiki.