### PR TITLE
Fix typo that caused note to display incorrectly in Publisher topics

### DIFF
--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/index.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/index.rst
@@ -4,7 +4,7 @@
 Creating and Announcing a Course Using Publisher
 ################################################
 
-..note::
+.. note::
   This process applies to courses on the edx.org site. If your course will run
   on Edge, you create the course and the About page in Studio. For more
   information, see :ref:`Creating a New Course` or :ref:`Creating a Course

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_add_about_video.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_add_about_video.rst
@@ -4,7 +4,7 @@
 Add a Course or Program About Video
 ##########################################
 
-..note::
+.. note::
   This process applies to courses on the edx.org site. If your course will run
   on Edge, you add the About video in Studio. For more information, see
   :ref:`Add an About Video`.

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_course.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_course.rst
@@ -6,7 +6,7 @@ Creating a Course
 
 This topic describes the process of creating and finalizing a course.
 
-..note::
+.. note::
   This process applies to courses on the edx.org site. If your course will run
   on Edge, you create the course and the About page in Studio. For more
   information, see :ref:`Creating a New Course` or :ref:`Creating a Course

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_course_run.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_course_run.rst
@@ -6,7 +6,7 @@ Creating a Course Run
 
 This topic describes the process of creating and finalizing a course run.
 
-..note::
+.. note::
   This process applies to courses on the edx.org site. If your course will run
   on Edge, you create the course and the About page in Studio. For more
   information, see :ref:`Creating a New Course` or :ref:`Creating a Course

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_introduction.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_introduction.rst
@@ -4,7 +4,7 @@
 Introduction to Publisher
 ################################
 
-..note::
+.. note::
   This information applies to courses on the edx.org site. If your course will
   run on Edge, you create the course and the About page in Studio. For more
   information, see :ref:`Creating a New Course` or :ref:`Creating a Course

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_publish_about_page.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_publish_about_page.rst
@@ -6,7 +6,7 @@ Publishing an About Page
 
 This topic describes the process of publishing a course About page on edx.org.
 
-..note::
+.. note::
   This process applies to courses on the edx.org site. If your course will run
   on Edge, you create the course and the About page in Studio. For more
   information, see :ref:`Creating a New Course` or :ref:`Creating a Course


### PR DESCRIPTION
Fixes a missing space that causes the note at the top of each page in the Publisher topic to display incorrectly.

### Date Needed (optional)
ASAP

- [ ] Doc team review (sanity check): @edx/doc
