### PR TITLE
Fix cross-reference link text in Starting a Course topic

### DIFF
--- a/en_us/shared/students/SFD_start_course.rst
+++ b/en_us/shared/students/SFD_start_course.rst
@@ -18,8 +18,9 @@ lessons or assignments.
 
 .. only:: Partners
 
-  For information about self-paced and instructor-paced courses, see :ref:`SFD
-  Course Pacing`.
+  For information about self-paced and instructor-paced courses, see
+  :ref:`Differences Between Instructor- and Self-Paced Courses<SFD Course
+  Pacing>`.
 
 
 .. only:: Open_edX


### PR DESCRIPTION
Add explicit link text to a cross reference

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review
- [x] Squash commits

