### PR TITLE
DOC-3634 Roll back to Sphinx v1.4.9

### DIFF
--- a/shared/travis_requirements.txt
+++ b/shared/travis_requirements.txt
@@ -1,3 +1,3 @@
 # Used for documentation gathering
 edx-sphinx-theme==1.0.2
-sphinx==1.5.4
+sphinx==1.4.9


### PR DESCRIPTION
## [DOC-3634](https://openedx.atlassian.net/browse/DOC-3634)
Update our requirements file to roll back to Sphinx v1.4.9 to avoid bad search results in RTD projects until some fix.
(Known issue here: https://github.com/rtfd/readthedocs.org/issues/2708)

### Reviewers 

- [x] Doc team : @edx/doc
FYI: @jmbowman @feanil @nedbat 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

