### PR TITLE
Fix another set of typos in the Set Up Course section

### DIFF
--- a/en_us/shared/set_up_course/studio_add_course_information/creating_about_page.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/creating_about_page.rst
@@ -6,7 +6,7 @@ Creating a Course About Page
 
 .. only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 
@@ -42,7 +42,7 @@ Describe Your Course
 
 .. only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 
@@ -103,7 +103,7 @@ Add a Course About Video
 
 . only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 
@@ -143,7 +143,7 @@ Set Course Effort Expectations
 
 . only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 

--- a/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
@@ -8,7 +8,7 @@ This topic describes how to use Studio to create and set up a course.
 
 .. only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 
@@ -35,7 +35,7 @@ Create a Course
 
 .. only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 
@@ -93,7 +93,7 @@ Edit a Course
 
 .. only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 

--- a/en_us/shared/set_up_course/studio_add_course_information/studio_course_image.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/studio_course_image.rst
@@ -3,7 +3,7 @@ Program Images and Videos`.
 
 . only:: Partners
 
-   ..note::
+   .. note::
     This process applies to courses on the edX Edge site. If your course will
     run on edx.org, see :ref:`Pub Creating and Announcing a Course`.
 

--- a/en_us/shared/set_up_course/studio_add_course_information/studio_course_staffing.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/studio_course_staffing.rst
@@ -69,8 +69,8 @@ prerequisites.
 Other course team members can edit the course and perform all tasks except
 adding and removing other team members and granting Admin access.
 
-.. note::  Any course team member can delete content created by other team
- members.
+.. note::
+ Any course team member can delete content created by other team members.
 
 To add a course team member, follow these steps.
 


### PR DESCRIPTION
Fixes another group of typos that make notes appear incorrectly in the Set Up Course section.

### Date Needed (optional)

ASAP
### Reviewers
 
- [ ] Doc team review (sanity check): @edx/doc
