### PR TITLE
Add information about IAM user roles

### DIFF
--- a/en_us/install_operations/source/insights/elastic_mapreduce.rst
+++ b/en_us/install_operations/source/insights/elastic_mapreduce.rst
@@ -58,7 +58,12 @@ Identity and Access Management
 For Amazon Identity and Access Management (IAM), create an IAM role for use
 by the EMR cluster. Assign all of the Elastic Compute Cloud (EC2) nodes in
 the cluster to this role. An option is to consider copying the contents of the
-`default EC2 role for Amazon EMR`_ used by AWS.
+`default IAM roles for Amazon EMR`_ used by AWS. The command
+``aws emr create-default-roles`` facilitates this task. For more information,
+see `default IAM roles for Amazon EMR`_.
+
+Also, you need to create a role named ``emr`` with the policy
+``AmazonElasticMapReduceforEC2Role`` for the EC2 instance profile.
 
 Make sure that an IAM user with administrative privileges is available for use.
 
@@ -235,7 +240,7 @@ Then, save this file to a temporary location such as ``/tmp/cluster.yml``.
                 # You might want to set this to CANCEL_AND_WAIT while debugging step failures.
                 action_on_failure: TERMINATE_JOB_FLOW
               }
-            ],            
+            ],
             configurations: [
               {
                 classification: mapred-site,

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -277,6 +277,8 @@
 
 .. _default EC2 role for Amazon EMR: http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles-defaultroles.html#emr-iam-roles-defaultec2
 
+.. _Default IAM Roles for Amazon EMR: http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-roles-defaultroles.html#emr-iam-roles-defaultec2
+
 .. _a single public subnet: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario1.html
 
 .. _example configuration scenario: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario2.html


### PR DESCRIPTION
## [DOC-3679](https://openedx.atlassian.net/browse/DOC-3679)

This builds on @aqt01 's PR 1496, add description about the user `emr` needed for the ec2 instance profile and more detail about the Amazon EMR default roles

I had some additional formatting and cross-reference changes to make to PR 1496, so I cherry-picked a commit and made the changes I needed on my branch.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @tobz 
- [ ] Subject matter expert: @aqt01
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

