### PR TITLE
DOC-3699, DOC-3622 Allow course teams to preassign learners to cohorts

### DIFF
--- a/en_us/shared/course_features/cohorts/cohort_config.rst
+++ b/en_us/shared/course_features/cohorts/cohort_config.rst
@@ -31,7 +31,7 @@ configuration steps (as applicable).
 
 #. :ref:`Enable cohorts<Enable Cohorts>`.
 
-#. Determine the method you want to use to assign students to cohorts.
+#. Determine the method you want to use to assign learners to cohorts.
 
   * :ref:`Implement an automated assignment strategy<Implementing the Automated
     Assignment Strategy>`
@@ -49,8 +49,14 @@ configuration steps (as applicable).
    For information about divided discussions, see :ref:`About Divided
    Discussions`.
 
-You complete these procedures on the **Cohorts** tab on the Instructor
-Dashboard.
+You complete these procedures on the **Cohorts** and **Discussions** tabs on
+the Instructor Dashboard.
+
+.. note:: On the **Cohorts** tab, the number of learners shown next to each
+   cohort name in the **Select a cohort** list includes only learners who are
+   enrolled in the course. The number does not include preassigned learners
+   who either do not yet have an edX account or are not enrolled in your
+   course.
 
 For an optimal learner experience, you should make sure that configuration of
 the cohort feature is as complete as possible before the start date of your
@@ -67,17 +73,17 @@ Implementing an Automated Assignment Strategy
 To implement an automated assignment strategy of learners to cohorts, you
 :ref:`enable the cohort feature<Enable Cohorts>` for your course, and
 :ref:`create cohorts<Add Cohorts>` that have the **Automatic**
-:ref:`assignment method<Changing the Assignment Method of a Cohort>`. To
-add learners to these cohorts, you do not need to take any action: the
-system automatically and randomly assigns learners to the available automatic
-cohorts when they first access any course content or discussion on the
-**Course** or **Discussion** pages. Learners who access the **Home** page or
-other course pages such as a **Textbook** page do not receive a cohort
-assignment until they view course content or discussions.
+:ref:`assignment method<Changing the Assignment Method of a Cohort>`. To add
+learners to these cohorts, you do not need to take any action: the system
+automatically and randomly assigns learners to the available automatic cohorts
+when they first access any course content or divided discussions. Learners who
+access the **Home** page or other course pages such as a **Textbook** page do
+not receive a cohort assignment until they view course content or divided
+discussions.
 
-.. note:: You can :ref:`add learners manually<Assign Learners to Cohorts
-   Manually>` to any cohort, whether it was created as an automated cohort or a
-   manual cohort.
+.. note:: You can :ref:`add learners manually<Assign Learners to Cohorts Manually>`
+    to any cohort, whether it was created as an automated cohort or a
+    manual cohort.
 
 For a scenario using an automated assignment strategy, see :ref:`All Automated
 Assignment`. For a scenario using a combination of automated and manual
@@ -112,14 +118,18 @@ To implement a manual assignment strategy of learners to cohorts, you
 method<Changing the Assignment Method of a Cohort>`. Then, you manually assign
 enrolled learners to the appropriate cohorts.
 
-.. note:: You can only add learners to a cohort manually if they have enrolled
-   in your course.
+.. note:: It is not a requirement that learners have enrolled in your course
+   or registered on edx.org for you to add them to a cohort. For learners who
+   have not yet created an edx.org account, you must provide a valid email
+   address. For learners who have an edx.org account but have not yet enrolled
+   in your course, you can provide either a valid email address or a
+   recognized edx.org username.
 
-Manual assignments should be as complete as possible before your course
-starts. If learners enroll after your course starts, you should continue to
-assign new learners to cohorts. If you need to make changes to the way you
-have configured cohorts while your course is running, see :ref:`Altering
-Cohort Configuration`.
+Manual assignments should be as complete as possible before your course starts.
+If learners enroll after your course starts, you should assign new learners to
+cohorts as soon as possible. If you need to make changes to the way you have
+configured cohorts while your course is running, see :ref:`Altering Cohort
+Configuration`.
 
 For a scenario using a manual assignment strategy, see :ref:`All Manual
 Assignment`. For a scenario using a combination of automated and manual
@@ -182,11 +192,11 @@ add a cohort to your course, follow these steps.
 Continue implementing your cohort strategy by creating additional cohorts as
 applicable, and specifying the assignment method for each cohort.
 
-.. note:: When your course starts, you must have at least one cohort in your
-   course that has automatic assignment. If you have not created at least one
-   automated assignment cohort in the course by the time that the first learner
-   accesses your course content, edX creates a default cohort to which learners
-   are automatically assigned.
+.. note:: By the time your course starts, you must have at least one cohort in
+   your course that is automatically assigned. If you have not created at
+   least one automated assignment cohort in the course by the time that the
+   first learner accesses your course content or a divided discussion topic,
+   edX creates a default cohort to which learners are automatically assigned.
 
 For details about adding learners to a cohort by uploading a .csv file, see
 :ref:`Assign Learners to Cohort Groups by uploading CSV`.
@@ -208,13 +218,15 @@ Assign Learners to Cohorts Manually
 
 If you have implemented a manual assignment strategy for cohorts in your
 course, make sure your manual assignments are as complete as possible before
-your course starts. Making changes to cohort assignments after the course
-starts affects the course experience for learners.
+your course starts. If learners enroll after your course starts, you should
+assign new learners to cohorts as soon as possible.
+
+.. note:: Making changes to cohort assignments after the course starts can
+   affect the course experience for learners. Learners might no longer have
+   access to course and discussion topics that were previously visible to
+   them. For more information, see :ref:`Altering Cohort Configuration`.
 
 To manually assign learners to cohorts in your course, follow these steps.
-
-.. note:: You can only add learners to a cohort manually if they have enrolled
-   in your course.
 
 #. View the live version of your course. For example, in Studio click **View
    Live**.
@@ -224,29 +236,45 @@ To manually assign learners to cohorts in your course, follow these steps.
 #. Scroll to the **Cohort Management** section at the bottom.
 
 #. From the **Select a cohort** list, select the cohort to which you want to
-   manually assign students.
+   manually assign learners.
 
-#. On the **Manage Students** tab, under **Add students to this cohort** enter
-   the username or email address of a single student, or enter multiple
+#. On the **Manage Learners** tab, under **Add learners to this cohort** enter
+   the username or email address of a single learner, or enter multiple
    usernames or addresses separated by commas or new lines. You can copy data
    from a .csv file of email addresses or usernames, and paste it into this
    field.
 
-#. Select **Add Students**. The learners you added are assigned to the selected
-   manual cohort. A message appears to indicate the number of learners who were
-   added to the cohort. Because learners can belong to only one cohort, adding a
-   learner to a cohort removes them from any cohort they were previously assigned
-   to. Therefore, the message also indicates the number of learners whose
-   assignment to another cohort was changed as a result of your adding them to
-   another cohort using this procedure.
+   .. note:: It is not a requirement that learners have enrolled in your
+      course or registered on edx.org for you to manually add them to a
+      cohort. For learners who have not yet created an edx.org account, you
+      must provide a valid email address. For learners who have an edx.org
+      account but have not yet enrolled in your course, you can provide either
+      a valid email address or a recognized edx.org username.
 
- .. note:: The number of learners reported on the **Cohorts** tab and in
-    downloaded reports includes only those learners who are enrolled in the
-    course.
+#. Select **Add Learners**.
 
-For a report that includes the cohort assignment for every enrolled learner,
-review the learner profile information for your course. See :ref:`View and
-download student data`.
+   Learners you added who have edX accounts are assigned to the selected
+   cohorts. A confirmation message indicates the number of learners who were
+   successfully added to the cohort.
+
+   Learners you added who do not yet have edX accounts are listed as
+   "Preassigned" to the cohort. When preassigned learners enroll in the
+   course, they are automatically added to the cohort.
+
+   If some learners that you listed could not be added to cohorts, an error
+   message lists the email addresses or usernames of learners who could not be
+   added to the cohort.
+
+.. note:: Because learners can belong to only one cohort, adding a learner to a
+   cohort moves them from any cohort they were previously assigned to. The
+   confirmation message indicates the number of learners who were moved from
+   their previous cohort assignment as a result of your adding them to the
+   current cohort.
+
+For a report that includes cohort assignments for your course, review the
+learner profile information for your course. See :ref:`View and download
+student data`.
+
 
 .. _Assign Learners to Cohort Groups by uploading CSV:
 
@@ -259,27 +287,33 @@ want to assign them to is another way of assigning learners to cohorts
 manually. For details about the other manual assignment method, see
 :ref:`Assign Learners to Cohorts Manually`.
 
-.. note:: You can only add learners to a cohort using a .csv file if they have
-   enrolled in your course.
 
-Any assignments to cohorts that you specify in the .csv files you upload
-will overwrite or change existing cohort assignments. The configuration of
-your cohorts should be complete and stable before your course begins. You
-should also complete manual cohort assignments as soon as possible after any
-learner enrolls, including any enrollments that occur while your course is
-running. To understand the effects of changing cohort assignments after your
-course has started, see :ref:`Altering Cohort Configuration`.
 
-.. note:: Be aware that the contents of the .csv file are processed row by row,
-  from top to bottom, and each row is treated independently.
+Any assignments to cohorts that you specify in the .csv files you upload will
+overwrite or change existing cohort assignments. The configuration of your
+cohorts should be complete and stable before your course begins. You should
+complete manual cohort assignments as soon as possible after any learner
+enrolls, especially for enrollments that occur after your course has started.
+To understand the effects of changing cohort assignments after your course has
+started, see :ref:`Altering Cohort Configuration`.
 
-  For example, if your .csv file contains conflicting information such as
-  Student A being first assigned to Cohort 1, then later in the spreadsheet
-  being assigned to Cohort 2, the end result of your .csv upload is that
-  Student A is assigned to Cohort 2. However, the upload results file will
-  count Student A twice in the "Students Added" count: once when they are added
-  to Cohort 1, and again when they are added to Cohort 2. Before submitting a
-  file for upload, check it carefully for errors.
+.. note:: Be aware that the contents of the .csv file are processed row by
+   row, from top to bottom, and each row is treated independently. If the same
+   learner is assigned to different cohorts in different rows in the
+   spreadsheet, the last assignment to be performed is that learner's final
+   assignment.
+
+    For example, if in your .csv file Learner A is first assigned to Cohort 1,
+    then later in the spreadsheet is assigned to Cohort 2, the end result of
+    your .csv upload is that Learner A is assigned to Cohort 2. However, the
+    upload results file will include Learner A twice in the "Learners Added"
+    count: once when they are added to Cohort 1, and again when they are added
+    to Cohort 2. Before submitting a file for upload, check it carefully for
+    duplicated learners and other errors.
+
+    If the same learner is assigned to a cohort that they already belong to,
+    they are not included in the count of "Learners Added".
+
 
 The requirements for the .csv file are summarized in this table.
 
@@ -295,10 +329,11 @@ The requirements for the .csv file are summarized in this table.
         * The file extension is .csv.
         * Every row must have the same number of commas, whether or not there
           are values in each cell.
+
     * - File size
       - The file size of .csv files for upload is limited to a maximum of 2MB.
-    * - UTF-8 encoded
 
+    * - UTF-8 encoded
       - You must save the file with UTF-8 encoding so that Unicode characters
         display correctly.
 
@@ -306,21 +341,22 @@ The requirements for the .csv file are summarized in this table.
 
     * - Header row
       - You must include a header row, with column names that exactly match
-         those specified in "Columns" below.
-    * - One or two columns identifying students
-      - You must include at least one column identifying students:
+        those specified in "Columns" below.
+
+    * - One or two columns identifying learners
+      - You must include at least one column identifying learners:
         either "email" or "username", or both.
 
-        If both the username and an email address are provided for a student,
-        the email address has precedence.
+        To preassign learners who do not yet have edX accounts, you must
+        provide their email addresses in an "email" column.
 
-        In other words, if an email address is present, an incorrect or non-
-        matching username is ignored.
+        If both the username and an email address are provided for a learner,
+        the email address has precedence. In other words, if an email address
+        is present, an incorrect or unrecognized username is ignored.
 
     * - One column identifying the cohort
-
       - You must include one column named "cohort" to identify the cohort
-        to which you are assigning each student.
+        to which you are assigning each learner.
 
         The specified cohorts must already exist in Studio.
 
@@ -329,8 +365,13 @@ The requirements for the .csv file are summarized in this table.
         ignored.
 
 
-To manually add enrolled learners to cohorts by uploading a .csv file, follow
-these steps.
+To manually add learners to cohorts by uploading a .csv file, follow these
+steps.
+
+.. note:: To add learners who do not yet have edX accounts to cohorts using a
+   .csv file upload, you must provide their email addresses in a column with
+   the heading "email". Learners without edX accounts are "preassigned" to
+   cohorts; they are not included in the count of learners "added" to cohorts.
 
 #. View the live version of your course. For example, in Studio, select **View
    Live**.
@@ -360,24 +401,42 @@ The results file provides the following information:
 
     * - **Column**
       - **Description**
+
     * - Cohort
       - The name of the cohort to which you are assigning learners.
+
     * - Exists
       - Whether the cohort was found in the system. TRUE/FALSE.
 
-        If the cohort was not found (value is FALSE), no action is taken for students you assigned to that cohort in the .csv file.
+        If the cohort was not found (value is FALSE), no action is taken for
+        learners who you assigned to that cohort in the .csv file.
 
-    * - Students Added
+    * - Learners Added
       - The number of learners added to the cohort during the row by row
-        processing of the .csv file.
-    * - Students Not Found
-      - A list of email addresses or usernames (if email addresses were not
-        supplied) of learners who could not be matched by either email address
-        or username and who were therefore not added to the cohort.
+        processing of the .csv file. This number does not include learners who
+        are not enrolled in the course.
+
+    * - Learners Not Found
+      - A list of the usernames of learners that could not be matched and who
+        were therefore not added to the cohort.
+
+    * - Invalid Email Addresses
+      - A list of email addresses that were not valid. These learners could
+        not be added to the cohort.
+
+    * - Preassigned Learners
+      - The email addresses of learners who do not yet have an edX account but
+        who you have preassigned to a cohort using their email addresses.
+        These learners are not included in the count of "Learners Added". When
+        these preassigned learners create an edX account and enroll in your
+        course, they are automatically added to the cohorts that you
+        preassigned them to.
+
 
 For a report that includes the cohort assignment for every enrolled learner,
 review the learner profile information for your course. See :ref:`View and
 download student data`.
+
 
 .. _Creating a Unicode Encoded CSV File:
 
@@ -418,7 +477,7 @@ consequences of these actions.
 .. _Changing Student Cohort Assignments:
 
 ***************************************************
-Change Student Cohort Assignments
+Change Learner Cohort Assignments
 ***************************************************
 
 After your course starts and learners begin to contribute to the course

--- a/en_us/shared/course_features/cohorts/cohorts_overview.rst
+++ b/en_us/shared/course_features/cohorts/cohorts_overview.rst
@@ -4,46 +4,15 @@
 Using Cohorts in Your Courses
 #############################
 
-This section provides an introduction to using cohorts.
+This section provides an introduction to using cohorts to divide the learners
+in your course into smaller groups.
 
 .. contents::
   :local:
   :depth: 1
 
-*********
-Overview
-*********
-
-To create smaller communities in your course, or design different
-course experiences for different groups of learners, you can :ref:`set up
-cohorts<Enabling and Configuring Cohorts>` in your course.
-
-In discussion topics that are divided by cohort, learners can also communicate
-and share experiences privately within the cohort that they are assigned to.
-Cohort-specific discussion opportunities can help learners develop a sense of
-community, provide specialized experiences, and encourage deeper, more
-meaningful course involvement.
-
-If you use cohorts in your course, you define a set of cohorts that reflect
-communities of learners, then select a strategy for :ref:`assigning learners to
-cohorts<Options for Assigning Learners to Cohorts>`.
-
-.. note::
-   * Every learner must be assigned to a cohort. This ensures that
-     every learner has the ability to read and contribute to course discussion
-     topics.
-
-   * Each learner can be in one and only one cohort.
-
-   To provide learners with a consistent experience throughout the course run,
-   do not change cohort configuration or a learner's cohort assignment after
-   your course begins.
-
-   The number of learners reported on the **Cohorts** tab and in
-   downloaded reports includes only those learners who are enrolled in the
-   course.
-
-For more information about using cohorts, see the following topics.
+For more information about setting up and managing cohorts, see the following
+topics.
 
 * :ref:`Enabling and Configuring Cohorts`
 
@@ -54,30 +23,85 @@ For more information about using cohorts, see the following topics.
 
 For information about discussions in general, see :ref:`Discussions`.
 
+
+*********
+Overview
+*********
+
+To create smaller communities in your course, or to design different course
+experiences for different groups of learners, you can :ref:`set up
+cohorts<Enabling and Configuring Cohorts>` in your course.
+
+To use cohorts in your course, you define a set of cohorts that are either
+random or that reflect some characteristic of the communities of learners in
+your course. Then, you decide on a strategy for :ref:`assigning learners to
+these cohorts<Options for Assigning Learners to Cohorts>`.
+
+With learners divided into smaller groups based on cohort, you can give
+learners a course experience that is specific to the cohort that they belong
+to. You can divide discussion topics by cohort so that learners only interact
+with other members of the same cohort. You can create course content in such a
+way that learners in different cohorts are offered different variations of
+assignments or exams.
+
+
+.. note::
+
+   * Every learner must be assigned to a cohort. This ensures that every
+     learner has the ability to read and contribute to course discussion
+     topics.
+
+   * Each learner can be in one and only one cohort.
+
+   To provide learners with a consistent experience throughout the course run,
+   do not change cohort configuration or a learner's cohort assignment after
+   your course begins.
+
+
+
+
+
 .. _Options for Assigning Learners to Cohorts:
 
 *****************************************
 Options for Assigning Learners to Cohorts
 *****************************************
 
-Learners are assigned to cohorts either automatically or manually, depending
-on the types of cohorts that you create. Manual cohorts do not have
-learners assigned to them unless you manually add learners. Automatic cohorts
-have learners randomly assigned to them if learners do not belong to any cohort
-by the time they access the course content (including the course **Discussion**
-page or content-specific discussion topics). If you have not created any
-automated cohorts by the time learners access course content, a default
+Learners are assigned to cohorts either :ref:`automatically<About Auto
+Cohorts>` or :ref:`manually<Assign Learners to Cohorts Manually>`, depending
+on the types of cohorts that you create.
+
+Manual cohorts do not have learners assigned to them unless you manually add
+learners. Automatic cohorts have learners randomly assigned to them if
+learners do not belong to any cohort by the time they access the course
+content (including the course **Discussion** page or content-specific
+discussion topics, if discussion topics are divided). If you have not created
+any automated cohorts by the time learners access course content, a default
 automated cohort is created and used for automatic assignment, so that no
 learner in the course is without a cohort.
 
-Determine the basic strategy that you will use to create cohorts. An automated
-assignment strategy means that you create cohorts to which learners are
-assigned automatically and randomly. A manual assignment strategy means that
-you create cohorts to which learners are assigned only when you or your course
-team manually adds them. You can use a hybrid assignment method by creating a
-combination of automated and manual cohorts. Typically, your purpose in
-including the cohort feature determines which assignment option you use for
-your course.
+Determine the basic strategy that you will use to create cohorts. Typically,
+your purpose in including the cohort feature determines which assignment
+option you use for your course.
+
+An :ref:`automated assignment strategy<Implementing the Automated Assignment
+Strategy>` means that you create cohorts to which learners are assigned
+automatically and randomly. Automated assignment works well if, for example,
+you are creating cohorts simply to create small groups of learners. Automated
+assignment means that learners are assigned randomly to cohorts as they access
+course content and divided discussion topics. The cohorts that result from
+automated random assignment are likely to be more equal in size.
+
+A :ref:`manual assignment strategy<Implementing the Manual Assignment
+Strategy>` means that learners are assigned only to the cohorts you have
+created when you or your course team manually adds them. A manual assignment
+strategy makes sense if you want to create cohorts based on some
+characteristic of your learners. For example, if you want alumni from your
+institution to have a particular course experience, you can create an alumni
+cohort and manually assign learners who you know are alumni to that cohort.
+
+You can use a :ref:`hybrid assignment method<Hybrid Assignment>` by creating a
+combination of automated and manual cohorts.
 
 .. note:: You can add learners manually to any cohort, whether it was created
    as an automated cohort or a manual cohort.
@@ -91,8 +115,8 @@ your course.
    consistent experience throughout the course run, do not change cohort
    configuration or a learner's cohort assignment after your course begins.
 
-For more information about strategies for assigning learners to cohorts, see
-the following topics.
+For use cases and examples of the strategies for assigning learners to cohorts,
+see the following topics.
 
 * :ref:`All Automated Assignment`
 
@@ -119,7 +143,7 @@ If you use the automated assignment strategy, you create several "auto"
 the auto cohorts when they first view any course content on the **Course** or
 **Discussion** page. In this way, each learner who engages with the course
 content or its discussion community is assigned to a cohort. No learner who
-particpates in these ways remains unassigned.
+participates in these ways remains unassigned.
 
 The following guidelines are based on the experiences of MOOC teams that have
 used cohorts in this way. They are suggested to help you determine how many
@@ -130,7 +154,7 @@ automated cohorts to define for your course.
   develop. Cohorts formed by random assignment tend to be successful if they
   include between 200 and 500 members.
 
-* For every 10,000 students who enroll, approximately 200 to 400 students
+* For every 10,000 learners who enroll, approximately 200 to 400 learners
   remain active in the discussions throughout the course run.
 
 * Divide the estimated total enrollment of the course run by 10,000.
@@ -138,7 +162,7 @@ automated cohorts to define for your course.
 * Use the result as the number of automated cohorts to create.
 
 For example, two days before it starts, a course has an enrollment of 80,000
-students. To create small communities within the discussions, the course team
+learners. To create small communities within the discussions, the course team
 enables cohorts and then creates eight automated cohorts. As learners visit the
 **Discussion** page or view the course content, they are randomly assigned to
 one of the eight cohorts. In divided discussion topics, learners read and
@@ -200,7 +224,7 @@ define existing cohorts in the student body. You also decide whether you want
 the remaining learners in the course to be divided into their own, similarly-
 sized cohorts, or if you want them all to be in just one other cohort.
 
-After you enable cohorts, you create a manual cohort for each student group
+After you enable cohorts, you create a manual cohort for each learner group
 that you identified. You manually assign learners who belong to each group to
 the corresponding cohort. You also set up automated cohorts for the other
 learners in the course, or rely on the default automated cohort. Any learners


### PR DESCRIPTION
## [DOC-3699](https://openedx.atlassian.net/browse/DOC-3699)
## [DOC-3622](https://openedx.atlassian.net/browse/DOC-3622)

Update the course author documentation to reflect that learners are not required to have edX accounts or be enrolled in a course, for course teams to manually add them to a cohort. 
Remove any notes that indicate that learners must be enrolled in the course before they can be added to cohorts. Update any descriptions of the counts of "Learners Added" vs "Preassigned Learners" in the cohort results tables.

### Date Needed: June 21 (Wed)
The feature is releasing to Prod on June 21

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @ssemenova 
- [x] Subject matter expert: @cahrens 
- [x] Doc team review: @edx/doc 
- [x] Product review: @sstack22 

FYI: @mmacfarlane, @jhendersonedx, @dhixonedx 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version
- [x] http://draft-ca-preassign-to-cohorts.readthedocs.io/en/latest/course_features/cohorts/cohort_config.html

### Sandbox
- [x] ssemenova.sandbox.edx.org

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

