### PR TITLE
Release Notes for week ending April 7, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-04-07.rst
+++ b/en_us/release_notes/source/2017/2017-04-07.rst
@@ -1,8 +1,8 @@
 #################################
-Week Ending 31 March 2017
+Week Ending 7 April 2017
 #################################
 
-The following information summarizes what was released in the edX platform during the week ending 31 March 2017.
+The following information summarizes what was released in the edX platform during the week ending 7 April 2017.
 
 .. contents::
   :local:
@@ -15,24 +15,10 @@ account for the wiki and review the dated release pages.
 
 
 *************
-Analytics
-*************
-
-.. include:: analytics/analytics_2017-03-31.rst
-
-
-*************
 LMS
 *************
 
-.. include:: lms/lms_2017-03-31.rst
-
-
-*************
-Website
-*************
-
-.. include:: website/website_2017-03-31.rst
+.. include:: lms/lms_2017-04-07.rst
 
 
 .. include:: ../../../links/links.rst

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-04-07
    2017-03-31
    2017-03-24
    2017-03-17

--- a/en_us/release_notes/source/2017/lms/lms_2017-04-07.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-04-07.rst
@@ -1,0 +1,6 @@
+Drag and Drop problems did not properly reset a learner's state for grading if
+a tile was moved back to the bank before the learner clicked Submit. This
+issue has been resolved. (:jira:`TNL-6753`)
+
+Content-specific discussion topics were displaying empty topic areas in the
+navigation pane. This issue has been resolved.  (:jira:`TNL-6284`)

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 7 April 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-04-07.rst 
+
+*************************
 Week ending 31 March 2017
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending April 7, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending April 7, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=158894770)

### Date Needed (optional)

EOD Tuesday April 10, 2017
### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

FYI: @sstack22 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [ ] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-04-07.html

### Post-review

- [x]  Squash commits

