### PR TITLE
Fix typo and make small revision to calculator information

### DIFF
--- a/en_us/shared/students/completing_assignments/SFD_mathformatting.rst
+++ b/en_us/shared/students/completing_assignments/SFD_mathformatting.rst
@@ -47,23 +47,21 @@ information, see :ref:`Math Expressions in Discussions`.
 Entering Math Expressions in Assignments or the Calculator
 ****************************************************************
 
-note::
-  If your course offers the calculator tool, the calculator appears as a small
-  icon on all pages in the body of the course.
-
-  .. image:: ../../../shared/images/Calc_Closed.png
-    :width: 600
-    :alt: Course page with an arrow pointing to the calculator.
-
-  To use the calculator, select the calculator icon. To close the calculator,
-  select the X that appears when the calculator is open.
-
 Both the calculator and the response fields in math problems accept a
 selection of characters that represent numbers, operators, constants,
 functions, and other mathematical concepts. You might recognize parts of this
 system if you have used math programs before.
 
 .. note::
+  If your course offers the calculator tool, the calculator appears as a small
+  icon on all pages in the body of the course. To open the calculator, select
+  the calculator icon. To close the calculator, select the X that appears when
+  the calculator is open.
+
+  .. image:: ../../../shared/images/Calc_Closed.png
+    :width: 600
+    :alt: Course page with an arrow pointing to the calculator.
+
   The calculator includes an information page that shows an abbreviated version
   of the information in this topic. To see the information page, select the
   circled ``i`` icon next to the input field.


### PR DESCRIPTION
I found a typo that affects formatting while I was looking at information about the calculator:

![screenshot](https://cloud.githubusercontent.com/assets/3493253/24767197/3304a120-1acc-11e7-946b-a84665fe37e0.png)

I fixed the formatting and revised the section slightly.


### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

