### PR TITLE
Updates to visibility setting descriptions

### DIFF
--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -327,16 +327,17 @@ By default, when learners submit answers to problems, they immediately receive
 the results of the problem: whether they answered the problem correctly, as
 well as their scores. However, you might want to temporarily hide problem
 results from learners when you run an exam, or permanently hide results when
-you administer a survey. You can do this by using the **Results Visibility**
-setting.
+you administer a survey. You can do this by using the **Assessment Results
+Visibility** setting.
 
 .. note::
- The **Results Visibility** setting is a subsection setting. You cannot change
- the visibility of individual problems. The **Results Visibility**
- subsection setting overrides the **Show Answer** setting for individual
- problems. Answers to problems are not visible when results are hidden.
+ The **Assessment Results Visibility** setting is a subsection setting. You
+ cannot change the visibility of individual problems. The **Assessment Results
+ Visibility** subsection setting overrides the **Show Answer** setting for
+ individual problems. Answers to problems are not visible when results are hidden.
 
-The **Results Visibility** setting affects the following common problem types.
+The **Assessment Results Visibility** setting can be used with the following
+common problem types.
 
 * :ref:`Checkbox`
 * :ref:`Dropdown`
@@ -344,8 +345,8 @@ The **Results Visibility** setting affects the following common problem types.
 * :ref:`Numerical Input`
 * :ref:`Text Input`
 
-The **Results Visibility** setting affects the following advanced problem
-types.
+The **Assessment Results Visibility** setting can be used with the following
+advanced problem types.
 
 * :ref:`Annotation`
 * :ref:`Circuit Schematic Builder`
@@ -363,20 +364,21 @@ To change the results visibility for your subsection, follow these steps.
 
    The **Settings** dialog box opens.
 
-#. Select the **Visibility** tab, and locate **Results Visibility**.
+#. Select the **Visibility** tab, and locate **Assessment Results Visibility**.
 
 #. Select one of the available options.
 
-   * **Always show results**: This is the default setting. Results are visible
-     immediately when learners and staff submit answers.
-   * **Never show results**: Results are never visible to learners or to course
-     staff.
+   * **Always show results**: This is the default setting. Problem results and
+     subsection scores are visible immediately when learners and staff submit
+     answers.
+   * **Never show results**: Subsection scores are visible, but problem results
+     are never visible to learners or to course staff.
    * **Show results when subsection is past due**: For learners, results are
      not visible until the subsection due date (for instructor-paced courses)
      or the course end date (for self-paced courses) has passed. For course
      staff, results are always visible unless the staff member is
      :ref:`previewing or viewing the course as a learner<Roles for
-     Viewing Course Content>` .
+     Viewing Course Content>`.
 
      .. note::
       If the subsection does not have a due date, or the course does not have

--- a/en_us/shared/students/SFD_check_progress.rst
+++ b/en_us/shared/students/SFD_check_progress.rst
@@ -55,15 +55,11 @@ current average of scores for assignments of that type. This average is
 recalculated as you progress through the course and complete more assignments.
 
 .. note::
-   In some courses, results for some assignments are hidden. For
-   example, the results of an exam might be hidden until after the exam's due
-   date. When the results are hidden, you do not see whether you answered
-   problems correctly, and you do not see your score in the body of the course.
-
-.. SP, 4/24/17 - Currently, problem results are visible on the Progress page
-.. even if they're hidden in the body of the course. When this changes, add the
-.. following as the last sentence in the above paragraph: These results are
-.. also not visible on your **Progress** page.
+   In some courses, the course staff may have chosen to hide results for some
+   assignments. For example, the results of an exam might be hidden until after
+   the exam's due date. When the results are hidden, you do not see whether you
+   answered problems correctly, and you do not see your score in the body of
+   the course or on your **Progress** page.
 
 Some courses allow some number of graded assignments to be automatically
 dropped from your final score. For example, out of 8 quizzes, a course might


### PR DESCRIPTION
## [DOC-3663](https://openedx.atlassian.net/browse/DOC-3663)

I updated the course authors guide and the Learner's Guide with information about the changes to assessment visibility. This PR replaces https://github.com/edx/edx-documentation/pull/1509 which I munged beyond my patience in repairing. I've adopted the 👍 s of @catong and @sanfordstudent from the previous PR, since the text is the same.

### Date Needed

This was released on June 5, so it would be good to update the docs very soon.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @sanfordstudent 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @catong 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

