### PR TITLE
Remove outdated note about more info in table

### DIFF
--- a/en_us/developers/source/extending_platform/extending.rst
+++ b/en_us/developers/source/extending_platform/extending.rst
@@ -8,7 +8,7 @@ Options for Extending the edX Platform
 There are several options for extending the Open edX Platform to provide useful
 and innovative educational content in your courses.
 
-This section of the developers' documentation lists and explains the different ways to extend the platform, starting with the following table. Click the name of the extension type in the column header for more information.
+This section of the developers' documentation lists and explains the different ways to extend the platform, starting with the following table.
 
 .. |br| raw:: html
 
@@ -18,7 +18,7 @@ This section of the developers' documentation lists and explains the different w
    :widths: 10 10 10 10 10 10
    :header-rows: 1
 
-   * - 
+   * -
      - Custom |br|
        JavaScript |br|
        Applications*


### PR DESCRIPTION
## [DOC-3521](https://openedx.atlassian.net/browse/DOC-3521)

I removed the outdated sentence "Click the name of the extension type in the column header for more information." The column headers aren't links, and I don't think they ought to be.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

