### PR TITLE
DOC: Make OpenBR structure same as edX BR

### DIFF
--- a/en_us/course_authors/source/getting_started/CA_get_started_Studio.rst
+++ b/en_us/course_authors/source/getting_started/CA_get_started_Studio.rst
@@ -1,3 +1,7 @@
+.. This is the "Getting Started with Studio" topic for the edX B&R Guide The
+.. Open edX B&R uses a same-named file in the
+.. open_edx_course_authors/source/getting_started dir
+
 .. _Getting Started with Studio:
 
 ###########################

--- a/en_us/open_edx_course_authors/source/getting_started/CA_get_started_Studio.rst
+++ b/en_us/open_edx_course_authors/source/getting_started/CA_get_started_Studio.rst
@@ -1,3 +1,7 @@
+.. This is the "Getting Started with Studio" topic for the Open edX B&R Guide
+.. The partner edX B&R guide uses a same-named file in
+.. course_authors/source/getting_started dir
+
 .. _Getting Started with Studio:
 
 ###########################
@@ -11,9 +15,6 @@ to view your courses.
   :local:
   :depth: 1
 
-If you are creating a course to run on `edx.org`_ or `edX Edge`_, see
-:ref:`partnercoursestaff:Getting Started with Studio` in *Building and
-Running an edX Course*.
 
 .. _What is Studio?:
 
@@ -21,7 +22,7 @@ Running an edX Course*.
 What Is Studio?
 ***************
 
-Studio is the edX tool you use to build your courses.
+Studio is the tool you use to build your courses.
 
 You use Studio to create a course structure, and then add problems, videos, and
 other resources for learners.
@@ -43,15 +44,14 @@ If you have not created a course, see :ref:`Creating a New Course`.
 
 #. In Studio, locate your course on your dashboard and open your course.
 
-#. On the **Course Outline** page, select **View
-   Live**.
+#. On the **Course Outline** page, select **View Live**.
 
    Your course enrollment page opens in a new browser tab.
 
 #. Select **Enroll** to enroll in your course. After you enroll in your course,
-   it opens in the edx.org LMS.
+   it opens in the LMS.
 
 #. To continue working on your course, return the browser tab that shows
    Studio.
 
-.. include:: ../../links/links.rst
+

--- a/en_us/open_edx_course_authors/source/getting_started/index.rst
+++ b/en_us/open_edx_course_authors/source/getting_started/index.rst
@@ -1,0 +1,11 @@
+.. _Getting Started Index:
+
+################
+Getting Started
+################
+
+.. toctree::
+   :maxdepth: 1
+
+
+   CA_get_started_Studio

--- a/en_us/open_edx_course_authors/source/index.rst
+++ b/en_us/open_edx_course_authors/source/index.rst
@@ -9,7 +9,7 @@ Building and Running an Open edX Course
    :maxdepth: 2
 
    front_matter/index
-   get_started
+   getting_started/index
    CA_dashboard_profile_SectionHead
    reaching_learners/index
    accessibility/index

--- a/en_us/shared/getting_started/Section_troubleshooting_signin.rst
+++ b/en_us/shared/getting_started/Section_troubleshooting_signin.rst
@@ -1,3 +1,6 @@
+.. This file is used in the SFD_account.rst file in the edX Learner's Guide
+.. (partner version only)
+
 .. _Troubleshooting signin:
 
 ***************************


### PR DESCRIPTION
Makes the structure and filename used in context-sensitive help the same in both the edX and Open edX B&R guides. Adds comments to a couple of other files to clarify use.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @grantgoodmanedX 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

