### PR TITLE
Clean up for differentiated content, divided discussions feature

### DIFF
--- a/en_us/shared/course_features/cohorts/cohort_config.rst
+++ b/en_us/shared/course_features/cohorts/cohort_config.rst
@@ -46,17 +46,8 @@ configuration steps (as applicable).
 3. Optionally, identify the discussion topics that you want to be divided by
    cohort.
 
-  * Course-wide discussion topics are unified by default, but you can specify
-    that they are :ref:`divided by cohort<Specify Whether CourseWide Discussion
-    Topics are Cohorted>`.
-
-  * Content-specific discussion topics are divided by cohort by default. You do
-    not need to take any action if you want :ref:`all content-specific
-    discussions<Specify that All ContentSpecific Discussion Topics are
-    Cohorted>` to be divided by cohort. You only need to change settings if you
-    want to make :ref:`only a few discussion topics divided by cohort<Specify
-    Some ContentSpecific Discussion Topics as Cohorted>` and make the remaining
-    topics unified.
+   For information about divided discussions, see :ref:`About Divided
+   Discussions`.
 
 You complete these procedures on the **Cohorts** tab on the Instructor
 Dashboard.
@@ -175,7 +166,7 @@ add a cohort to your course, follow these steps.
    .. note::
     Learners can see the name of the cohort they are assigned to. The message
     "This post is visible only to {cohort name}" appears with each post in
-    discussion topics that are divided by cohort. See :ref:`Read the Cohort
+    discussion topics that are divided by cohort. See :ref:`Read the Group
     Indicator in Posts`.
 
 #. Specify whether learners are automatically or manually assigned to this

--- a/en_us/shared/manage_discussions/discussions.rst
+++ b/en_us/shared/manage_discussions/discussions.rst
@@ -44,7 +44,7 @@ For information about creating discussions in which learners in a group such as
 a cohort or in a particular enrollment track only interact with posts from other
 learners in the same group, see :ref:`About Divided Discussions`. For
 information about moderating course discussions that are divided, see
-:ref:`Moderating Discussions for Cohorts`.
+:ref:`Managing Divided Discussion Topics`.
 
 .. _Overview_discussions:
 
@@ -75,9 +75,8 @@ of the course history.
 
 All course team members and enrolled learners can add posts, responses, and
 comments, and they can also view posts, responses, and comments made by other
-course participants. For information about cohorts and how members of cohorts
-interact in course discussions, see :ref:`Coursewide Discussion Topics and
-Cohorts` and see :ref:`Content Specific Discussion Topics and Cohorts`.
+course participants. For information about divided discussions, see :ref:`About
+Divided Discussions` and :ref:`Managing Divided Discussion Topics`.
 
 Members of the course community, learners as well as the course team, can be
 given permission to moderate or administer course discussions through a set of
@@ -232,10 +231,10 @@ Discussion list now includes the topic you added.
   :alt: A new topic named Course Q&A in the list of discussion topics.
 
 .. note:: In courses that use cohorts, the course-wide discussion topics that
-   you add are unified. All posts can be read and responded to by every
-   learner, regardless of the cohort that they belong to. You can optionally
-   configure these topics to be divided by cohort. For more information, see
-   :ref:`Coursewide Discussion Topics and Cohorts`.
+   you add are unified. All posts can be read and responded to by every learner,
+   regardless of the cohort that they belong to. You can optionally configure
+   these topics to be divided by cohort. For more information, see :ref:
+   `Specify Which Course Wide Discussion Topics are Divided`.
 
 .. _Create ContentSpecific Discussion Topics:
 
@@ -258,13 +257,13 @@ content.
 For information about the visibility of content-specific discussion
 topics, see :ref:`Visibility of Discussion Topics`.
 
-.. note:: In courses with cohorts enabled, all content-specific discussion
-   topics are divided by cohort when you first add them. Posts by learners to
-   divided discussion topics can only be read and responded to by members of
-   the same cohort and course team members who have a discussion administration
-   role. You can change the configuration of content-specific discussion topics
-   to make them unified and available to all learners in the course. For more
-   information, see :ref:`Content Specific Discussion Topics and Cohorts`.
+
+.. note:: In courses with cohorts enabled, when you add discussion components to
+   units in Studio, these discussion topics are by default unified. All learners
+   in the course can see and respond to posts from all other learners. You can
+   change content-specific discussion topics to be divided, so that only members
+   of the same group can see and respond to each other's posts. For information,
+   see :ref:`Content Specific Discussion Topics and Groups`.
 
 
 .. _Assigning_discussion_roles:

--- a/en_us/shared/manage_discussions/manage_divided_discussions.rst
+++ b/en_us/shared/manage_discussions/manage_divided_discussions.rst
@@ -130,8 +130,7 @@ discussion topic, the topic names indicate who can see the posts, responses,
 and comments.
 
 For more information about adding and configuring course-wide discussion
-topics, see :ref:`Create CourseWide Discussion Topics` and :ref:`Specify
-Whether CourseWide Discussion Topics are Cohorted`.
+topics, see :ref:`Create CourseWide Discussion Topics` and :ref:`Specify Which Course Wide Discussion Topics are Divided`.
 
 
 .. _Choosing the Visibility of a Post:


### PR DESCRIPTION
## [DOC-3645](https://openedx.atlassian.net/browse/DOC-3645)
This PR fixes some missed instances of obsolete anchors.

### Reviewers
- [x] Doc team review (sanity check): @edx/doc

### Testing
- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review
- [x] Squash commits

