### PR TITLE
Update latest release to Ficus before it becomes Gingko

### DIFF
--- a/en_us/install_operations/source/index.rst
+++ b/en_us/install_operations/source/index.rst
@@ -11,8 +11,8 @@ This document applies to the most recent version of the Open edX platform; that
 is, it applies to the *master* branch of the edX platform.
 
 This document also contains instructions for installing Open edX releases. The
-most recent release of the Open edX platform is :ref:`Eucalyptus <Open edX
-Eucalyptus Release>`.
+most recent release of the Open edX platform is :ref:`Ficus <Open edX
+Ficus Release>`.
 
 You can install any release of the Open edX platform. For most situations, edX
 recommends that you install the most recent release. However, if your


### PR DESCRIPTION
## [DOC-3708](https://openedx.atlassian.net/browse/DOC-3708)

This page said the most recent release is Eucalyptus. It is really Ficus, at least for a little while longer.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

