### PR TITLE
Made sentences about edx and edge for partners only

### DIFF
--- a/en_us/shared/manage_live_course/course_enrollment.rst
+++ b/en_us/shared/manage_live_course/course_enrollment.rst
@@ -5,10 +5,14 @@ Enrollment
 ##########################
 
 Learners can enroll themselves in a course during its defined enrollment
-period. For a course running on `edx.org`_, enrollment is publicly available to
-anyone who registers an edX account. For other courses, such as those on
-`edx Edge`_, enrollment is limited to learners who know the course URL
-and learners you explicitly enroll.
+period.
+
+.. only:: Partners
+
+  For a course running on `edx.org`_, enrollment is publicly available to
+  anyone who registers an edX account. For other courses, such as those on
+  `edx Edge`_, enrollment is limited to learners who know the course URL
+  and learners you explicitly enroll.
 
 The course creator and course team members with the Staff and Admin roles can
 enroll learners in a course. These course team members can also unenroll


### PR DESCRIPTION
## [DOC-2885](https://openedx.atlassian.net/browse/DOC-2885)

I searched for 'edge' in the Open edX B&R guide and Learner's guide. I found only one place where I wanted to make text conditional to partner only.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check, copy edit): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

