### PR TITLE
Move LMS instructor dashboard Help topic into B&R guides

### DIFF
--- a/en_us/course_authors/source/CA_instructor_dash_help.rst
+++ b/en_us/course_authors/source/CA_instructor_dash_help.rst
@@ -1,0 +1,32 @@
+:orphan:
+
+.. This is the edx version of this hidden dashboard topic
+
+.. _Instructor Dashboard Help:
+
+############################
+Instructor Dashboard
+############################
+
+You can manage various aspects of your course on the instructor dashboard in
+the LMS, including learner enrollment, course staffing, grade reports and
+adjustments, and bulk email messaging. The pages that are available in your
+instructor dashboard in a course depend on the features that are enabled in
+the course.
+
+The following topics cover some of the tasks you perform on the instructor
+dashboard.
+
+* :ref:`Reviewing Course Information<partnercoursestaff:Course Data>`
+* :ref:`Enrolling Learners<partnercoursestaff:Enrollment>`
+* :ref:`Managing Your Course Team<partnercoursestaff:Course_Staffing>`
+* :ref:`Managing Cohorts<partnercoursestaff:Cohorts Overview>`
+* :ref:`Generating Grade Reports<partnercoursestaff:Access_grades>`
+* :ref:`Sending Email to Learners<partnercoursestaff:Bulk Email>`
+* :ref:`Issuing Certificates<partnercoursestaff:Issuing Certificates>`
+* :ref:`Accessing Metrics for Open Response
+  Assessments<partnercoursestaff:Accessing ORA Assignment Information>`
+
+For more information, see the :ref:`Building and Running an edX
+Course<partnercoursestaff:document index>` guide.
+

--- a/en_us/open_edx_course_authors/source/CA_instructor_dash_help.rst
+++ b/en_us/open_edx_course_authors/source/CA_instructor_dash_help.rst
@@ -1,0 +1,32 @@
+:orphan:
+
+.. This is the Open edx version of this hidden dashboard topic
+
+.. _Instructor Dashboard Help:
+
+############################
+Instructor Dashboard
+############################
+
+You can manage various aspects of your course on the instructor dashboard in
+the LMS, including learner enrollment, course staffing, grade reports and
+adjustments, and bulk email messaging. The pages that are available in your
+instructor dashboard in a course depend on the features that are enabled in
+the course.
+
+The following topics cover some of the tasks you perform on the instructor
+dashboard.
+
+* :ref:`Reviewing Course Information<opencoursestaff:Course Data>`
+* :ref:`Enrolling Learners<opencoursestaff:Enrollment>`
+* :ref:`Managing Your Course Team<opencoursestaff:Course_Staffing>`
+* :ref:`Managing Cohorts<opencoursestaff:Cohorts Overview>`
+* :ref:`Generating Grade Reports<opencoursestaff:Access_grades>`
+* :ref:`Sending Email to Learners<opencoursestaff:Bulk Email>`
+* :ref:`Issuing Certificates<opencoursestaff:Issuing Certificates>`
+* :ref:`Accessing Metrics for Open Response
+  Assessments<opencoursestaff:Accessing ORA Assignment Information>`
+
+
+For more information, see the :ref:`Building and Running an Open edX
+Course<opencoursestaff:Building and Running an Open edX Course>` guide.


### PR DESCRIPTION
## [DOC-3411](https://openedx.atlassian.net/browse/DOC-3411)

This PR creates a landing page within the Building and Running guide for the Help link in the LMS instructor dashboard. 
(Linking to individual topics is not possible until instructor dashboard tabs have individual help context - for now, there's just one Help context regardless of which tab you are on, hence this landing page.)
This PR is the first of 2 steps to move the Help link - first we need to publish this new page, then we will update the Help config in edx-platform to point to this topic.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [x] Doc team review (sanity check): @edx/doc 

### Testing

- [x] Ran ./run_tests.sh - known error caused by new anchors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

