### PR TITLE
Add title_truncated member field to edx.forum.thread.created event

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -4051,7 +4051,8 @@ complete, the server emits an ``edx.forum.thread.created`` event.
 
    * - ``body``
      - string
-     - The text supplied for the new post.
+     - The text supplied for the new post. Truncated if the field contains more
+       than 2000 characters.
 
        Also present for ``edx.forum.response.created`` and
        ``edx.forum.comment.created`` events.
@@ -4115,11 +4116,17 @@ complete, the server emits an ``edx.forum.thread.created`` event.
 
    * - ``title``
      - string
-     - The brief descriptive text supplied to identify the post.
+     - The brief descriptive text supplied to identify the post. Truncated if
+       the title has more than 1000 characters.
+
+   * - ``title_truncated``
+     - Boolean
+     - 'true' only if the title is longer than 1000 characters, which is the
+       maximum included in the event.
 
    * - ``truncated``
      - Boolean
-     - 'true' only if the post was longer than 2000 characters, which is the
+     - 'true' only if the post contains more than 2000 characters, which is the
        maximum included in the event.
 
        Also present for ``edx.forum.response.created`` and


### PR DESCRIPTION
## [DOC-3657](https://openedx.atlassian.net/browse/DOC-3657)

This PR adds the **title_truncated** member field to the **edx.forum.thread.created** event in preparation for a new **edx.forum.thread.viewed** event. 

For more information, see comments on [platform PR 15351](https://github.com/edx/edx-platform/pull/15351).

### Date Needed (optional)

21 June 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @kdmccormick 
- [ ] Doc team review (copy edit?): @edx/doc

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

