### PR TITLE
Added note for setting the default topic for new posts in the Discussion page

### DIFF
--- a/en_us/shared/manage_discussions/discussions.rst
+++ b/en_us/shared/manage_discussions/discussions.rst
@@ -236,6 +236,22 @@ Discussion list now includes the topic you added.
    these topics to be divided by cohort. For more information, see :ref:
    `Specify Which Course Wide Discussion Topics are Divided`.
 
+.. note:: You can configure the default topic for new posts in the
+   **Discussion** page by setting its "default" attribute to true. For
+   example:
+
+   ::
+
+     {
+        "General": {
+            "id": "course"
+        },
+        "Questions about the Course": {
+            "id": "course_q",
+            "default": true
+        }
+     }
+
 .. _Create ContentSpecific Discussion Topics:
 
 ============================================


### PR DESCRIPTION
This PR adds a note explaining how to set the default topic for new posts in the Discussion page.

This is the [edx-platform PR](https://github.com/edx/edx-platform/pull/14862) for the feature.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

