### PR TITLE
Update info for LTI 'request user email/username' settings

### DIFF
--- a/en_us/shared/exercises_tools/lti_component.rst
+++ b/en_us/shared/exercises_tools/lti_component.rst
@@ -351,9 +351,31 @@ LTI Component Settings
        An LTI component will only send learners' email addresses if the **LTI
        Launch Target** control is set to **New Window**.
 
+       By default, this setting is not available in Studio.
+
+       .. only:: Partners
+
+         To make this setting available, contact your edX partner manager.
+
+       .. only:: Open_edX
+
+         To make this setting available, a system administrator must enable the
+         setting in the Django administration console.
+
    * - Request user's username
      - Sends the learner's username to the remote LTI tool. This is the
        username that the learner used to register for the course.
 
        An LTI component will only send learners' usernames if the **LTI Launch
        Target** control is set to **New Window**.
+
+       By default, this setting is not available in Studio.
+
+       .. only:: Partners
+
+         To make this setting available, contact your edX partner manager.
+
+       .. only:: Open_edX
+
+         To make this setting available in Studio, a system administrator must
+         enable the setting in the Django administration console.


### PR DESCRIPTION
## [TNL-6688](https://openedx.atlassian.net/browse/TNL-6688)

Our documentation currently tells course authors how to use two LTI settings to ask for user information from their LTI providers. TNL-6688 hides these settings by default. This PR adds disclaimers to the documentation, saying that an edX PM or OE system admin has to enable these settings.

### Date Needed (optional)

6 April 2017 (approximately)

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check, copy edit): @edx/doc
- [x] Product review: @sstack22 or @katymyw

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

