### PR TITLE
New paragraph about OS support

### DIFF
--- a/en_us/install_operations/source/installation/installation_options.rst
+++ b/en_us/install_operations/source/installation/installation_options.rst
@@ -8,9 +8,10 @@ This section describes Open edX installation options and the components that
 each option includes. More details about the various options are at the
 `Open edX Installation Options`_ page on the edX wiki.
 
-There are a three virtual machine options, which install the Open edX
+There are three virtual machine options, which install the Open edX
 software in a virtual Ubuntu machine.  If you prefer, you can install into an
 Ubuntu machine of your own using the Native installation.
+
 
 .. contents::
  :local:
@@ -34,6 +35,13 @@ devstack**).
 * Analytics devstack is a modified version of the devstack virtual machine that
   allows you to run Open edX Analytics. For more information, see
   :ref:`Info Analytics Devstack`.
+
+The Open edX Ficus release is supported only on the Ubuntu 16.04 operating
+system. You can use the virtual machine installation options to run Fullstack in
+a Vagrant virtual machine running on Linux, Mac OS, or Windows systems, or to
+run Devstack or Analytics Devstack on Linux or Mac OS. See the `Vagrant`_
+downloads page for information about the operating systems and architectures on
+which you can run Vagrant.
 
 .. _Info Devstack:
 


### PR DESCRIPTION
## [DOC-3648](https://openedx.atlassian.net/browse/DOC-3648)

In the Installation Options section, I made it more explicit that only Ubuntu is supported and pointed to Vagrant for OS options. Am I correct that you can use Windows versions of Vagrant to run fullstack and devstack?

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @nedbat 
- [x] Doc team review (copy edit): @edx/doc 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

