### PR TITLE
Release notes for March 31, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-03-31.rst
+++ b/en_us/release_notes/source/2017/2017-03-31.rst
@@ -1,0 +1,39 @@
+#################################
+Week Ending 31 March 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 24 March 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+Analytics
+*************
+
+.. include:: analytics/analytics_2017-03-31.rst
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-03-31.rst
+
+
+*************
+Website
+*************
+
+.. include:: website/website_2017-03-31.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/analytics/analytics_2017-03-31.rst
+++ b/en_us/release_notes/source/2017/analytics/analytics_2017-03-31.rst
@@ -1,0 +1,5 @@
+On the Insights **Courses** page, tooltips that provide a brief description of
+each column have been added to the Course List table. (:jira:`AN-8200`)
+
+Summary metrics have been added to the Insights **Courses** page, showing
+enrollment totals across all courses. (:jira:`AN-8187`)

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-03-31
    2017-03-24
    2017-03-17
    2017-03-10

--- a/en_us/release_notes/source/2017/lms/lms_2017-03-31.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-03-31.rst
@@ -1,0 +1,21 @@
+Drag and drop problems can now be rescored using the same process that CAPA
+problems use. For more information, see :ref:`partnercoursestaff:rescore` in
+*Building and Running an edX Course* or :ref:`opencoursestaff:rescore` in
+*Building and Running an Open edX Course*. (:jira:`TNL-6765`)
+
+On the **Cohorts** tab on the instructor dashboard, the count of learners
+associated with the cohort reflects only active learners. Previously, this
+count also reflected unenrolled learners.  (:jira:`TNL-6603`)
+
+A problem that prevented learners from using the **Show Answer** option more
+than one time has been resolved. (:jira:`TNL-6436`)
+ 
+When learners select **Bookmarks** to view their bookmarks, the **Bookmarks**
+view that opens now covers the whole page. Previously, the left pane that
+lists course sections and subsections was visible when learners viewed
+bookmarks. This change improves navigation for screen readers.
+(:jira:`LEARNER-39`)
+
+On the Programs page of learners' dashboards, each program card clearly
+displays the number of courses completed, enrolled in, and remaining in the
+program. (:jira:`ECOM-6601`)

--- a/en_us/release_notes/source/2017/website/website_2017-03-31.rst
+++ b/en_us/release_notes/source/2017/website/website_2017-03-31.rst
@@ -1,0 +1,8 @@
+From a course or program's About page, learners can now enroll in any of the
+course's available course runs. (:jira:`ECOM-7262`)
+
+Catalog performance has been improved so that edx.org and the LMS load faster
+with fewer errors.  (:jira:`ECOM-7140`)
+
+When learners search for courses, results now return only the first run of
+each course instead of multiple runs of the same course. (:jira:`ECOM-6816`)

--- a/en_us/release_notes/source/analytics_index.rst
+++ b/en_us/release_notes/source/analytics_index.rst
@@ -11,6 +11,12 @@ The following information describes what is new in edX analytics.
   :depth: 2
 
 *************************
+Week ending 31 March 2017
+*************************
+
+.. include:: 2017/analytics/analytics_2017-03-31.rst
+
+*************************
 Week ending 10 March 2017
 *************************
 

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 31 March 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-03-31.rst 
+
+*************************
 Week ending 24 March 2017
 *************************
 

--- a/en_us/release_notes/source/website_index.rst
+++ b/en_us/release_notes/source/website_index.rst
@@ -9,7 +9,13 @@ The following information describes what is new on edx.org and Edge.
   :depth: 1
 
 *************************
-Week of 24 September 2017
+Week of 31 March 2017
+*************************
+
+.. include:: 2017/website/website_2017-03-31.rst
+
+*************************
+Week of 24 March 2017
 *************************
 
 .. include:: 2017/website/website_2017-03-24.rst


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending March 31, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending March 31, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=158782235)

### Date Needed (optional)

EOD Wednesday April 5, 2017
### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review: @srpearce 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [ ] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-03-31.html

### Post-review

- [ ]  Squash commits
- [ ] Build on release notes project is run. 

