### PR TITLE
Release Notes for week ending April 14, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-04-14.rst
+++ b/en_us/release_notes/source/2017/2017-04-14.rst
@@ -1,0 +1,25 @@
+#################################
+Week Ending 14 April 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 14 April 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-04-14.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-04-14
    2017-04-07
    2017-03-31
    2017-03-24

--- a/en_us/release_notes/source/2017/lms/lms_2017-04-14.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-04-14.rst
@@ -1,0 +1,9 @@
+An issue causing learners to see sections in the wrong order on the Progress
+page has been fixed. (:jira:`TNL-6836`)
+
+For newly created courses that use cohorts, inline discussion components are
+no longer divided by cohort by default. By default, inline discussion
+components are unified so that all learners can participate in the discussion.
+You can still decide which inline discussion components are divided, and
+specify this on the Cohorts tab in the instructor dashboard.
+(:jira:`TNL-6815`)

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 14 April 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-04-14.rst 
+
+*************************
 Week ending 7 April 2017
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending April 14, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending April 14, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=159168386)

### Date Needed (optional)

EOD Tuesday April 18, 2017

### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [ ] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-04-14.html

### Post-review

- [x]  Squash commits

