### PR TITLE
Fix broken links in release notes

### DIFF
--- a/en_us/release_notes/source/2015/documentation/doc_1007_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_1007_2015.rst
@@ -17,7 +17,7 @@ Building and Running an edX Course
 * Added the :ref:`partnercoursestaff:Using edX as an LTI Tool Provider`
   section.
 
-* Added the :ref:`partnercoursestaff:Setting Up Course Certificates` topic.
+* Added the :ref:`partnercoursestaff:Setting Up Certificates` topic.
 
 * Added information about awarding partial credit for certain types of
   problems, listed in the :ref:`partnercoursestaff:Awarding Partial Credit for

--- a/en_us/release_notes/source/2015/studio/studio_1021_2015.rst
+++ b/en_us/release_notes/source/2015/studio/studio_1021_2015.rst
@@ -8,14 +8,14 @@
   * EdX Partners: :ref:`partnercoursestaff:Oppia Exploration Tool`.
 
   * Open edX Users: :ref:`opencoursestaff:Oppia Exploration Tool`.
-    
+
   On Open edX instances, you must install the `Oppia XBlock`_ before you can
   use Oppia explorations in courses.
 
 * This release includes several updates to web certificates.
-  
+
   * Course teams can now override the course number as well as the course name
-    on the certificate. (SOL-1247) 
+    on the certificate. (SOL-1247)
 
   * Both the course number and the override course number are displayed in the
     certificate set up page in Studio. (SOL-1247)
@@ -25,15 +25,15 @@
 
     For information on web certificates, see the following documentation.
 
-    * EdX Partners: :ref:`partnercoursestaff:Setting Up Course Certificates`.
+    * EdX Partners: :ref:`partnercoursestaff:Create a Certificate`.
 
-    * Open edX Users: :ref:`opencoursestaff:Setting Up Course Certificates`.
+    * Open edX Users: :ref:`opencoursestaff:Create a Certificate`.
 
 * LTI components consume remote learning tools and present them in a course.
   With this release, LTI components use full screen mode to present remote
   content that is configured for full screen viewing.
 
-  .. note:: To ensure that content shown by the LTI component is accessible,  
+  .. note:: To ensure that content shown by the LTI component is accessible,
    verify that the remote system providing the content has implemented full
    screen mode with accessible controls that allow learners to enter and exit
    full screen mode.

--- a/en_us/release_notes/source/2016/documentation/doc_0502_2016.rst
+++ b/en_us/release_notes/source/2016/documentation/doc_0502_2016.rst
@@ -2,5 +2,5 @@
   information about several new events that have been added as a result of
   accessibility enhancements from December 2015 and January 2016.
 
-* The :ref:`Setting Details About Your Course` topic now includes an
-  :ref:`partnercoursestaff:XSeries About Video` section.
+* The :ref:`Setting up Your Course Index` topic now includes an
+  :ref:`partnercoursestaff:Pub Add an About Video` section.

--- a/en_us/release_notes/source/2016/studio/studio_0202_2016.rst
+++ b/en_us/release_notes/source/2016/studio/studio_0202_2016.rst
@@ -1,6 +1,6 @@
 
 For courses running on edx.org, a new procedure for uploading course About
 videos is now ready for use. The edX media team has developed a process that
-automates hosting and encoding for your About videos. For more information,
-see :ref:`partnercoursestaff:Add a Course Video` in the *Building and Running
+automates hosting and encoding for your About videos. For more information, see
+:ref:`partnercoursestaff:Pub Add an About Video` in the *Building and Running
 an edX Course* guide.

--- a/en_us/release_notes/source/2016/studio/studio_2016-12-12.rst
+++ b/en_us/release_notes/source/2016/studio/studio_2016-12-12.rst
@@ -2,7 +2,7 @@ Course team members with either the Admin or Staff role can now activate or
 disable course certificates in Studio. Previously, activating or disabling
 certificates could only be done by edX partner managers. (:jira:`TNL-6086`) For
 information about setting up course certificates, see
-:ref:`partnercoursestaff:Setting Up Course Certificates`.
+:ref:`partnercoursestaff:Setting Up Certificates`.
 
 In Custom JavaScript Display and Grading problems (also called Custom
 JavaScript  or JavaScript Input problems), you can now specify a ``title``


### PR DESCRIPTION
## [DOC-3694](https://openedx.atlassian.net/browse/DOC-3694)

This PR fixes five links that were broken in the release notes when the Publisher docs were released.

### Date Needed (optional)

16 June 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (sanity check): @edx/doc

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

