### PR TITLE
Social sharing of course enrollment

### DIFF
--- a/en_us/install_operations/source/configuration/enable_socialsharing_icons.rst
+++ b/en_us/install_operations/source/configuration/enable_socialsharing_icons.rst
@@ -140,8 +140,4 @@ This URL is provided to the social sharing site for linking back to a course
 location. This URL is used only if you have enabled custom URLs in your
 instance of Open edX.
 
-.. note:: If custom URLs are enabled but a course team does not provide a
-  value in the **Social Media Sharing URL** advanced setting in Studio,
-  social sharing icons are not visible in the LMS for that course.
-
 .. include:: ../../../links/links.rst

--- a/en_us/shared/students/SFD_dashboard_profile.rst
+++ b/en_us/shared/students/SFD_dashboard_profile.rst
@@ -61,6 +61,32 @@ Change Course Information`.
     appear on this page if you are enrolled in any course that is part of that
     program. For more information, see :ref:`Programs Page`.
 
+.. _Social Sharing:
+
+======================================
+Sharing Your Courses on Social Media
+======================================
+
+On your dashboard, you can share the courses you are enrolled in on social
+media sites such as Facebook and Twitter.
+
+.. only:: Open_edX
+
+ This feature is available only if it has been enabled by your course provider.
+
+#. Sign in to the social media site on which you want to share your course
+   enrollment.
+
+#. From your dashboard, find the course that you want to share.
+
+#. Select the icon for the social media site where you want to share.
+   A dialog box for the social media site you selected opens, with the course
+   URL entered and a default social media message.
+
+#. Optionally, modify the text of the social media message.
+
+#. Select the appropriate button to publish your message on the social media
+   site.
 
 .. only:: Partners
 


### PR DESCRIPTION
## [DOC-3627](https://openedx.atlassian.net/browse/DOC-3627)

I added a section to the Learner's Guide in the dashboard docs. I also removed the custom URL configuration note from the end of the ICR guide [social sharing config doc](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_socialsharing_icons.html)

### Date Needed 

This feature is set for release tomorrow, April 14.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
  
- [x] Subject matter expert: @muzaffaryousaf 
- [x] Doc team review (sanity check, copy edit): @catong 
- [x] Product review: @sstack22 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Sandbox (optional)

- [x]  [Sandbox for the software change](https://course-sharing-on-lms-dashboard.sandbox.edx.org/dashboard)

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

