### PR TITLE
Release Notes for Week ending April 21, 2017

### DIFF
--- a/en_us/release_notes/source/2017/2017-04-21.rst
+++ b/en_us/release_notes/source/2017/2017-04-21.rst
@@ -1,0 +1,25 @@
+#################################
+Week Ending 21 April 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 21 April 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-04-21.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,7 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-04-21
    2017-04-14
    2017-04-07
    2017-03-31

--- a/en_us/release_notes/source/2017/lms/lms_2017-04-21.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-04-21.rst
@@ -1,0 +1,5 @@
+When learners enroll in a course, they can now share links to the course's
+About Page on Facebook or Twitter. (:jira:`EDUCATOR-103`)
+
+The Advertised Start Date for courses was not reflected on learners'
+dashboards. This issue has been resolved. (:jira:`ECOM-7537`)

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -11,6 +11,12 @@ The following information summarizes what is new in the edX LMS.
   :depth: 2
 
 *************************
+Week ending 21 April 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-04-21.rst
+
+*************************
 Week ending 14 April 2017
 *************************
 


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the week ending April 21, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: [Release Notes: Week Ending April 21, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=159284662)

### Date Needed (optional)

EOD Wed April 26, 2017

### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @catong

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [ ] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-04-21.html

### Post-review

- [x]  Squash commits

