### PR TITLE
Note about how we display the number of learners in a cohort

### DIFF
--- a/en_us/shared/course_features/cohorts/cohort_config.rst
+++ b/en_us/shared/course_features/cohorts/cohort_config.rst
@@ -248,6 +248,10 @@ To manually assign learners to cohorts in your course, follow these steps.
    cohort was changed as a result of your adding them to another cohort using
    this procedure.
 
+ .. note:: The number of learners reported on the **Cohorts** tab and in
+    downloaded reports includes only those learners who are enrolled in the
+    course.
+
 For a report that includes the cohort assignment for every enrolled learner,
 review the learner profile information for your course. See :ref:`View and
 download student data`.
@@ -309,8 +313,8 @@ The requirements for the .csv file are summarized in this table.
         See :ref:`Creating a Unicode Encoded CSV File`.
 
     * - Header row
-      - You must include a header row, with column names that exactly match those
-        specified in "Columns" below.
+      - You must include a header row, with column names that exactly match
+         those specified in "Columns" below.
     * - One or two columns identifying students
       - You must include at least one column identifying students:
         either "email" or "username", or both.

--- a/en_us/shared/course_features/cohorts/cohorts_overview.rst
+++ b/en_us/shared/course_features/cohorts/cohorts_overview.rst
@@ -39,6 +39,10 @@ cohorts<Options for Assigning Learners to Cohorts>`.
    do not change cohort configuration or a learner's cohort assignment after
    your course begins.
 
+   The number of learners reported on the **Cohorts** tab and in
+   downloaded reports includes only those learners who are enrolled in the
+   course.
+
 For more information about using cohorts, see the following topics.
 
 * :ref:`Enabling and Configuring Cohorts`
@@ -56,8 +60,8 @@ For information about discussions in general, see :ref:`Discussions`.
 Options for Assigning Learners to Cohorts
 *****************************************
 
-Learners are assigned to cohorts either automatically or manually, depending on
-the types of cohorts that you create. Manual cohorts do not have
+Learners are assigned to cohorts either automatically or manually, depending
+on the types of cohorts that you create. Manual cohorts do not have
 learners assigned to them unless you manually add learners. Automatic cohorts
 have learners randomly assigned to them if learners do not belong to any cohort
 by the time they access the course content (including the course **Discussion**

--- a/en_us/shared/course_features/cohorts/cohorts_overview.rst
+++ b/en_us/shared/course_features/cohorts/cohorts_overview.rst
@@ -159,7 +159,7 @@ that are of particular interest.
 
 To implement this assignment strategy, you identify the "real-world" cohorts
 that your learners already belong to. You enable cohorts and then create
-"manual" cohorts to represent each of the real-world cohorts. You then manually
+manual cohorts to represent each of the real-world cohorts. You then manually
 assign each enrolled learner to a cohort. Every learner in your course,
 including those who enroll after the course starts, must be assigned to a
 cohort.


### PR DESCRIPTION
## [DOC-3615](https://openedx.atlassian.net/browse/DOC-3615)

I added this note in the [Cohorts overview](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohorts_overview.html) of the B&R guide and also in the [Assign Learners Manually](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohort_config.html#assign-learners-to-cohorts-manually) section.

 * The number of learners reported on the **Cohorts** tab and in
    downloaded reports includes only those learners who are enrolled in the
    course.

### Date Needed (optional)

This has already been released (about 3/31), so a quick review would be good.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @staubina 
- [ ] Subject matter expert: @cahrens 
- [x] Doc team review (copy edit): @edx/doc
- [ ] Product review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

