### PR TITLE
Release notes for 04-28 through 05-12

### DIFF
--- a/en_us/release_notes/source/2017/2017-04-28.rst
+++ b/en_us/release_notes/source/2017/2017-04-28.rst
@@ -1,0 +1,25 @@
+#################################
+Week Ending 28 April 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 28 April 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-04-28.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/2017-05-05.rst
+++ b/en_us/release_notes/source/2017/2017-05-05.rst
@@ -1,0 +1,25 @@
+#################################
+Week Ending 05 May 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 05 May 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+LMS
+*************
+
+.. include:: lms/lms_2017-05-05.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/2017-05-12.rst
+++ b/en_us/release_notes/source/2017/2017-05-12.rst
@@ -1,0 +1,25 @@
+#################################
+Week Ending 12 May 2017
+#################################
+
+The following information summarizes what was released in the edX platform during the week ending 12 May 2017.
+
+.. contents::
+  :local:
+  :depth: 2
+
+The edX engineering wiki `Release Pages`_ provide detailed information about
+every change made to the edx-platform GitHub repository. If you are interested
+in additional information about every change in a release, create a user
+account for the wiki and review the dated release pages.
+
+
+*************
+Analytics
+*************
+
+.. include:: analytics/analytics_2017-05-12.rst
+
+
+.. include:: ../../../links/links.rst
+

--- a/en_us/release_notes/source/2017/analytics/analytics_2017-05-12.rst
+++ b/en_us/release_notes/source/2017/analytics/analytics_2017-05-12.rst
@@ -1,0 +1,2 @@
+We have added program filters to Insights **Courses** page, so that Insights users
+can filter to see courses in a specific program.  (:jira:`EDUCATOR-184`)

--- a/en_us/release_notes/source/2017/index.rst
+++ b/en_us/release_notes/source/2017/index.rst
@@ -10,6 +10,9 @@ The following pages summarize what is new in 2017.
 .. toctree::
    :maxdepth: 1
 
+   2017-05-12
+   2017-05-05
+   2017-04-28
    2017-04-21
    2017-04-14
    2017-04-07

--- a/en_us/release_notes/source/2017/lms/lms_2017-04-28.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-04-28.rst
@@ -1,0 +1,23 @@
+The batch beta tester addition tool now correctly identifies when any students
+could not be added successfully. (:jira:`TNL-4412`)
+
+On the **Programs** tab of learners' dashboards, learners can now easily track
+their progress towards program completion. Learners can use the new progress
+ring to visualize their progress. They use the dashboard to track which
+courses are in progress, completed, or remaining. Finally, they can retrieve
+their course and program certificates from their program dashboard.
+(:jira:`ECOM-7385`)
+
+An issue was addressed where students requesting refunds for courses with
+closed enrollment were not receiving their refunds automatically. Their
+refunds will now be processed correctly if they are eligible for one.
+(:jira:`ECOM-7252`)
+
+In the LMS, the Course page now opens to a course outline that serves as the
+basis for a new course home experience. This course outline replaces the
+course outline sidebar on course content pages that listed sections and
+subsections and allows learners to focus on content consumption and
+progression through the course. For more information, see any of the following
+sources. For more information, see `Update: Course Navigation Changes
+<https://open.edx.org/announcements/update-course-navigation-changes>`_ or 
+`May 2017 Open edX Product Update <https://open.edx.org/announcements/may-2017-open-edx-product-update>`_ on the Open edX portal. (:jira:`LEARNER-23`)

--- a/en_us/release_notes/source/2017/lms/lms_2017-05-05.rst
+++ b/en_us/release_notes/source/2017/lms/lms_2017-05-05.rst
@@ -1,0 +1,2 @@
+We have updated the new course outline page to expose the course tools sidebar
+also rendered on the course home page today. (:jira:`LEARNER-368`)

--- a/en_us/release_notes/source/analytics_index.rst
+++ b/en_us/release_notes/source/analytics_index.rst
@@ -11,6 +11,12 @@ The following information describes what is new in edX analytics.
   :depth: 2
 
 *************************
+Week ending 12 May 2017
+*************************
+
+.. include:: 2017/analytics/analytics_2017-05-12.rst
+
+*************************
 Week ending 31 March 2017
 *************************
 

--- a/en_us/release_notes/source/lms_index.rst
+++ b/en_us/release_notes/source/lms_index.rst
@@ -10,6 +10,19 @@ The following information summarizes what is new in the edX LMS.
   :local:
   :depth: 2
 
+
+*************************
+Week ending 05 May 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-05-05.rst
+
+*************************
+Week ending 28 April 2017
+*************************
+
+.. include:: 2017/lms/lms_2017-04-28.rst
+
 *************************
 Week ending 21 April 2017
 *************************


### PR DESCRIPTION
The following pull request includes the read the docs changes necessary for the weeks ending April 28, May 5 and May 12, 2017 

### Release Notes Page

The confluence page for this week's release notes can be found here: 
[Release Notes: Week Ending April 28, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=159524742)
[Release Notes: Week Ending May 5, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=159988544)
[Release Notes: Week Ending May 12, 2017](https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=159988721)

### Date Needed (optional)

EOD Friday May 19, 2017
### Reviewers
Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @srpearce 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version 

- [x] http://draft-release-notes.readthedocs.io/en/latest/2017/2017-04-28.html

### Post-review

- [ ]  Squash commits

