### PR TITLE
Update docs to reflect component name change for ORA

### DIFF
--- a/en_us/course_authors/source/exercises_tools/open_response_assessments/index.rst
+++ b/en_us/course_authors/source/exercises_tools/open_response_assessments/index.rst
@@ -6,11 +6,11 @@ Open Response Assessments
 
 .. note:: EdX offers full support for this problem type.
 
-Open response assessments (ORA), also called peer assessments, are a flexible
-assignment type in which learners answer questions that might not have definite
-answers. Learners submit text responses or short essays. You can also require
-learners to submit an image or other type of file to accompany their written
-responses.
+Open response assessments (ORA), sometimes also called peer assessments, are a
+flexible assignment type in which learners answer questions that might not have
+definite answers. Learners submit text responses or short essays. You can also
+require learners to submit an image or other type of file to accompany their
+written responses.
 
 After submitting their original responses, learners are guided through a
 series of assessment steps that can include a training step, peer assessment,

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -28,8 +28,8 @@ You then choose the type of problem that you want to add from a list of
 
 The common problem types include relatively straightforward CAPA problems such
 as multiple choice and text or numeric input. The advanced problem types can be
-more complex to set up, such as math expression input, peer assessment, or
-custom JavaScript problems.
+more complex to set up, such as math expression input, open response
+assessment, or custom JavaScript problems.
 
 The common and advanced problem types that the problem component lists are the
 core set of problems that every course team can include in a course. You can
@@ -76,13 +76,13 @@ The editing interface that opens depends on the type of problem you choose.
   elements of the problem, such as the prompt and the correct and incorrect
   answer options.
 
-* For advanced problem types (with the exception of :ref:`peer assessment<Open
-  Response Assessments 2>`), the :ref:`advanced editor<Advanced Editor>` opens.
-  In this editor you use open learning XML (OLX) elements and attributes
-  to identify the elements of the problem.
+* For advanced problem types (with the exception of :ref:`open response
+  assessment<Open Response Assessments 2>`), the :ref:`advanced editor<Advanced
+  Editor>` opens. In this editor you use open learning XML (OLX) elements and
+  attributes to identify the elements of the problem.
 
-  For peer assessment problem types, you define the problem elements and
-  options by using a graphical user interface. For more information, see
+  For open response assessment problem types, you define the problem elements
+  and options by using a graphical user interface. For more information, see
   :ref:`PA Create an ORA Assignment`.
 
 You can switch from the simple editor to the advanced editor at any time by
@@ -249,8 +249,8 @@ problem types in the advanced editor.
 
 * :ref:`Molecular Structure<Molecule Editor>`
 
-For the :ref:`Peer Assessment<Open Response Assessments 2>` advanced problem
-type, a dialog box opens for problem setup.
+For the :ref:`Open Response Assessment<Open Response Assessments 2>` advanced
+problem type, a dialog box opens for problem setup.
 
 Blank advanced problems do not provide an example problem, but they also open
 in the advanced editor by default.

--- a/en_us/shared/course_components/libraries.rst
+++ b/en_us/shared/course_components/libraries.rst
@@ -18,8 +18,8 @@ Content Libraries Overview
 
 In Studio, you can create a library to build a pool of components for use in
 randomized assignments in your courses. You can add HTML components, problems,
-and video components to a library. Peer assessment and discussion components
-are not supported in libraries.
+and video components to a library. Open response assessment and discussion
+components are not supported in libraries.
 
 .. note:: Content libraries are available only for courses that have course
    identifiers in this format: ``{key type}:{org}+{course}+{run}``. For

--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -222,7 +222,7 @@ editor<Advanced Editor>` opens.
        expressions. You can specify a correct answer either explicitly or by
        using a Python script.
      - Full support; mobile-ready
-   * - :ref:`Peer Assessment<Open Response Assessments 2>`
+   * - :ref:`Open Response Assessment<Open Response Assessments 2>`
      - Learners receive feedback on responses that they submit and give
        feedback to other course participants. Open response assessments include
        self assessment, peer assessment, and optionally, staff assessment.

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -41,7 +41,7 @@ steps.
 
 #. Under **Add New Component**, select **Problem**.
 
-#. Select **Advanced**, and then select **Peer Assessment**.
+#. Select **Advanced**, and then select **Open Response Assessment**.
 
 #. In the problem component that appears, select **Edit**.
 
@@ -82,11 +82,12 @@ complete these steps.
 Add Formatting or Images to a Prompt
 ========================================
 
-Currently, you cannot format text or add images inside the Peer Assessment
-component. To include formatting or images in a prompt, you can add an HTML
-component that contains your text above the Peer Assessment component, and
-leave the text field in the **Prompt** tab blank. The instructions for the peer
-assessment still appear above the **Your Response** field.
+Currently, you cannot format text or add images inside an open response
+assessment component. To include formatting or images in a prompt, you can add
+an HTML component that contains your text above the open response assessment
+component, and leave the text field in the **Prompt** tab blank. The
+instructions for the open response assessment still appear above the **Your
+Response** field.
 
 .. image:: ../../../../shared/images/PA_HTMLComponent.png
       :alt: A peer assessment component that has an HTML component containing


### PR DESCRIPTION
## [DOC-3616](https://openedx.atlassian.net/browse/DOC-3616)

[PI-95](https://openedx.atlassian.net/browse/PI-95) updates the UI label for the "Peer Assessment" component to the more accurate "Open Response Assessment". This PR updates the docs to reflect this change.

### Date Needed (optional)

5 April 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check: @edx/doc

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

