### PR TITLE
DOC: Fix refs to modified/deleted labels

### DIFF
--- a/en_us/release_notes/source/2015/documentation/doc_0422_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0422_2015.rst
@@ -7,8 +7,7 @@ edX Guide for Students
   of profiles.
 * Added a new section about the Learner Dashboard.
 
-For more information, see the :ref:`learners:SFD Dashboard Settings Profile`
-section.
+For more information, see the *edX Learner's Guide*.
 
 ==================================
 Building and Running an edX Course

--- a/en_us/release_notes/source/2015/documentation/doc_0428_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0428_2015.rst
@@ -6,8 +6,8 @@ Building and Running an edX Course
 * Updated the :ref:`partnercoursestaff:Working with Video Components` section
   to reflect a field label change.
 
-* Added the :ref:`partnercoursestaff:SFD Dashboard Settings Profile` topic with
-  profile and account settings information.
+* Added the "Exploring Your Dashboard and Profile" topic with profile and
+  account settings information.
 
 ==================================
 EdX Platform APIs
@@ -16,4 +16,4 @@ EdX Platform APIs
 * Updated the example responses in the :ref:`openplatformapi:edX Platform
   Enrollment API` documentation to include new ``enrollment_start``
   and ``enrollment_end`` fields.
-  
+

--- a/en_us/shared/manage_live_course/discussions.rst
+++ b/en_us/shared/manage_live_course/discussions.rst
@@ -586,8 +586,7 @@ follow these steps.
    The learner's account profile page opens. Learners can have either a limited
    profile or a full profile.
 
-For more information about profiles, see :ref:`openlearners:SFD Dashboard
-Settings Profile`.
+For more information about profiles, see :ref:`learners:SFD Dashboard`.
 
 ========================================
 Provide Guidelines for Learners

--- a/en_us/shared/set_up_course/setting_pacing.rst
+++ b/en_us/shared/set_up_course/setting_pacing.rst
@@ -63,11 +63,6 @@ complete course material at any time before the course end date.
   For more information about the way learners experience instructor-paced and
   self-paced courses, see :ref:`learners:SFD Course Pacing`.
 
-.. only:: Open_edX
-
-  For more information about the way learners experience instructor-paced and
-  self-paced courses, see :ref:`openlearners:SFD Course Pacing`.
-
 
 ***************************
 Set Pacing for Your Course

--- a/en_us/shared/set_up_course/setting_up_student_view.rst
+++ b/en_us/shared/set_up_course/setting_up_student_view.rst
@@ -7,7 +7,7 @@ Setting Details About Your Course
 This topic describes how to set details about your course in Studio. The
 details you set determine the information that learners see about the course on
 their dashboards and on the course **About** page. For more information,
-see :ref:`SFD Dashboard Settings Profile`.
+see :ref:`SFD Dashboard`.
 
 .. only:: Open_edX
 


### PR DESCRIPTION
Fixes references broken by changes in https://github.com/edx/edx-documentation/pull/1449

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors





