### PR TITLE
DOC-3629 Change default setting for cohort inline topics

### DIFF
--- a/en_us/shared/course_features/cohorts/cohorts_manage_discussions.rst
+++ b/en_us/shared/course_features/cohorts/cohorts_manage_discussions.rst
@@ -7,6 +7,9 @@ Managing Discussions in Courses with Learner Cohorts
 This section provides information about managing discussions when cohorts are
 enabled in your course.
 
+For information about setting up discussions in courses with cohorts, see
+:ref:`Set up Discussions in Cohorted Courses`.
+
 .. contents::
   :local:
   :depth: 1

--- a/en_us/shared/course_features/cohorts/cohorts_setup_discussions.rst
+++ b/en_us/shared/course_features/cohorts/cohorts_setup_discussions.rst
@@ -17,7 +17,7 @@ Overview
 *********
 
 In courses that have cohorts enabled, discussion topics can be either divided
-by cohort, or unified and accessible to all learners.
+by cohort, or they can be unified and accessible to all learners.
 
 Discussion topics that are divided by cohort are visible to all learners but
 the posts, responses, and comments within them are divided so that they are
@@ -25,15 +25,14 @@ visible only to members of the same cohort. Posts, responses, and comments
 within unified discussion topics are visible to all learners in the course,
 regardless of cohort.
 
-When you first enable cohorts in your course, the initial behavior for
-:ref:`course-wide discussion topics<Coursewide Discussion Topics and Cohorts>`
-is different from the behavior of :ref:`content-specific discussion topics
-<Content Specific Discussion Topics and Cohorts>`.
+When you first enable cohorts in your course, both :ref:`course-wide
+discussion topics<Create CourseWide Discussion Topics>` and :ref:`content-specific discussion topics<Create ContentSpecific Discussion Topics>` are by
+default unified, so that all posts and responses are visible to all learners.
 
-By default, course-wide discussion topics are unified because these discussions
-are generally used for posts that are of broad interest to all learners in the
-course. In contrast, content-specific discussion topics are by default divided
-by cohort. You can change discussion topics of either type to be divided or
+.. note:: In courses that started prior to April 10, 2017, content-specific
+   discussion topics are by default divided by cohort.
+
+You can change discussion topics of either type to be divided or
 unified on the instructor dashboard in the LMS.
 
 .. warning:: If you change the cohort settings of discussion topics in a live
@@ -156,20 +155,21 @@ For more information about managing discussions that are divided by cohort, see
 Content-Specific Discussion Topics and Cohorts
 **********************************************
 
-When you enable the cohort feature for a course, and :ref:`create content-specific discussion topics<Create ContentSpecific Discussion Topics>` by adding
-discussion components to units in Studio, these content-specific discussion
-topics are by default divided by cohort. A learner who is assigned to one
-cohort cannot read or add to the posts, responses, or comments contributed by
-the members of another cohort.
+When you enable the cohort feature for a course, and :ref:`create content-specific
+discussion topics<Create ContentSpecific Discussion Topics>` by
+adding discussion components to units in Studio, these content-specific
+discussion topics are by default unified. All learners in the course can see
+and respond to posts from all other learners. You can change content-specific
+discussion topics to be divided by cohort, so that only members of the same
+cohort can see and respond to each other's posts.
 
-If you want all content-specific discussion topics in your course to be
-divided by cohort, you do not need to take any action. For more information,
-see :ref:`Specify that All ContentSpecific Discussion Topics are Cohorted`.
+If you want all content-specific discussion topics in your course to be always
+divided by cohort, follow the steps in the topic :ref:`Specify that All
+ContentSpecific Discussion Topics are Cohorted`.
 
-Alternatively, you can specify that you want most of the content-specific
-discussion topics in your course to be unified, and make :ref:`only a few
-discussion topics divided by cohort<Specify Some ContentSpecific Discussion
-Topics as Cohorted>`.
+If you want only some content-specific discussion topics to be divided by
+cohorts, following the steps in the topic :ref:`Specify Some ContentSpecific
+Discussion Topics as Cohorted`.
 
 .. _Specify that All ContentSpecific Discussion Topics are Cohorted:
 
@@ -177,34 +177,36 @@ Topics as Cohorted>`.
 Specify that All Content-Specific Discussion Topics are Cohorted
 *****************************************************************
 
-The default behavior for content-specific discussion topics is that they are
-divided by cohort when you first :ref:`add them<Create ContentSpecific
-Discussion Topics>` in your course. If you want all content-specific
-discussion topics in your course to be divided by cohort, you do not need to
-take any action.
+When you first :ref:`add content-specific topics<Create ContentSpecific
+Discussion Topics>` in your course, by default they are unified.
 
-You can confirm this setting on the Instructor Dashboard **Cohorts** tab.
+If you want all content-specific discussion topics in your course to be
+divided by cohort instead of unified, follow these steps.
 
 #. In the LMS, select **Instructor**, then select **Cohorts**.
 
 #. Select **Specify whether discussion topics are divided by cohort**.
 
-  .. image:: ../../../../shared/images/CohortDiscussionsSpecifyLink.png
-    :alt: The link in the UI to specify whether content specific discussion
+   .. image:: ../../../../shared/images/CohortDiscussionsSpecifyLink.png
+     :alt: The link in the UI to specify whether content specific discussion
         topics are divided by cohort.
-    :width: 800
+     :width: 800
 
-In the **Content-Specific Discussion Topics** section, you see that the
-**Always cohort content-specific discussion topics** option is selected.
+   In the **Content-Specific Discussion Topics** section, you see that the
+   **Cohort selected content-specific discussion topics** option is selected.
+   Content-specific topics that exist are listed, but none of them should
+   be selected, indicating that these topics are not divided by cohort.
 
-All content-specific discussion topics in your course are divided by cohort,
-and you cannot change the cohort settings of individual content-specific
+3. Select **Always cohort content-specific discussion topics**.
+
+   .. image:: ../../../../shared/images/CohortDiscussionsAlwaysCohort.png
+     :alt: Content specific discussion topics controls with the "Always cohort
+        content specific discussion topics" option selected.
+     :width: 500
+
+All content-specific discussion topics in the course are now divided by
+cohort, and you cannot change the cohort settings of individual content-specific
 discussion topics.
-
-.. image:: ../../../../shared/images/CohortDiscussionsAlwaysCohort.png
- :alt: Content specific discussion topics controls with the "Always cohort
-  content specific discussion topics" option selected.
- :width: 500
 
 For information about changing the cohort settings for your content-specific
 discussions to make all of them unified except a few, see :ref:`Specify Some
@@ -217,22 +219,20 @@ Specify that Some Content-Specific Discussion Topics are Divided by Cohort
 **************************************************************************
 
 The default behavior for content-specific discussion topics is that they are
-divided by cohort when you first :ref:`add them<Create ContentSpecific
-Discussion Topics>` in your course.
+unified when you first :ref:`add them<Create ContentSpecific Discussion
+Topics>` in your course.
 
-To make only a few of your content-specific discussion topics divided by
-cohort, you change the cohort settings for content-specific discussion topics
-to make them all unified, and then explicitly select only the topics that you
-want to be divided by cohort.
+To specify that only some of your content-specific discussion topics are
+divided by cohort, you explicitly select only the topics that you want to
+be divided by cohort.
 
-.. warning:: When you change the cohort setting from **Always Cohort Content-
-   Specific Discussion Topics** to **Cohort Selected Content-Specific
-   Discussion Topics**, you are making all content-specific discussion topics
-   in your course unified, unless you explicitly change them to be divided by
-   cohort before saving your changes. This means that any posts that were
-   previously divided by cohort and restricted to viewing, responding, and
-   commenting by members of the same cohort are now visible to all learners in
-   your course.
+.. warning:: If you change the cohort setting from **Always Cohort Content-Specific
+   Discussion Topics** to **Cohort Selected Content-Specific
+   Discussion Topics**, all content-specific discussion topics are unified,
+   unless you explicitly specify that they are divided by cohort before saving
+   your changes. This means that any posts that were previously divided by
+   cohort and restricted to viewing, responding, and commenting by members of
+   the same cohort are now visible to all learners in your course.
 
    If you make changes to cohort settings in a running course, be aware of the
    implications of your changes. For more details, see :ref:`Altering Cohort


### PR DESCRIPTION
## [DOC-3629](https://openedx.atlassian.net/browse/DOC-3629)

The default behavior for content-specific discussions is changing.
Previously, in courses with cohorts enabled, all content-specific discussion topics are divided by cohort when you add them. 
Now, only in NEW courses with cohorts enabled, all content-specific discussion topics are unified when you add them. 
In currently running courses the old default behavior remains.

### Date Needed - ASAP: TNL-6815 is already merged.

### HTML Version

- [x] http://draft-inlinedisc-unified-by-default.readthedocs.io/en/latest/course_features/cohorts/cohorts_setup_discussions.html#setting-up-discussions-in-courses-with-cohorts

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @cahrens 
- [x] Doc team review: @edx/doc  
- [x] Product review: @sstack22

FYI: @mmacfarlane, @dhixonedx, @jhendersonedx

### Testing

- [x] Ran ./run_tests.sh without warnings or errors


### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

