### PR TITLE
PLAT-1227 Upgrade Sphinx to 1.5.4

### DIFF
--- a/shared/travis_requirements.txt
+++ b/shared/travis_requirements.txt
@@ -1,4 +1,3 @@
 # Used for documentation gathering
 edx-sphinx-theme==1.0.2
-sphinx==1.5.3
-sphinx_rtd_theme==0.2.4
+sphinx==1.5.4


### PR DESCRIPTION
## [PLAT-1227](https://openedx.atlassian.net/browse/PLAT-1227)

Upgrade Sphinx to 1.5.4, which claims to fix a bug we're hitting with empty toctrees.  Also removed the dependency on sphinx_rtd_theme, since we're no longer using it (edx-sphinx-theme is a fork of it).

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @macdiesel 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

