### PR TITLE
DOC-3633 Remove govt-issued as photo ID requirement

### DIFF
--- a/en_us/course_authors/source/course_features/credit_courses/CA_online_proctoring_rules_students.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/CA_online_proctoring_rules_students.rst
@@ -22,9 +22,8 @@ practice proctored exams, so that learners can experience an example proctored
 exam, including the software download and system check steps.
 
 As with other ID-verified assessments and exams, learners will be asked to
-establish their identity during the proctored exam process by supplying a
-government-issued photo ID with a full name that matches the name they used to
-register on edX.org.
+establish their identity during the proctored exam process by supplying a photo
+ID with a name that matches the full name they use in their edx.org account.
 
 .. note:: Learners who require additional time or any specific accommodations
    or exemptions to the exam policies in order to complete a proctored exam,

--- a/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
+++ b/en_us/course_authors/source/course_features/credit_courses/proctored_exams.rst
@@ -228,8 +228,8 @@ The following list represents only some of the requirements listed in the
 :ref:`online proctoring rules <CA Online Proctoring Rules>`.
 
 * System and environment checks that learners are asked to perform for the
-  proctoring session include taking a photo of a government-issued photo ID,
-  and a photo of themselves, using the webcam on their computer.
+  proctoring session include taking a photo of themselves and a photo of a photo
+  ID using the webcam on their computer.
 
   In addition, they must use the webcam to provide a scan of the room that
   they will take the current exam in. The scan includes the desk area, the

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -392,7 +392,7 @@ E
     * The type of certificate, if any, that learners receive if they pass the
       course.
     * Whether learners must verify their identity to earn a certificate, using
-      a webcam and a government-issued photo ID.
+      a webcam and a photo ID.
     * Whether the course requires a fee.
 
   The edX platform offers the following enrollment tracks.
@@ -404,8 +404,7 @@ E
   * **verified**: This enrollment track offers verified certificates to
     learners who pass the course, verify their identities, and pay a required
     course fee. A course that offers the verified enrollment track also
-    automatically offers a free enrollment track, either the audit track or
-    honor track.
+    automatically offers a free non-certificate enrollment track.
 
   * **honor**: This enrollment track offers an honor code certificate to
     learners who pass the course. This track does not require identity

--- a/en_us/shared/students/SFD_update_acct_settings.rst
+++ b/en_us/shared/students/SFD_update_acct_settings.rst
@@ -89,10 +89,11 @@ see only your username. They do not see your full name.
 
 .. only:: Partners
 
-  When you :ref:`verify your identity<SFD Verify Your Identity>`, the name on
-  your government-issued ID must match the full name for your account.
+  When you :ref:`verify your identity<SFD Verify Your Identity>`, the photo ID
+  that you use for verification must show a name that exactly matches the full
+  name used in your edX account.
 
-To change your full name, follow these steps.
+To change the full name used in your account, follow these steps.
 
 #. At the top of any page, select the dropdown menu icon next to your
    username.

--- a/en_us/students/source/SFD_certificates.rst
+++ b/en_us/students/source/SFD_certificates.rst
@@ -54,8 +54,8 @@ catalog`_.
 
 To earn a verified certificate from an edX course, you enroll in or upgrade to
 the verified track in the course, pay the certificate fee, :ref:`verify your
-identity<SFD Verify Your Identity>` with a webcam and a government-issued ID,
-and earn a passing grade.
+identity<SFD Verify Your Identity>` using a webcam and a photo ID, and earn a
+passing grade.
 
 Verified certificates include the following information.
 

--- a/en_us/students/source/SFD_enrolling.rst
+++ b/en_us/students/source/SFD_enrolling.rst
@@ -69,8 +69,7 @@ About the Verified Track
 Many courses offer a verified track in addition to the audit track. The
 verified track awards :ref:`verified certificates<SFD Verified Certificates>`
 to learners who submit payment, :ref:`verify their identities<SFD Verify Your
-Identity>` using a webcam and a government-issued photo ID, and pass the
-course.
+Identity>` using a webcam and a photo ID, and pass the course.
 
 If a course has a verified track, you see a "Verified" indication on the
 course image in the course catalog on edx.org.
@@ -205,8 +204,8 @@ Enroll in the Verified Track for a Course
 =============================================
 
 Verified track enrollment requires that you pay for the :ref:`verified
-certificate<SFD Verified Certificates>` and also :ref:`verify your
-identity<SFD Verify Your Identity>` with a webcam and a government-issued ID.
+certificate<SFD Verified Certificates>` and also :ref:`verify your identity<SFD
+Verify Your Identity>` using a webcam and a photo ID.
 
 To pursue a verified certificate in a course, follow these steps.
 

--- a/en_us/students/source/SFD_pursue_certs.rst
+++ b/en_us/students/source/SFD_pursue_certs.rst
@@ -62,7 +62,8 @@ Upgrade to the Verified Track
 ===============================
 
 Verified track enrollment requires that you pay for the certificate and verify
-your identity with a webcam and a government-issued ID.
+your identity using a webcam and a photo ID that has your photo and full name
+on the same side.
 
 To upgrade to the verified track, follow these steps.
 
@@ -158,14 +159,15 @@ Verifying Your Identity
 ******************************
 
 When you enroll in the :ref:`verified track<SFD Verified Track>` for a course,
-you must use a webcam to take a photograph of yourself and of a
-government-issued photo ID. You do not have to verify your identity
-immediately, but you must verify your identity before the course ID
-verification deadline. The deadline appears below the name of the course on
-your dashboard.
+you must use a webcam to take a photograph of yourself and of a photo ID that
+has your photo and full name on the same side.
 
-To verify your identity, you use a webcam to submit a photo of yourself and of
-a government-issued photo ID to edX's authorization service. EdX encrypts your
+You do not have to verify your identity immediately, but you must verify your
+identity before the course ID verification deadline. The deadline appears
+below the name of the course on your dashboard.
+
+To verify your identity, you use a webcam to take a photo of yourself and of a
+photo ID that has your photo and full name on the same side. EdX encrypts your
 photos and uses the highest levels of security available to protect your data.
 
 .. contents::
@@ -175,8 +177,8 @@ photos and uses the highest levels of security available to protect your data.
 When you verify your identity for an edX course, that verification is effective
 for one year.
 
-* If you enroll in the verified track for another course, you must verify your
-  identity for that course separately.
+* If you enroll in the verified track for another course, you pay for that
+  course's certificate, but you do not have to verify your identify again.
 
 * If you enroll in a course that offers academic credit, you might have to
   verify your identity periodically during the course. For more information,
@@ -187,9 +189,9 @@ Preparing to Verify Your Identity
 ===================================
 
 When you enroll in the verified track for a course, you must use a webcam to
-take a photograph of yourself and of a government-issued photo ID. Before you
-begin the identity verification process, follow these recommendations to make
-the process as straightforward as possible.
+take a photograph of yourself and of a photo ID that has your photo and name
+on the same side. Before you begin the identity verification process, follow
+these recommendations to make the process as straightforward as possible.
 
 * Make sure that you have access to a webcam.
 
@@ -206,20 +208,17 @@ the process as straightforward as possible.
   If you do not use a webcam to verify your identity, you cannot receive a
   verified certificate.
 
-* Compare the way that your name appears when you sign in to edx.org to the way
-  it appears on your ID card. Your name must be the same for both, including
-  the type of characters used (Roman or non-Roman), accented characters,
-  initials, and spelling.
+* Compare the name on your photo ID card to the full name you use in your edX
+  account. Both names must match, including the type of characters used (Roman
+  or non-Roman), accented characters, initials, and spelling.
 
-  You can update your edX account name at any time on the edX :ref:`account
-  settings page<SFD Update Account Settings>`. You also have the opportunity to
-  change your edX account name during the identity verification process.
-
-* Make sure that your identification card is government issued, such as a
-  driver's license or passport.
+  If necessary, you can update your edX account name at any time on the edX
+  :ref:`account settings page<SFD Update Account Settings>`. You also have the
+  opportunity to change your edX account name during the identity verification
+  process.
 
 * Make sure that your name is legible, and that your name and photo are visible
-  together on a single image.
+  together on the same side of the card.
 
   If your name and your photo are on two different pages, or on the front and
   back of a single page, you can copy both pages onto a single piece of paper.
@@ -237,7 +236,7 @@ Verify Your Identity
 
 To verify your identity, follow these steps.
 
-#. Make sure that you have a webcam and a government-issued photo ID available.
+#. Make sure that you have a webcam and a photo ID available.
 
 #. Start the verification process by completing one of the following actions.
 
@@ -272,9 +271,9 @@ To verify your identity, follow these steps.
    * When you are satisfied with the photo, select **Next: Take a photo of your
      ID**.
 
-#. On the **Take a Photo of Your ID** page, hold your government-issued photo
-   ID up to the webcam on your computer. Make sure that the image of your ID is
-   legible, and then select the camera icon to take a photo of your ID.
+#. On the **Take a Photo of Your ID** page, hold your photo ID up to the webcam
+   on your computer. Make sure that the image of your ID is legible, and then
+   select the camera icon to take a photo of your ID.
 
 #. Review the photo of your ID to make sure that it is well-lit and fills the
    available space.

--- a/en_us/students/source/completing_assignments/SFD_proctored_exams.rst
+++ b/en_us/students/source/completing_assignments/SFD_proctored_exams.rst
@@ -295,8 +295,9 @@ Take a Picture of Your Photo ID
 ================================
 
 To fulfill the identity check for online proctoring, you use your webcam to
-take a picture of a government-issued photo ID that clearly identifies you by
-your full name, and that can be used to confirm your identity.
+take a picture of a photo ID that has your photo and your name on the same
+side. The name shown on this ID must match the full name you use in your edX
+account.
 
 .. note:: If you do not complete this photo ID step, you cannot achieve a
    **Satisfactory** result for your proctoring review, and you cannot be

--- a/en_us/students/source/completing_assignments/online_proctoring_rules_students.rst
+++ b/en_us/students/source/completing_assignments/online_proctoring_rules_students.rst
@@ -43,9 +43,8 @@ practice proctored exams, so that learners can experience an example proctored
 exam, including the software download and system check steps.
 
 As with other ID-verified assessments and exams, learners will be asked to
-establish their identity during the proctored exam process by supplying a
-government-issued photo ID with a full name that matches the name they used to
-register on edX.org.
+establish their identity during the proctored exam process by supplying a photo
+ID with a name that matches the full name they use in their edx.org account.
 
 .. note:: If you require additional time or any specific accommodations or
    exemptions to the exam policies in order to complete a proctored exam,


### PR DESCRIPTION
## [DOC-3633](https://openedx.atlassian.net/browse/DOC-3633)
## [DOC-3463](https://openedx.atlassian.net/browse/DOC-3463)

Per check-in with Support, edit both learner and course team doc to remove mention of "government-issued" as a requirement for photo IDs used for verification.

Also addresses https://openedx.atlassian.net/browse/DOC-3463 - corrects information about requirement for verification for each verified course.

### Reviewers:
- [x] Doc team review: @edx/doc
FYI: @dhixonedx @mmacfarlane @marcotuts 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

