### PR TITLE
Correctness Visibility in a Subsection

### DIFF
--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -565,21 +565,6 @@ reached, the **Reset** option is not visible.
 This problem-level setting overrides the course-level **Show Reset Button for
 Problems** advanced setting.
 
-.. _Submitted Message:
-
-=================
-Submitted Message
-=================
-
-If problem correctness is withheld for the subsection, then this message is
-shown to learners after submitting an answer.
-
-This problem-level setting overrides the course-level default **Submitted Message**
-advanced setting.
-
-See :ref:`Correctness Visibility in a Subsection` for information about
-showing/hiding problem correctness from learners.
-
 .. _Timer Between Attempts:
 
 =======================

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -565,6 +565,21 @@ reached, the **Reset** option is not visible.
 This problem-level setting overrides the course-level **Show Reset Button for
 Problems** advanced setting.
 
+.. _Submitted Message:
+
+=================
+Submitted Message
+=================
+
+If problem correctness is withheld for the subsection, then this message is
+shown to learners after submitting an answer.
+
+This problem-level setting overrides the course-level default **Submitted Message**
+advanced setting.
+
+See :ref:`Correctness Visibility in a Subsection` for information about
+showing/hiding problem correctness from learners.
+
 .. _Timer Between Attempts:
 
 =======================

--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -317,6 +317,28 @@ whether the answer was correct or incorrect, and how many points were awarded.
 However, you may want to delay or withhold showing correctness to learners,
 for example, if you are running an exam or other assessment exercise.
 
+This setting affects the correctness shown for these basic problem types:
+
+* :ref:`Checkbox`
+* :ref:`Dropdown`
+* :ref:`Multiple Choice`
+* :ref:`Numerical Input`
+* :ref:`Text Input`
+
+And these advanced problem types:
+
+* :ref:`Annotation`
+* :ref:`Circuit Schematic Builder`
+* :ref:`Custom JavaScript Display and Grading<Custom JavaScript>`
+* :ref:`Custom Python-Evaluated Input<Write Your Own Grader>`
+* :ref:`Image Mapped Input`
+* :ref:`Math Expression Input`
+* :ref:`Problem Written in LaTeX`
+* :ref:`Problem with Adaptive Hint`
+* :ref:`Molecular Structure<Molecule Editor>`
+
+To change the correctness visibility for your subsection:
+
 #. Select the **Configure** icon in the subsection box.
 
    The **Settings** dialog box opens.
@@ -343,9 +365,15 @@ for example, if you are running an exam or other assessment exercise.
 
 #. Select **Save**.
 
-When correctness is withheld for a subsection, instead of the usual message,
-e.g. "Correct (1/1 point)" or "Incorrect (0/1 point)", learners will instead
-see a general message, "Answer received."
+.. _Submitted Message when Hiding Correctness:
+
+=========================================
+Submitted Message when Hiding Correctness
+=========================================
+
+When correctness is withheld for a subsection, instead of the usual message
+shown when an answer is submitted, e.g. "Correct (1/1 point)" or "Incorrect
+(0/1 point)", learners will instead see a general message: "Answer received."
 
 To change this default message for the whole course:
 

--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -360,11 +360,16 @@ To change the results visibility for your subsection:
       If no Grade Due Date (for instructor-paced courses) or Course End Date
       (for self-paced courses) has been set, then results are always shown.
 
-     .. note::
-      Results will be always be displayed to staff members of the course,
-      unless **Never show results** is selected.
-
 #. Select **Save**.
+
+ .. note::
+  Results will be always be displayed to staff members of the course, unless
+  **Never show results** is selected.
+
+  To see problems as they are presented to your learners, select the :ref:`View
+  this course as: Student<Roles for Viewing Course Content>` option when
+  previewing or viewing your live course content.
+
 
 .. _Publish all Units in a Subsection:
 

--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -314,6 +314,7 @@ Correctness Visibility in a Subsection
 
 By default, when the learner submits an answer to a problem, she will be shown
 whether the answer was correct or incorrect, and how many points were awarded.
+
 However, you may want to delay or withhold showing correctness to learners,
 for example, if you are running an exam or other assessment exercise.
 
@@ -364,26 +365,6 @@ To change the correctness visibility for your subsection:
       unless **Never show correctness** is selected.
 
 #. Select **Save**.
-
-.. _Submitted Message when Hiding Correctness:
-
-=========================================
-Submitted Message when Hiding Correctness
-=========================================
-
-When correctness is withheld for a subsection, instead of the usual message
-shown when an answer is submitted, e.g. "Correct (1/1 point)" or "Incorrect
-(0/1 point)", learners will instead see a general message: "Answer received."
-
-To change this default message for the whole course:
-
-#. Open your course in Studio.
-#. Select **Settings**, then **Advanced Settings**.
-#. Scroll down to the **Submitted Message** field, and update the text shown there.
-#. At the bottom of the page, select **Save Changes**.
-
-You can also customize the message for each problem using the :ref:`Submitted
-Message` problem setting.
 
 .. _Publish all Units in a Subsection:
 

--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -306,6 +306,57 @@ To set the assignment type and due date for a subsection, follow these steps.
 
 For more information, see :ref:`Grading Index`.
 
+.. _Correctness Visibility in a Subsection:
+
+**************************************
+Correctness Visibility in a Subsection
+**************************************
+
+By default, when the learner submits an answer to a problem, she will be shown
+whether the answer was correct or incorrect, and how many points were awarded.
+However, you may want to delay or withhold showing correctness to learners,
+for example, if you are running an exam or other assessment exercise.
+
+#. Select the **Configure** icon in the subsection box.
+
+   The **Settings** dialog box opens.
+
+#. Select the **Advanced** tab, and locate the **Correctness Visibility** section.
+
+#. Select one of the available options:
+
+   * **Always show correctness**: default behavior.
+   * **Never show correctness**: withhold correctness completely for problems
+     in this subsection.
+   * **Show correctness when subsection is past due**: withhold correctness
+     until the Grade Due Date for the subsection (if instructor-paced course),
+     or the Course End Date for the course (if self-paced course), has passed.
+
+     .. note::
+      If no Grade Due Date (for instructor-paced courses) or Course End Date
+      (for self-paced courses) has been set, then the default behavior of
+      always showing correctness is used.
+
+     .. note::
+      Correctness will be always be displayed to staff members of the course,
+      unless **Never show correctness** is selected.
+
+#. Select **Save**.
+
+When correctness is withheld for a subsection, instead of the usual message,
+e.g. "Correct (1/1 point)" or "Incorrect (0/1 point)", learners will instead
+see a general message, "Answer received."
+
+To change this default message for the whole course:
+
+#. Open your course in Studio.
+#. Select **Settings**, then **Advanced Settings**.
+#. Scroll down to the **Submitted Message** field, and update the text shown there.
+#. At the bottom of the page, select **Save Changes**.
+
+You can also customize the message for each problem using the :ref:`Submitted
+Message` problem setting.
+
 .. _Publish all Units in a Subsection:
 
 **********************************

--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -306,19 +306,19 @@ To set the assignment type and due date for a subsection, follow these steps.
 
 For more information, see :ref:`Grading Index`.
 
-.. _Correctness Visibility in a Subsection:
+.. _Results Visibility in a Subsection:
 
-**************************************
-Correctness Visibility in a Subsection
-**************************************
+**********************************
+Results Visibility in a Subsection
+**********************************
 
 By default, when the learner submits an answer to a problem, she will be shown
 whether the answer was correct or incorrect, and how many points were awarded.
 
-However, you may want to delay or withhold showing correctness to learners,
+However, you may want to delay or withhold showing results to learners,
 for example, if you are running an exam or other assessment exercise.
 
-This setting affects the correctness shown for these basic problem types:
+This setting affects the results shown for these basic problem types:
 
 * :ref:`Checkbox`
 * :ref:`Dropdown`
@@ -338,31 +338,31 @@ And these advanced problem types:
 * :ref:`Problem with Adaptive Hint`
 * :ref:`Molecular Structure<Molecule Editor>`
 
-To change the correctness visibility for your subsection:
+To change the results visibility for your subsection:
 
 #. Select the **Configure** icon in the subsection box.
 
    The **Settings** dialog box opens.
 
-#. Select the **Advanced** tab, and locate the **Correctness Visibility** section.
+#. Select the **Visibility** tab, and locate the **Results Visibility** section.
 
 #. Select one of the available options:
 
-   * **Always show correctness**: default behavior.
-   * **Never show correctness**: withhold correctness completely for problems
-     in this subsection.
-   * **Show correctness when subsection is past due**: withhold correctness
-     until the Grade Due Date for the subsection (if instructor-paced course),
-     or the Course End Date for the course (if self-paced course), has passed.
+   * **Always show results**: default behavior; results are shown immediately
+     when answers are submitted.
+   * **Never show results**: never show results for answers submitted in this
+     subsection.
+   * **Show results when subsection is past due**: delay showing results until
+     the Grade Due Date for the subsection (if instructor-paced course), or the
+     Course End Date for the course (if self-paced course), has passed.
 
      .. note::
       If no Grade Due Date (for instructor-paced courses) or Course End Date
-      (for self-paced courses) has been set, then the default behavior of
-      always showing correctness is used.
+      (for self-paced courses) has been set, then results are always shown.
 
      .. note::
-      Correctness will be always be displayed to staff members of the course,
-      unless **Never show correctness** is selected.
+      Results will be always be displayed to staff members of the course,
+      unless **Never show results** is selected.
 
 #. Select **Save**.
 


### PR DESCRIPTION
## [OSPR-1716](https://openedx.atlassian.net/browse/OSPR-1716)

cf [DOC-1319](https://openedx.atlassian.net/browse/DOC-1319), [DOC-832](https://openedx.atlassian.net/browse/DOC-832)

Adds a section describing the new Correctness Visibility for Subsections and the associated Submitted Message settings, added by https://github.com/edx/edx-platform/pull/14737.

Please see https://github.com/edx/edx-platform/pull/14737 for full description and screenshots.

### Date Needed

Merge deadline for https://github.com/edx/edx-platform/pull/14737 is 21 April 2017.

### Partner Information

3rd party-hosted open edX instance

### Deployment Targets

edx.org, edge.edx.org

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] OpenCraft: @bradenmacdonald 
- [ ] Subject matter expert: @cahrens 
- [ ] Doc team review (sanity check, and copy edit please): @edx/doc
- [x] Product review: @sstack22 
- [ ] Partner support: ?
- [ ] PM review: ?

FYI: @nasthagiri , @srpearce 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Sandbox

- [ ] Studio: https://studio-pr14737.sandbox.opencraft.hosting/
- [ ] LMS: https://pr14737.sandbox.opencraft.hosting/

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
