### PR TITLE
Update ORA docs to reflect multi-file uploading and size limit increase

### DIFF
--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -131,8 +131,8 @@ in :ref:`Steps in an Open Response Assessment`.
  :local:
  :depth: 1
 
-At any time during an assessment, you can see your progress at the bottom of the
-page under **Your Grade**. A message indicates the steps that must still be
+At any time during an assessment, you can see your progress at the bottom of
+the page under **Your Grade**. A message indicates the steps that must still be
 completed before you can receive your final grade for the assignment.
 
 
@@ -160,10 +160,10 @@ steps.
 
    .. note::
 
-      In some assignments, you can submit an image or other type of file to
-      accompany your written response. If you are allowed to upload a file in
-      your assignment, **Browse** and **Upload your file** options are
-      available below the response field.
+      In some assignments, you can submit images or other types of files along
+      with or instead of a written response. If you can upload files in your
+      assignment, **Browse** and **Upload your files** options are available
+      below the response field.
 
       For information about uploading images or other files in your ORA
       assignment, see :ref:`Submit a File with Your Response`.
@@ -190,39 +190,33 @@ back later, just refresh or reopen your browser when you come back.
 Submit a File with Your Response
 ***********************************
 
-If your assignment requires you to submit an image or other type of file to
-accompany your text response, you see **Browse** and **Upload your file**
-options below the response field.
+If your assignment requires or allows you to submit images or other types of
+files, you see two buttons below the response field: **Choose Files** one one
+side of the page, and **Upload Files** on the other side of the page.
 
 .. note::
 
-   * You can upload only one file with your response.
-
-   * The file that you upload must be smaller than 5 MB in size.
+   * The cumulative size of the files that you upload must be less than 10 MB.
 
    * Image files can be in .jpg, .gif, or .png format.
 
-   * A text response is always required in open response assessments, in
-     addition to the file that you upload. Include some text in your response
-     that describes file that you uploaded, so that reviewers who cannot
-     access the uploaded file can still understand the text content of your
-     response.
+To upload files in your response, follow these steps.
 
+#. Below the response field, select **Choose Files**.
 
-To upload a file in your response, follow these steps.
+#. In the dialog box that opens, select the file that you want to upload, and
+   then select **Open**.
 
-#. Below the response field, select **Browse**.
+   A preview image of each file is visible.
 
-#. Select the file that you want to upload, and then select **Open**.
+#. In the boxes next to each preview image, enter a written description of the
+   image. This step is required to help learners who cannot see or access the
+   image understand and evaluate your response.
 
-   The name of the file that you selected for uploading appears next to **Browse**.
+#. Across from the **Choose Files** button, select **Upload files**.
 
-#. Select **Upload your file**.
-
-   Your file is uploaded and a preview image is displayed.
-
-You can replace the file that you uploaded with a different one until you
-submit your response. To replace your chosen file, repeat steps 1-3.
+You can replace the files that you uploaded with different files until you
+submit your response. To replace your uploaded files, repeat steps 1-3.
 
 
 View Your Submitted Response

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -93,39 +93,6 @@ assessment still appear above the **Your Response** field.
          text and an image, above the peer assessment.
       :width: 500
 
-.. _PA Allow Images:
-
-============================================
-Allow Learners to Submit Files (optional)
-============================================
-
-Before you enable this feature for your open response assessment, be sure to
-read about its limitations and best practices. For more information, see
-:ref:`Asking Learners to Upload Other Files in Responses`.
-
-To allow learners to submit a file along with their text responses, follow
-these steps.
-
-#. In the ORA component editor, select **Settings**.
-
-#. Set **Allow File Upload** to one of these options.
-
-   * **Image File**
-   * **PDF or Image File**
-   * **Custom File Types**
-
-#. If you select **Custom File Types**, the **File Types** field appears. Enter
-   the file extensions, separated by commas, of the types of files that
-   you want learners to submit.
-
-   .. note:: To reduce the potential for problems from files with malicious
-    content, learners cannot upload certain file types. For more information,
-    see :ref:`Prohibited File Extensions`.
-
-#. Make sure the text of your prompt includes adequate instructions for
-   learners to upload the required files, including the file type or types
-   that learners can upload.
-
 .. _PA Add Rubric:
 
 ******************************
@@ -210,15 +177,27 @@ To provide a comment field without options, complete these steps.
 #. Next to **Feedback for This Criterion**, select **Required** from the list.
 
 
+.. _PA Specify Additional Settings:
+
+***********************************
+Step 4. Specify Additional Settings
+***********************************
+
+After you have added a prompt and rubric, you must specify additional settings
+for the assignment. These settings include the type of response that learners
+must submit, assignment dates, and whether learners will see a list of top
+scoring responses.
+
 .. _PA Specify Name and Dates:
 
-************************************************************
-Step 4. Specify the Assignment Name and Response Dates
-************************************************************
+========================
+Specify a Name and Dates
+========================
 
 Before you specify the start and due dates and times for a response, be sure
 that you consider these aspects of, and best practices for, the open response
-assessment feature. For more information, see :ref:`Best Practices for ORA`.
+assessment feature. For more information, see
+:ref:`Best Practices for ORA`.
 
 * Unlike other problem types, ORA assignments are not governed by the
   subsection due date. You set due dates for each ORA assignment in the
@@ -241,9 +220,9 @@ assessment feature. For more information, see :ref:`Best Practices for ORA`.
   <http://www.timeanddate.com/worldclock/converter.html>`_.
 
 To specify a name for the assignment as well as start and due dates for all
-learner responses, complete these steps.
+learner responses, follow these steps.
 
-#. In the ORA component editor, select the **Settings** tab.
+#. In the ORA component editor, select **Settings**.
 
 #. Next to **Display Name**, enter the name you want to give the assignment.
 
@@ -253,6 +232,81 @@ learner responses, complete these steps.
 #. Next to **Response Due Date** and **Response Due Time**, enter the date and
    time by which all learner responses must be submitted.
 
+.. _PA Allow Images:
+
+=========================
+Specify the Response Type
+=========================
+
+Learners can submit written responses, files, or both in their responses to the
+assigment. If you want learners to upload files, make sure the text of your prompt includes adequate instructions for learners to upload the required files, including the file types that learners can upload.
+
+.. note::
+  Before you ask learners to submit files for your open response assessment, be
+  sure to read about limitations and best practices. For more information, see
+  :ref:`Asking Learners to Upload Other Files in Responses`.
+
+  If you allow or require learners to upload image files, learners must also
+  provide a brief written description of each image for accessibility.
+
+To specify the response type that learners must submit, follow
+these steps.
+
+#. In the ORA component editor, select **Settings**.
+
+#. For **Text Response**, select one of the following options.
+
+   * **None**
+   * **Required**
+   * **Optional**
+
+#. For **File Uploads Response**, select one of the following options.
+
+   * **None**
+   * **Required**
+   * **Optional**
+
+   If you select **Required** or **Optional**, the **File Upload Types** list
+   appears. Select one of the following options.
+
+   * **PDF or Image Files**
+   * **Image Files**
+   * **Custom File Types**
+
+   If you select **Custom File Types**, the **File Types** field appears.
+   Enter the file name extensions, separated by commas, of the types of files
+   that you want learners to submit.
+
+   .. note:: To reduce the potential for problems from files with malicious
+    content, learners cannot upload certain file types. For more information,
+    see :ref:`Prohibited File Extensions`.
+
+#. For **Allow LaTeX Responses**, select **True** or **False**.
+
+.. _PA Show Top Responses:
+
+=====================
+Include Top Responses
+=====================
+
+You can specify whether learners see a section that shows the :ref:`highest
+scoring responses<PA Top Responses>` that were submitted for each question in
+the assignment. If offered, this section displays only after each learner has
+completed all steps in the assignment. You specify the number of highest
+scoring responses to show.
+
+.. note:: Because each response can be up to 300 pixels in height, we
+   recommend that you set the number of top responses lower than 20, to
+   prevent the page from becoming too long.
+
+#. In the ORA component editor, select **Settings**.
+
+#. In the **Top Responses** field, specify the number of responses that you
+   want to appear in the **Top Responses** section below the learner's final
+   score.
+
+   If you do not want this section to appear, set the number to 0. The
+   maximum number is 100.
 
 .. _PA Select Assignment Steps:
 
@@ -338,8 +392,6 @@ To add and score learner training responses, follow these steps.
 #. Under **Response Score**, for each criterion, select the option that you
    want.
 
-
-
 ============================
 Peer Assessment
 ============================
@@ -395,7 +447,6 @@ the step starts and ends.
    `Time and Date Time Zone Converter
    <http://www.timeanddate.com/worldclock/converter.html>`_.
 
-
 ================
 Staff Assessment
 ================
@@ -404,37 +455,10 @@ For the :ref:`staff assessment step<Staff Assessment Step>`, there are no
 additional settings to specify after you have selected the step for inclusion
 in the assignment.
 
-
-.. _PA Show Top Responses:
-
-******************************
-Step 7. Show Top Responses
-******************************
-
-You can specify whether learners see a section that shows the :ref:`highest
-scoring responses<PA Top Responses>` that were submitted for each question in
-the assignment. If offered, this section displays only after each learner has
-completed all steps in the assignment. You specify the number of highest
-scoring responses to show.
-
-.. note:: Because each response can be up to 300 pixels in height, we
-   recommend that you set the number of top responses lower than 20, to
-   prevent the page from becoming too long.
-
-#. In the ORA component editor, select the **Settings** tab.
-
-#. In the **Top Responses** field, specify the number of responses that you
-   want to appear in the **Top Responses** section below the learner's final
-   score.
-
-   If you do not want this section to appear, set the number to 0. The
-   maximum number is 100.
-
-
 .. _PA Test Assignment:
 
 ******************************
-Step 8. Test the Assignment
+Step 7. Test the Assignment
 ******************************
 
 To test your ORA assignment, you can set up the assignment in your course, set

--- a/en_us/shared/subsections/open_response_assessments/Manage_ORA_Assignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/Manage_ORA_Assignment.rst
@@ -77,13 +77,13 @@ To access information about a specific learner, follow these steps.
 
 #. Enter the learner's username or email address, and then select **Submit**.
 
-   The **Manage Individual Learners** dialog updates with expandable sections
-   for each of the assessment steps in the assignment and other actions you
-   can take on the learner's response. Only the types of assessment steps
-   (self, peer, or staff) that are included in the assignment are shown.
+   The **Manage Individual Learners** dialog box updates with expandable
+   sections for each of the assessment steps in the assignment and other
+   actions you can take on the learner's response. Only the types of assessment
+   steps (self, peer, or staff) that are included in the assignment are shown.
 
-   If the learner uploaded a file along with her response, select **View
-   the file associated with this submission** to review or download it.
+   If the learner uploaded files along with her response, select **View
+   the files associated with this submission** to review or download the files.
 
 #. Select any of the section headings to expand that section.
 

--- a/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
+++ b/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
@@ -631,14 +631,14 @@ Peer Assessments
 Asking Learners to Upload Files in Responses
 *******************************************************
 
-In ORA assignments, you can ask your learners to upload an image, a .pdf file,
-or a file of another type as a part of their responses. Other learners
+In ORA assignments, you can ask your learners to upload images, .pdf files,
+or other types of files as a part of their responses. Other learners
 evaluate the responses and their accompanying files during the peer
-assessment. Offering the option to upload a file in addition to a text
+assessment. Offering the option to upload files in addition to a text
 response can give learners the opportunity to use tools and develop skills
 that are relevant to your course.
 
-Before you decide to ask learners to upload other files along with their text
+Before you decide to ask learners to upload files along with their text
 responses, however, be aware of the following limitations and best practices.
 
 * During the peer assessment step, learners download the files that other
@@ -651,15 +651,7 @@ responses, however, be aware of the following limitations and best practices.
   that are available from the instructor dashboard, and course data packages do
   not include any of the uploaded files.
 
-* You cannot require your learners to upload files. You can only give them the
-  option to do so.
-
-* All responses must include some response text. Learners cannot submit a
-  response that contains only an uploaded file.
-
-* Learners can submit only one file with each response.
-
-* Files must be smaller than 5MB in size.
+* The cumulative size of all uploaded files must be less than 10 MB.
 
 * Image files must be in .jpg, .gif, or .png format.
 
@@ -671,16 +663,16 @@ For more information, see :ref:`PA Allow Images`.
 Prohibited File Extensions
 ==========================
 
-This topic lists the file extensions for the set of file types that learners
-are prohibited from uploading as part of an open response assessment on edx.org
-or edX Edge. When you define a set of custom file types for learners to upload
-with their responses, you cannot specify these file types. The extensions on
-this list are selected and maintained by the development operations team at
-edX, and are subject to change.
+Learners cannot upload file types that have the following file name extensions
+as part of an open response assessment on edx.org or edX Edge. When you define
+a set of custom file types for learners to upload with their responses, you
+cannot specify these file types. The extensions on this list are selected and
+maintained by the development operations team at edX, and are subject to
+change.
 
 .. only:: Open_edX
 
-  This set of file extensions is provided as the default for Open edX
+  This set of file name extensions is provided as the default for Open edX
   installations. Open edX system administrators can update this list. For more
   information, see
   :ref:`installation:Configuring ORA2 to Prohibit Submission of File Types`.


### PR DESCRIPTION
## [DOC-3605](https://openedx.atlassian.net/browse/DOC-3605)

[OSPR-1646](https://openedx.atlassian.net/browse/OSPR-1646) adds the ability to upload multiple files in response to an ORA assignment. It may also increase the file size limit from 5 MB to 10 MB.

The PR for the engineering work is [PR 964](https://github.com/edx/edx-ora2/pull/964).

**Note**: Some of the UI text changes in this PR depend on these changes being made in [PR 964](https://github.com/edx/edx-ora2/pull/964). If these changes aren't made in the engineering PR, I'll change the UI text back. 

### Date Needed (optional)

10 April 2017 (approx.)

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @efischer19 
- [ ] Doc team review (copy edit): @edx/doc
- [ ] Product review: @sstack22 

### Sandbox

https://efischer19.sandbox.edx.org (DemoX edX Demonstration Course)

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

