### PR TITLE
DOC-3698 Add Group Community TA discussion role, DOC-3683, DOC-3684

### DIFF
--- a/en_us/course_authors/source/manage_discussions/moderate_discussions.rst
+++ b/en_us/course_authors/source/manage_discussions/moderate_discussions.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/manage_discussions/moderate_discussions.rst

--- a/en_us/course_authors/source/manage_discussions/running_discussions.rst
+++ b/en_us/course_authors/source/manage_discussions/running_discussions.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/manage_discussions/running_discussions.rst

--- a/en_us/open_edx_course_authors/source/manage_discussions/moderate_discussions.rst
+++ b/en_us/open_edx_course_authors/source/manage_discussions/moderate_discussions.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/manage_discussions/moderate_discussions.rst

--- a/en_us/open_edx_course_authors/source/manage_discussions/running_discussions.rst
+++ b/en_us/open_edx_course_authors/source/manage_discussions/running_discussions.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../shared/manage_discussions/running_discussions.rst

--- a/en_us/shared/course_features/cohorts/cohorts_setup_discussions.rst
+++ b/en_us/shared/course_features/cohorts/cohorts_setup_discussions.rst
@@ -5,12 +5,13 @@
 Setting up Discussions in Courses with Cohorts
 ######################################################
 
-In courses that use cohorts, in addition to discussion topics that are by
-default shared by all learners, you can create divided discussion topics, within
-which learners interact only with other members of their cohort.
+In courses that use cohorts, in addition to :ref:`discussion
+topics<Discussions>` that are by default shared by all learners, you can create
+divided discussion topics, within which learners interact only with other
+members of their cohort.
 
 For information about divided discussions, see :ref:`About Divided
 Discussions`.
 
 For information about managing and moderating discussions, see :ref:`Managing
-Divided Discussion Topics` and :ref:`Guidance for Discussion Moderators`.
+Divided Discussion Topics` and :ref:`Moderating_discussions`.

--- a/en_us/shared/manage_discussions/discussions.rst
+++ b/en_us/shared/manage_discussions/discussions.rst
@@ -1,124 +1,34 @@
 .. _Discussions:
 
 ##################################
-Managing Course Discussions
+Creating Course Discussions
 ##################################
 
-Course discussions foster interaction among learners and between learners and
-the course team. You can set up different topics to guide these interactions
-when you create your course, and then run and moderate discussions throughout
-the course to encourage participation and develop course community.
-Discussions are also excellent sources of feedback and ideas for the future.
+Discussions in an edX course include both course-wide topics of interest to
+all learners (such as "Feedback", "Troubleshooting", or "Technical Help") as
+well as content-specific topics that you add to course units as discussion
+components. You create both types of discussion topics in Studio.
 
-.. only:: Partners
-
- For information about participating in discussions, see the
- :ref:`learners:Course Discussions Index` section in the *EdX Learner's Guide*.
- Consider referring learners in your courses to that section, which describes
- the structure and features of edX course discussions, and provides useful
- information to help learners make the most of their participation in course
- discussions.
-
-.. only:: Open_edX
-
- For information about participating in discussions, see the
- :ref:`openlearners:Course Discussions Index` section in the *Open edX
- Learner's Guide*. Consider referring learners in your courses to that section,
- which describes the structure and features of course discussions, and provides
- useful information to help learners make the most of their participation in
- course discussions.
-
-For information about running and moderating discussions, see the following
-sections.
+For information about creating discussion topics, see the following sections.
 
 .. contents::
  :local:
  :depth: 1
 
-.. note:: Some features of discussions, especially moderation features, are
-   not available when discussions are accessed in the edX mobile app. For
-   information about the differences between discussions on the edx.org site
-   and in the mobile app, see :ref:`Discussions on Mobile Apps`.
 
 For information about creating discussions in which learners in a group such as
 a cohort or in a particular enrollment track only interact with posts from other
-learners in the same group, see :ref:`About Divided Discussions`. For
-information about moderating course discussions that are divided, see
-:ref:`Managing Divided Discussion Topics`.
+learners in the same group, see :ref:`About Divided Discussions`.
 
-.. _Overview_discussions:
+For information about running and moderating course discussions, see
+:ref:`Running_discussions` and :ref:`Moderating_discussions`.
 
-************
-Overview
-************
-
-Learners and the course team use course discussions to share ideas, exchange
-views, consider different viewpoints, and ask questions. In course discussions
-there are three hierarchical levels of interaction.
-
-* A post is the first level of interaction. A post opens a new subject. Posts
-  can be made as questions, to solicit a concrete answer, or as discussions,
-  to start a conversation. When participants add a post, they must choose an
-  existing topic to associate it with, and decide whether to add it as a
-  **Question** or as a **Discussion**.
-
-* A response is the second level of interaction. A response is a reply made
-  directly to a post to provide a solution or continue the conversation.
-
-* A comment is the third level of interaction. A comment is often a
-  clarification or side note made to a specific response, rather than to the
-  post as a whole.
-
-The dialog created by a post, its responses, and the comments on those
-responses is sometimes called a thread. Discussion threads are saved as part
-of the course history.
-
-All course team members and enrolled learners can add posts, responses, and
-comments, and they can also view posts, responses, and comments made by other
-course participants. For information about divided discussions, see :ref:`About
-Divided Discussions` and :ref:`Managing Divided Discussion Topics`.
-
-Members of the course community, learners as well as the course team, can be
-given permission to moderate or administer course discussions through a set of
-discussion administration roles.
-
-.. note:: The course team members that you set up in Studio or in the LMS are
-   not automatically granted discussion administration roles. Only people who
-   have a discussion administration role can view all of the discussion
-   contributions, for example in courses using cohorts.
-
-   Discussion administration roles must be explicitly granted to members of
-   the course team for them to moderate or administer course discussions. The
-   course author, and any team members with the Admin role, can grant
-   discussion administration roles. For information about assigning discussion
-   privileges, see :ref:`Assigning_discussion_roles`.
-
-.. note:: Not all options for moderating discussions are available when
-   discussions are accessed using the edX mobile apps. For information about
-   the differences between discussions on the edx.org site and in the mobile
-   apps, see :ref:`Discussions on Mobile Apps`.
-
-.. _Organizing_discussions:
-
-*************************************************
-Creating Discussion Topics for Your Course
-*************************************************
-
-Discussions in an edX course include both broad topics on course-wide areas of
-interest such as "Feedback", "Troubleshooting", or "Technical Help", and the
-content-specific topics that you add to course units as discussion components.
-You create both types of discussion topics in Studio.
-
-For more information about creating discussion topics, see :ref:`Create
-CourseWide Discussion Topics` and :ref:`Create ContentSpecific Discussion
-Topics`. For information about configuring discussion topics in courses that
-use cohorts, see :ref:`Set up Discussions in Cohorted Courses`.
 
 .. _Create CourseWide Discussion Topics:
 
-=====================================
+*************************************
 Create Course-Wide Discussion Topics
-=====================================
+*************************************
 
 All courses include a page named **Discussion**. When you create a course, a
 course-wide discussion topic named "General" is already included by default.
@@ -153,7 +63,7 @@ To create a course-wide discussion topic, follow these steps.
          }
      }
 
-4. Copy the three lines provided for the General topic and paste
+4. Copy the three lines provided for the "General" topic and paste
    them above the closing brace character (``}``).
 
 
@@ -230,15 +140,10 @@ Discussion list now includes the topic you added.
   :width: 300
   :alt: A new topic named Course Q&A in the list of discussion topics.
 
-.. note:: In courses that use cohorts, the course-wide discussion topics that
-   you add are unified. All posts can be read and responded to by every learner,
-   regardless of the cohort that they belong to. You can optionally configure
-   these topics to be divided by cohort. For more information, see :ref:
-   `Specify Which Course Wide Discussion Topics are Divided`.
 
-.. note:: You can configure the default topic for new posts in the
-   **Discussion** page by setting its "default" attribute to true. For
-   example:
+.. note:: To make a particular course-wide discussion topic the default topic
+   when learners add new posts on the **Discussion** page, add a "default"
+   attribute with a value of ``true`` to the topic's definition.
 
    ::
 
@@ -252,17 +157,26 @@ Discussion list now includes the topic you added.
         }
      }
 
+
+.. note:: In courses that use cohorts, the course-wide discussion topics that
+   you add are unified. All posts can be read and responded to by every
+   learner, regardless of the cohort that they belong to. You can optionally
+   configure these topics to be divided by cohort. For more information, see
+   :ref:`Specify Which Course Wide Discussion Topics are Divided`.
+
+
 .. _Create ContentSpecific Discussion Topics:
 
-============================================
+*********************************************
 Create Content-Specific Discussion Topics
-============================================
+*********************************************
 
 To create a content-specific discussion topic, you add a discussion component
 to a unit. Typically, you do this while you are designing and creating your
 course in Studio. Follow the instructions in :ref:`Working with Discussion
 Components`. The result is a discussion topic associated with a unit and its
-content.
+content. Learners can access content-specific topics both in the course unit
+and on the **Discussion** page.
 
 .. warning:: Follow the recommended steps to add discussion components. Do not
    create discussion topics by using the **Duplicate** button in Studio, and do
@@ -273,7 +187,6 @@ content.
 For information about the visibility of content-specific discussion
 topics, see :ref:`Visibility of Discussion Topics`.
 
-
 .. note:: In courses with cohorts enabled, when you add discussion components to
    units in Studio, these discussion topics are by default unified. All learners
    in the course can see and respond to posts from all other learners. You can
@@ -282,114 +195,11 @@ topics, see :ref:`Visibility of Discussion Topics`.
    see :ref:`Content Specific Discussion Topics and Groups`.
 
 
-.. _Assigning_discussion_roles:
-
-*************************************************
-Assign Discussion Administration Roles
-*************************************************
-
-You can designate a team of people to help you run course discussions. Team
-members who have a discussion administration role have additional options for
-working with posts, responses, and comments.
-
-
-.. important:: The course team members that you set up in Studio or in the LMS
-   are not automatically granted discussion administration roles.
-
-   Discussion administration roles must be explicitly granted to members of
-   the course team for them to be able to moderate or administer course
-   discussions. The course author and any team members who have the Admin role
-   can grant discussion administration roles.
-
-Different options for working with discussions are available through
-the following roles.
-
-.. note:: The options for moderating discussions described below are only
-   available when members of the discussion administration team work in a web
-   browser. The edX mobile apps do not currently offer moderation options.
-
-   For more information about differences between discussions on the edx.org
-   site and on the mobile apps, see :ref:`Discussions on Mobile Apps`.
-
-* Discussion moderators can edit and delete messages at any level, review
-  messages flagged for misuse, close and reopen posts, pin posts, and mark
-  responses as correct answers.
-
-  Posts, responses, and comments made by moderators are marked with a
-  **Staff** identifier. The moderator role is often given to course team
-  members who already have the Staff role.
-
-.. removed this clause from 1st sentence per JAAkana and MHoeber: , and, if the
-.. course is cohorted, see posts from all cohorts
-
-* Discussion community teaching assistants (TAs) have the same options for
-  working with discussions as moderators do.
-
-  Posts, responses, and comments made by community TAs are marked with a
-  **Community TA** identifier. The community TA role is often given to
-  learners.
-
-* Discussion admins have the same options for working with discussions as
-  moderators, and their posts, responses, and comments have the same **Staff**
-  identifiers.
-
-  This role can be reserved for assignment to course team members
-  who have the Admin role only: the discussion admins can then both
-  moderate discussions and give other users discussion management roles
-  whenever necessary.
-
-Before you can assign roles to your discussion team, you need their email
-addresses or usernames.
-
-* To get this information for a course team member, in the LMS select
-  **Instructor** to access the instructor dashboard. Select **Membership**, and
-  then select either **Staff** or **Admin**.
-
-* To get this information for an enrolled learner, in the LMS select
-  **Instructor** to access the instructor dashboard. Select **Data Download**,
-  and then **Download profile information as a CSV**.
-
-====================================
-Assign Roles
-====================================
-
-You can assign a course team role to any user who is already enrolled in your
-course. To assign a discussion administration role, you must be the course
-author or an Admin.
-
-#. View the live version of the course.
-
-#. Select **Instructor**, and then select **Membership**.
-
-#. In the **Course Team Management** section, select **Discussion Admins**,
-   **Discussion Moderators**, or **Discussion Community TAs**.
-
-#. Under the list of users who currently have that role, enter an email address
-   or username, and then select **Add** for the role type.
-
-
-==============
-Remove Roles
-==============
-
-To remove a role from a user, you must be the course author or an Admin.
-
-#. View the live version of the course.
-
-#. Select **Instructor**, and then select **Membership**.
-
-#. In the **Course Team Management** section, select **Discussion Admins**,
-   **Discussion Moderators**, or **Discussion Community TAs**.
-
-#. From the list of users who currently have that role, select the user you
-   want to remove, and then select **Revoke access**.
-
-
 .. _Visibility of Discussion Topics:
 
-**********************************
-Visibility of Discussion Topics
-**********************************
+*********************************************************
+Understanding When Learners Can See Discussion Topics
+*********************************************************
 
 The names that you specify as the category and subcategory names for discussion
 components are not visible on the **Discussion** page in the LMS until after
@@ -413,16 +223,16 @@ release dates.
 
 .. _Anonymous_posts:
 
-************************************
-Enabling Anonymous Discussion Posts
-************************************
+*****************************************************
+Allowing Learners to Make Anonymous Discussion Posts
+*****************************************************
 
 By default, when learners participate in a discussion, their usernames are
-visible in the discussion. You can enable learners to make their discussion
-posts anonymous, so that their usernames are not visible to other learners.
-Their usernames will still be visible to course staff.
+visible in the discussion. You can allow learners to make discussion posts
+that are anonymous to their peers: their usernames are not visible to other
+learners. Their usernames will still be visible to course staff.
 
-To enable anonymous discussion posts in your course, follow these steps.
+To allow anonymous discussion posts in your course, follow these steps.
 
 #. In Studio, select **Settings**, then select **Advanced Settings**.
 
@@ -436,501 +246,11 @@ To enable anonymous discussion posts in your course, follow these steps.
 Learners can now create discussion posts in your course that are anonymous
 to other learners.
 
-The **Advanced Settings** page in Studio also includes a field named **Allow
-Anonymous Discussion Posts**. Setting the value of that field to ``true``
-enables learners to create discussion posts that are anonymous to course
-staff, as well as to other learners. As a best practice, edX recommends
-that you do not set this field to ``true``.
-
-
-.. _Running_discussions:
-
-*********************
-Run a Discussion
-*********************
-
-On an ongoing basis, the members of your discussion team run the course
-discussion by making contributions, marking answers as correct, and guiding
-learner messages into pertinent threads. Techniques that you can use
-throughout your course to make discussions successful follow.
-
-==========================================
-Use Conventions in Discussion Subjects
-==========================================
-
-To identify certain types of messages and make them easier to find, you can
-define a set of standard tags to include in the subject of a post or in the
-body of a response or comment. Examples follow.
-
-* Use "[OFFICIAL]" at the start of announcements about changes to the course.
-
-* Provide information about corrected errors with a subject that begins
-  "[CORRECTIONS]" or "[ERRORS]".
-
-* Ask learners to use "[STAFF]" in the subject of each post that needs the
-  attention of a course team member.
-
-Both the discussion team and your learners can use tags like these to search
-the discussions more effectively.
-
-When a post is created its type must be selected: either "question" or
-"discussion". Members of the discussion team should be thoughtful when
-selecting the type for their posts, and encourage learners to do the same. For
-more information, see :ref:`Find Question Posts and Discussion Posts`.
-
-.. future: changing the type of a post, maybe resequence or separate  conventions from post types
-
-========================
-Seed Discussion Topics
-========================
-
-To help learners learn how to get the most out of course discussions, and find
-the best discussion topic to use for their questions and conversations, you can
-seed discussion topics in course-wide discussion topics before the course
-starts.
-
-Some examples follow.
-
-* In the General topic (which is included in every course by default), add an
-  [INTRO] post to initiate a thread for learner and course team introductions.
-
-* For each course-wide discussion topic that you create, add an initial post
-  to describe the way you intend that discussion to be used. In addition to
-  providing guidance, these initial messages can act as models for learners to
-  follow when they create their own posts.
-
-EdX strongly recommends that you do not create seed posts in content-specific
-discussion topics before the course starts or before the containing unit is
-released. The category and subcategory names for content-specific discussion
-topics are subject to the release visibility of their containing unit, and are
-not visible until the unit is released. For more details, see :ref:`Visibility
-of Discussion Topics`.
-
-
-======================================
-Minimize Thread Proliferation
-======================================
-
-To encourage longer, threaded discussions rather than many similar, separate
-posts, the discussion team can use the following techniques. However, be aware
-that long threads (with more than 200 responses and comments) can be difficult
-to read, and can therefore result in an unsatisfactory experience in the
-discussion.
-
-.. note:: You can only pin or close posts and mark questions as answered when
-   you work in a web browser. You cannot complete these activities when you
-   work in the edX mobile app.
-
-* Pin a post. Pinning a post makes it appear at the top of the list of posts in
-  the discussion navigation pane on the **Discussion** page. As a result, it is
-  more likely that learners will see and respond to pinned posts. You can write
-  your own post and then pin it, or pin a post by any author. Select the "More"
-  icon and then **Pin**.
-
-  .. image:: ../../../shared/images/Discussion_Pin.png
-   :alt: The pin icon for discussion posts.
-
-* Mark a response as answered or endorsed. Depending on whether a post is a
-  question or a discussion, you use the same option to mark a response either
-  as the answer to the posted question, or to endorse a response. Marking a
-  question as answered makes it easier for learners to find answers to already
-  asked questions, rather than ask the same question again. Endorsing a
-  response confirms that it adds value to a discussion.
-
-  To mark a response as answered or endorsed, select the "check mark" icon.
-  You cannot mark your own responses as answers or as endorsed.
-
-  .. image:: ../../../shared/images/Discussion_MarkAsAnswer.png
-   :alt: The "check mark" icon for marking a response as the correct answer
-         to a question.
-
-* Vote for posts or responses. Learners can sort discussions by posts with the
-  most votes, so posts and responses with many votes are more likely to be
-  read and responded to. Select the "plus" icon for the response. You cannot
-  vote for your own posts.
-
-  .. image:: ../../../shared/images/Discussion_vote.png
-   :alt: The "plus" icon for voting for discussion posts.
-
-* Close a post. You can respond to a redundant post by (optionally) pasting in
-  a link to the post that you prefer learners to contribute to, and prevent
-  further interaction by closing the post. Select the "More" icon and then
-  **Close**.
-
-* Provide post/response/comment guidelines. You can post information from the
-  :ref:`overview<Overview_discussions>` in this section, or the :ref:`anatomy
-  of edX discussions<Anatomy of edX Course Discussions>` in the next section,
-  in a course-wide discussion topic (such as General) to provide guidance about
-  when to start a new thread by adding a post, responding to an existing post,
-  or commenting on a response.
-
-
-.. _Moderating_discussions:
-
-***********************
-Moderate Discussions
-***********************
-
-The members of a course discussion team monitor discussions and keep them
-productive. They can also collect information, such as areas of particular
-confusion or interest, and relay it to the course team.
-
-Developing and sustaining a positive discussion culture requires that
-sufficient moderator time is dedicated to reviewing and responding to
-discussions. Keeping up-to-date with a large MOOC forum requires a commitment
-of 5 or more hours per week, and involves reading threads, replying to and
-editing posts, and communicating with the rest of the discussion administration
-team and other members of the course team.
-
-For information on setting up moderators for your course, see
-:ref:`Assigning_discussion_roles`.
-
-For information about best practices for moderating discussions, see
-:ref:`Guidance for Discussion Moderators`. If you are using :ref:`divided
-discussions`<About Divided Discussions>`, see :ref:`Managing Divided Discussion
-Topics`.
-
-====================================================
-View Profile Information for Discussion Participants
-====================================================
-
-To find out more about a specific discussion participant, you can view that
-learner's edX profile from their linked username on discussion posts.
-
-To access a learner's profile from a discussion post that they contributed,
-follow these steps.
-
-#. On the **Discussion** page, select a username in a post, response, or
-   comment.
-
-#. On the discussion page for that learner, select the linked username.
-
-   The learner's account profile page opens. Learners can have either a limited
-   profile or a full profile.
-
-For more information about profiles, see :ref:`learners:SFD Dashboard`.
-
-========================================
-Provide Guidelines for Learners
-========================================
-
-You can develop a set of best practices for discussion participation and make
-them available to learners as a course handout file or on a defined page in
-your course. These guidelines can define your expectations and optionally
-introduce features of edX discussions.
-
-.. only:: Partners
-
- You can also refer learners to the :ref:`learners:Course Discussions Index`
- section in the *EdX Learner's Guide*. Consider referring learners in your
- courses to that section, which describes the structure and features of edX
- course discussions, and provides useful information to help learners make the
- most of their participation in course discussions.
-
-.. only:: Open_edX
-
- You can also refer learners to the :ref:`openlearners:Course Discussions
- Index` section in the *Open EdX Learner's Guide*. Consider referring learners
- in your courses to that section, which describes the structure and features of
- edX course discussions, and provides useful information to help learners make
- the most of their participation in course discussions.
-
-.. For a template that you can use to develop your own guidelines, see
-.. :ref:`Discussion Forum Guidelines`.
-
-.. _Develop a Positive Discussion Culture:
-
-========================================
-Develop a Positive Discussion Culture
-========================================
-
-Discussion monitors can cultivate qualities in their own discussion
-interactions to make their influence positive and their time productive.
-
-* Encourage quality contributions: thank learners whose posts have a positive
-  impact and who answer questions.
-
-* Check links, images, and videos in addition to the text of each message. Edit
-  offensive or inappropriate posts quickly, and explain why.
-
-* Review posts with a large number of votes and recognize "star posters"
-  publicly and regularly.
-
-* Stay on topic yourself: before responding to a post, be sure to read it
-  completely.
-
-* Maintain a positive attitude. Acknowledge problems and errors without
-  assigning blame.
-
-* Provide timely responses. More time needs to be scheduled for answering
-  discussion questions when deadlines for homework, quizzes, and other
-  milestones approach.
-
-* Discourage redundancy: before responding to a post, search for similar posts.
-  Make your response to the most pertinent or active post and then copy its URL
-  and use it to respond to the redundant threads.
-
-* Publicize issues raised in the discussions: add questions and their answers
-  to an FAQ topic, or announce them on the **Home** page.
-
-For a template that you can use to develop guidelines for your course
-moderators, see :ref:`Guidance for Discussion Moderators`.
-
-.. _Find Question Posts and Discussion Posts:
-
-==========================================
-Find Questions and Discussions
-==========================================
-
-When learners create posts, they specify the type of post to indicate whether
-they are asking for concrete information (a question) or starting an open-ended
-conversation (a discussion).
-
-On the **Discussion** page, a question mark image identifies posts that ask
-questions, and a conversation bubble image identifies posts that start
-discussions. When an answer is provided and marked as correct for a question, a
-check or tick mark image replaces the question mark image. For more
-information, see :ref:`Answer Questions`.
-
-The titles and icons of posts that you have not yet read appear in blue, with
-a blue vertical bar on the post's left side. Posts that you have read have
-dark gray titles and icons. When new responses and comments are made on posts
-that you have read, a "new" indicator displays with the number of new
-responses or comments that you have not yet read.
-
-.. image:: ../../../shared/images/Discussion_ReadUnreadNew.png
-  :width: 300
-  :alt: The discussion navigation pane, showing some unread and some read
-     posts, including a post that has been read but now has additional new
-     responses or comments.
-
-In addition to these visual cues, filters can help you find questions and
-discussions that need review. In the discussion navigation pane on the
-**Discussion** page, you can also select the following options from the **Show
-all** drop-down menu.
-
-* **Unread**, to list only the discussions and questions that you have not yet
-  viewed.
-
-* **Unanswered**, to list only questions that do not yet have any responses
-  marked as answers.
-
-* **Flagged**, to list only posts that learners have reported as inappropriate.
-
-
-==================
-Edit Messages
-==================
-
-Discussion moderators, community TAs, and discussion admins can edit the
-content of posts, responses, and comments. Messages that include spoilers or
-solutions, or that contain inappropriate or off-topic material, should be
-edited quickly to remove text, images, or links.
-
-.. removed note for open edx re edit behavior in mobile apps. Posts can
-.. now be edited in the mobile apps (though ability depends on permissions)
-.. CT April 25, 2016
-
-#. Log in to the site and then select the course on your **Current Courses**
-   dashboard.
-
-#. Open the **Discussion** page and then open the post with the content that
-   requires editing. You can select a single topic from the drop-down list of
-   discussion topics, apply a filter, or search to locate the post.
-
-#. For the post or for the response or comment that you want to edit, select
-   the "More" icon and then **Edit**.
-
-#. Remove the problematic portion of the message, or replace it with standard
-   text such as "[REMOVED BY MODERATOR]".
-
-#. Communicate the reason for your change. For example, "Posting a solution
-   violates the honor code."
-
-==================
-Delete Messages
-==================
-
-Discussion moderators, community TAs, and discussion admins can delete the
-content of posts, responses, and comments. Posts that include spam or abusive
-language may need to be deleted, rather than edited.
-
-.. removed note for open edx re deletion behavior in mobile apps. Posts can
-.. now be deleted in the mobile apps (though ability depends on permissions)
-.. CT April 25, 2016
-
-#. Log in to the site and then select the course on your **Current Courses**
-   dashboard.
-
-#. Open the **Discussion** page and then open the post with the content that
-   requires deletion. You can select a single topic from the drop-down list of
-   discussion topics, apply a filter, or search to locate the post.
-
-#. For the post or for the response or comment that you want to delete, select
-   the "More" icon and then **Delete**.
-
-#. Select **OK** to confirm the deletion.
-
-.. how to communicate with the poster?
-
-.. important:: If a message is threatening or indicates serious harmful
- intent, contact campus security at your institution. Report the incident
- before taking any other action.
-
-==================================
-Respond to Reports of Misuse
-==================================
-
-Learners have the option to report contributions that they find inappropriate.
-Moderators, community TAs, and admins can check for messages that have been
-flagged in this way and edit or delete them as needed.
-
-.. removed note for open edx re flag behavior in mobile apps. Posts can
-.. now be flagged in the mobile apps. CT April 25, 2016
-
-#. View the live version of your course and select **Discussion** at the top of
-   the page.
-
-#. In the discussion navigation pane at the side of the page, use the filter
-   drop-down list (set to **Show all** by default) to select **Flagged**.
-
-#. Review listed posts. A post is listed if it or any of its responses or
-   comments has been reported. The reported contribution includes a
-   **Reported** identifier.
-
-#. Edit or delete the post, response, or comment. Alternatively, remove the
-   flag: select the "More" icon and then **Unreport**.
-
-===============
-Block Users
-===============
-
-For a learner who continues to misuse the course discussions, you can unenroll
-the learner from the course. For more information, see :ref:`unenroll_student`.
-If the enrollment period for the course is over, the learner cannot re-enroll.
-
-.. _Close_discussions:
-
-******************************
-Close Discussions
-******************************
-
-You can close the discussions for your course so that learners cannot add
-messages. Course discussions can be closed temporarily, such as during an exam
-period, or permanently, such as when a course ends.
-
-.. note:: You can only close discussions when you work in a web browser. You
-   cannot close discussions when you work in an edX mobile app.
-
-When you close the discussions for a course, all of the discussion topics in
-course units and all of the course-wide topics are affected.
-
-* Existing discussion contributions remain available for review.
-
-* Learners cannot add posts, respond to posts, or comment on responses.
-  However, learners can continue to vote on existing threads, follow threads,
-  or report messages for misuse.
-
-* Course team members with the Staff, Admin, Discussion Admins, Discussion
-  Moderators, and Discussion Community TAs roles are not affected when you
-  close the discussions for a course. Users with these roles can continue to
-  add to discussions.
-
-.. note:: To make sure your learners understand why they cannot add to
-  discussions, you can add the dates that discussions are closed to the
-  **Home** page and post them to a General discussion.
-
-.. _Start-End Date Format Specification:
-
-=====================================
-Start-End Date Format Specification
-=====================================
-
-To close course discussions, you supply a start date and time and an end date
-and time in Studio. You enter the values in the following format.
-
-``["YYYY-MM-DDTHH:MM", "YYYY-MM-DDTHH:MM"]``
-
-where:
-
-* The dates and times that you enter are in Coordinated Universal Time (UTC),
-  not in your local time zone. You might want to verify that you have specified
-  the times that you intend by using a time zone converter such as `Time and
-  Date Time Zone Converter`_.
-
-* You enter an actual letter **T** between the numeric date and time values.
-
-* The first date and time indicate when you want course discussions to close.
-
-* The second date and time indicate when you want course discussions to reopen.
-
-* If you do not want the discussions to reopen, enter a date that is far in the
-  future.
-
-* Quotation marks enclose each date-time value.
-
-* A comma and a space separate the start date-time from the end date-time.
-
-* Square brackets enclose the start-end value pair.
-
-* You can supply more than one complete start and end value pair. A comma and a
-  space separate each pair.
-
-For example, to close course discussions temporarily for a final exam period in
-July, you enter these start and end dates.
-
-``["2016-07-22T08:00", "2016-07-25T18:00"]``
-
-To add a blackout date that closes course discussions permanently on 9 August
-2016, you add these start and end dates.
-
-``["2016-07-22T08:00", "2016-07-25T18:00"], ["2016-08-09T00:00", "2099-08-09T00:00"]``
-
-You enter these values between an additional pair of square brackets which are
-supplied for you in Studio.
-
-============================================
-Define When Discussions Are Closed
-============================================
-
-To define when discussions are closed to new contributions and when they
-reopen, follow these steps.
-
-#. Open your course in Studio.
-
-#. Select **Settings**, and then select **Advanced Settings**.
-
-#. Locate the **Discussion Blackout Dates** field.
-
-#. If the **Discussion Blackout Dates** field is empty, place your cursor
-   between the brackets ``([ ])``.
-
-   If the field already contains one or more blackout dates, place your cursor
-   before the final bracket ``(])``.
-
-#. Enter the start and end date for the time period during which you want
-   discussions to be closed. Be sure to use the required :ref:`date format
-   specification <Start-End Date Format Specification>`.
-
-  * To define the temporary blackout period in the example above, the field
-    contains start and end dates in the following format.
-
-    ``[["2016-07-22T08:00", "2016-07-25T18:00"]]``
-
-  * To add the dates that close the discussions permanently, the field contains
-    a second pair of start and end dates in the following format.
-
-    ``[["2016-07-22T08:00", "2016-07-25T18:00"], ["2016-08-09T00:00", "2099-08-09T00:00"]]``
-
-#. Select **Save Changes**.
-
-   Studio checks the syntax of your entry and reformats your entry to add line
-   feeds and indentation. A message lets you know whether your changes were
-   saved successfully.
-
-For examples of email messages that you can send to let learners know when the
-course discussions are closed (or open), see :ref:`Example Messages to
-Students`.
+.. note:: The **Advanced Settings** page in Studio includes another field named
+   **Allow Anonymous Discussion Posts**. Setting the value of that field to
+   ``true`` enables learners to create discussion posts that are anonymous to
+   course staff, as well as to other learners. As a best practice, edX
+   recommends that you do not set this field to ``true``.
 
 
 .. _Discussions on Mobile Apps:
@@ -951,6 +271,7 @@ The following actions are not supported on the edX mobile apps.
   * Marking responses to question posts as answers
   * Endorsing responses to discussion posts
   * Closing posts
+
 
 
 .. include:: ../../../links/links.rst

--- a/en_us/shared/manage_discussions/index.rst
+++ b/en_us/shared/manage_discussions/index.rst
@@ -4,14 +4,29 @@
 Managing Discussions
 ##########################
 
+Course discussions foster interaction among learners and between learners and
+the course team. You can set up different topics to guide these interactions
+when you create your course, and then run and moderate discussions throughout
+the course to encourage participation and develop course community. Discussions
+are also excellent sources of feedback and ideas for future courses or course
+runs.
+
 Use the topics in this section to learn about managing course discussions,
-including creating discussion topics, choosing to divide topics based on
-learner groups, and moderating discussions.
+including creating discussion topics, running discussions in a live course,
+choosing to divide topics based on learner groups, building a team of
+discussion moderators, and moderating discussions.
+
+.. note:: Some features of discussions, especially moderation features, are
+   not available when discussions are accessed in the edX mobile app. For
+   information about the differences between discussions on the edx.org site
+   and in the mobile app, see :ref:`Discussions on Mobile Apps`.
 
 .. toctree::
    :maxdepth: 2
 
    discussions
+   running_discussions
    set_up_divided_discussions
    manage_divided_discussions
+   moderate_discussions
    discussion_guidance_moderators

--- a/en_us/shared/manage_discussions/manage_divided_discussions.rst
+++ b/en_us/shared/manage_discussions/manage_divided_discussions.rst
@@ -4,9 +4,9 @@
 Managing Divided Discussion Topics
 ###################################
 
-This section provides information about managing discussions that are divided
-based on one type of group in your course, either :ref:`cohorts<Cohort>` or
-:ref:`enrollment tracks<enrollment_track_g>`.
+This section provides information about managing :ref:`discussions<Discussions>`
+that are divided based on one type of group in your course, either
+:ref:`cohorts<Cohort>` or :ref:`enrollment tracks<enrollment_track_g>`.
 
 For information about divided discussions, see :ref:`About Divided Discussions`.
 
@@ -18,11 +18,11 @@ For information about divided discussions, see :ref:`About Divided Discussions`.
 Overview
 *********
 
-In discussion topics in your course, every post has an indicator of who can read
-it: either all learners, or only the members of a particular group. For
-learners, this is the only noticeable difference between discussions in courses
-that use divided discussions, and courses that do not have groups and do not use
-divided discussions.
+In :ref:`discussion topics<Discussions>` in your course, every post has an
+indicator of who can read it: either all learners, or only the members of a
+particular group. For learners, this is the only noticeable difference between
+discussions in courses that use divided discussions, and courses that do not
+have groups and do not use divided discussions.
 
 .. only:: Partners
 
@@ -39,22 +39,23 @@ divided discussions.
  help learners make the most of their participation in course discussions.
 
 
-Course team members who have the discussion admin, discussion moderator, or
-community TA role see the same indicator of who can read each post. Unlike the
-learners, however, team members with discussion privileges can read and
-contribute to every post, regardless of the group membership of the learner
-who posted it.
+Course team members who have the Discussion Admin, Discussion Moderator,
+Community TA or Group Community TA role see the indicator of who can read each
+post. Team members with these roles, except for Group Community TAs, can read
+and contribute to every post, regardless of the group membership of the learner
+who posted it. Group Community TAs can moderate discussions only if the course
+uses divided discussions, and they can see and manage only posts that other
+members of their group add. Community TAs, in comparison, can read and
+contribute to all posts.
 
-.. note:: Course team members must have the discussion moderator or discussion
- admin role in addition to the Staff or Admin role to be able to view posts
+.. note:: Course team members must have the Discussion Moderator or Discussion
+ Admin role in addition to the Staff or Admin role to be able to view posts
  that are divided by group. For information about assigning discussion
  moderation roles, see :ref:`Assigning_discussion_roles`.
 
- Learners who have the Community TA role can read and contribute to all posts.
-
 In courses where either cohorts or multiple enrollment tracks are enabled,
-course team members who have discussion moderator or admin privileges can also
-perform the following actions.
+course team members who have discussion moderation roles that are not
+restricted by group can also perform the following actions.
 
 * Choose who will be able to see the posts that they add to divided topics. See
   :ref:`Choosing the Visibility of a Post`.
@@ -62,8 +63,10 @@ perform the following actions.
 * Filter the posts that are listed on the **Discussion** page by group.
   See :ref:`Viewing the Posts of a Group`.
 
-All of the other options and features described in the :ref:`Discussions`
-section continue to be available to the discussion moderation team.
+All of the other options and features described in the :ref:`Discussions`,
+:ref:`Moderating_discussions`, and :ref:`Running_discussions` sections continue
+to be available to the discussion moderation team.
+
 
 .. _Finding Out Who Can See a Post:
 
@@ -130,7 +133,8 @@ discussion topic, the topic names indicate who can see the posts, responses,
 and comments.
 
 For more information about adding and configuring course-wide discussion
-topics, see :ref:`Create CourseWide Discussion Topics` and :ref:`Specify Which Course Wide Discussion Topics are Divided`.
+topics, see :ref:`Create CourseWide Discussion Topics` and :ref:`Specify Which
+Course Wide Discussion Topics are Divided`.
 
 
 .. _Choosing the Visibility of a Post:
@@ -139,11 +143,19 @@ topics, see :ref:`Create CourseWide Discussion Topics` and :ref:`Specify Which C
 Choosing the Visibility of a Post
 ***************************************
 
-If you have the discussion admin, discussion moderator, or community TA role,
-you can make posts to divided discussion topics visible to everyone who is
-enrolled in the course or only to the members of a specified group. When you
-:ref:`add a post<Add a Post>`, the **Visible to** dropdown list appears above
-the **Title** field.
+Course team members who have the Discussion Admin, Discussion Moderator or
+Community TA role can make posts to divided discussion topics visible to
+everyone who is enrolled in the course or only to the members of a specified
+group.
+
+If you are a course team member with one of these roles, when you :ref:`add a
+post<Add a Post>`, the **Visible to** dropdown list appears above the **Title**
+field.
+
+.. note:: Group Community TAs cannot choose the group visibility of a post.
+   Unlike Community TAs, Group Community TAs can only add post to, and interact
+   with, discussion topics that are available to the same group that they
+   themselves belong to.
 
 This example shows a new post being added to a content-specific
 discussion topic.
@@ -152,18 +164,20 @@ discussion topic.
  :alt: The fields and controls that appear when a course team member with
     discussion admin privileges clicks "Add a Post" for a divided topic.
 
-As a discussion team member, you can choose the visibility of your posts in
-topics that are divided. This means that you can add a single post with
-information that you want everyone to see, rather than having to write a
-separate post for each group. It also means that it is possible for you to
-unintentionally share information with a different audience than you intended.
+When you add a new post in discussion topics that are divided, you can choose
+whether all learners or a specific group of learners can see your post. This
+means that you can add a single post with information that you want everyone to
+see, rather than having to write a separate post for each group. It also means
+that it is possible for you to unintentionally share information with a
+different audience than you intended.
 
-.. note:: Learners do not choose the visibility of their posts. The
- visibility of learner posts is determined by the configuration of the topic
- they post in. See :ref:`Finding Out Who Can See a Post`.
+.. note:: Learners cannot choose the visibility of their posts. The visibility
+   of learner posts is determined by the configuration of the topic they post
+   in. See :ref:`Finding Out Who Can See a Post`.
 
 Posts that discussion team members add to unified discussion topics are always
 visible to all learners, regardless of what group they belong to.
+
 
 .. _Considerations When Editing Posts:
 
@@ -197,9 +211,12 @@ When a course includes cohorts or multiple enrollment tracks, you can view
 posts and monitor discussion activity for each of the groups within the group
 type that you chose to divide discussions for. You can also view all posts.
 
-.. note:: Course team members must have discussion moderator or admin
-   privileges in addition to their course team privileges to be able to view
-   and filter posts that are divided.
+.. note:: Course team members must have the Discussion Admin or Discussion
+   Moderator role in addition to the course team Staff or Admin role to be
+   able to view and filter all posts that are divided.
+
+   In divided discussions, Group Community TAs can only view posts that are
+   visible to the group that they themselves belong to.
 
 Above the discussion navigation pane on the **Discussion** page, the **in all
 groups** filter is selected by default. You see every post when you make this

--- a/en_us/shared/manage_discussions/moderate_discussions.rst
+++ b/en_us/shared/manage_discussions/moderate_discussions.rst
@@ -1,0 +1,402 @@
+.. _Moderating_discussions:
+
+#######################
+Moderating Discussions
+#######################
+
+Developing and sustaining a positive discussion culture requires that a team of
+discussion moderators dedicates sufficient time to reviewing discussions and
+responding to questions from learners. Keeping up-to-date with a large MOOC
+forum requires a commitment of five or more hours per week, and involves reading
+threads, replying to and editing posts, and communicating with the rest of the
+discussion moderation team and other members of the course team.
+
+Members of the course community, learners as well as course team members, can
+be given permission to moderate or administer course discussions through a set
+of discussion moderation or administration roles. The members of a course
+discussion team monitor discussions and keep them productive. They can also
+collect information, such as areas of particular confusion or interest, and
+relay it back to the course team.
+
+.. note:: The course team members that you set up in Studio or in the LMS are
+   not automatically granted discussion moderation roles. For information
+   about discussion roles, see :ref:`About_discussion_roles`.
+
+.. note:: Not all options for moderating discussions are available when
+   discussions are accessed using the edX mobile apps. For information about
+   the differences between discussions on the edx.org site and in the mobile
+   apps, see :ref:`Discussions on Mobile Apps`.
+
+.. contents::
+ :local:
+ :depth: 1
+
+For information about best practices for moderating discussions, see
+:ref:`Guidance for Discussion Moderators`. If you are using :ref:`divided
+discussions`<About Divided Discussions>`, see :ref:`Managing Divided Discussion
+Topics`.
+
+
+.. _About_discussion_roles:
+
+*********************************
+About Discussion Moderation Roles
+*********************************
+
+You can designate a team of people to help you run course discussions. All
+course team members can view discussion topics and posts, but only team members
+who have one of the discussion moderation roles have additional abilities to
+moderate discussions and work with posts, responses, and comments.
+
+.. important:: The course team members that you set up in Studio or in the LMS
+   are not automatically granted discussion administration roles.
+
+   Discussion moderation and administration roles must be explicitly granted
+   to members of the course team for them to be able to moderate or administer
+   course discussions. The course author and any team members who have the
+   Admin role can grant discussion roles.
+
+
+============================
+The Discussion Roles
+============================
+
+Different options for working with discussions are available through
+the following roles.
+
+.. note:: The options for moderating discussions described below are only
+   available when members of the discussion administration team work in a web
+   browser. The edX mobile apps do not currently offer moderation options.
+
+   For more information about differences between discussions on the edx.org
+   site and on the mobile apps, see :ref:`Discussions on Mobile Apps`.
+
+* Course team members with the Discussion Moderator role can edit and delete
+  messages at any level, review messages flagged for misuse, close and reopen
+  posts, pin posts, and mark responses as correct answers.
+
+  Posts, responses, and comments made by Discussion Moderators are marked with
+  a **Staff** identifier. The Discussion Moderator role is usually given to
+  course team members who already have the Staff role.
+
+* Course team members with the Discussion Admin role have the same options for
+  working with discussions as Discussion Moderators, and their posts,
+  responses, and comments have the same **Staff** identifiers.
+
+  The Discussion Admin role is typically reserved for course team members who
+  have the Admin role within the course: Discussion Admins can both moderate
+  discussions and give other users discussion moderation roles.
+
+* Some learners who are enrolled in the course can be asked to help with
+  moderating course discussions. These learners are assigned the Community
+  Teaching Assistant (TA) role, and have the same options for working with
+  discussions as Discussion Moderators do.
+
+  Posts, responses, and comments made by Community TAs are marked with a
+  **Community TA** identifier.
+
+* In courses with divided discussions, enrolled learners can be assigned the
+  Group Community TA role. Group Community TAs have the same abilities as
+  Community TAs. However, the moderation and posting abilities of Group
+  Community TAs are limited to discussion topics that are visible to members
+  of the group that they themselves belong to.
+
+  Posts, responses, and comments made by Group Community TAs are also marked
+  with a **Community TA** identifier.
+
+
+.. _Assigning_discussion_roles:
+
+*************************************
+Assigning Discussion Moderation Roles
+*************************************
+
+You must either be the course author, or have the Admin role, to add people to
+discussion moderation roles.
+
+You must obtain the email address or username for each person that you want to
+add.
+
+* To obtain the email address or username for a course team member, in the LMS
+  select **Instructor**, then select **Membership**. In the **Course Team
+  Management** section, select the current course team role (Staff or Admin) of
+  the person whose information you are looking for. From the list of course
+  team members with the selected role locate the required email address or
+  username.
+
+* To obtain the email address or username for an enrolled learner, in the LMS
+  select **Instructor**, then select **Data Download**. In the
+  **Reports** section, select **Download profile information as a CSV**. In the
+  downloaded file, locate the required email address or username.
+
+
+====================================
+Add Someone To a Discussion Role
+====================================
+
+You can add any user who is already enrolled in your course to a discussion
+moderation role.
+
+.. note:: To add someone to the Discussion Admin role, you must be the course
+   author or a course team member who has the Admin role.
+
+#. View the live version of the course.
+
+#. Select **Instructor**, and then select **Membership**.
+
+#. In the **Course Team Management** section, select the discussion role that
+   you want to assign: **Discussion Admins**, **Discussion Moderators**,
+   **Group Community TA**, or **Community TA**.
+
+#. Under the list of users who currently have that role, enter the email address
+   or username of the person you want to add.
+
+#. Select **Add** for the role type.
+
+   The person who you added appears in the list.
+
+
+======================================
+Remove Someone from a Discussion Role
+======================================
+
+To remove someone from a discussion moderation role, you must be the course
+author or have the Admin role.
+
+#. View the live version of the course.
+
+#. Select **Instructor**, and then select **Membership**.
+
+#. In the **Course Team Management** section, select the discussion role from
+   which you want to remove the user: **Discussion Admins**, **Discussion
+   Moderators**, **Group Community TA**, or **Community TA**.
+
+#. In the list of users who currently have that role, locate the user you
+   want to remove, and then select **Revoke access**.
+
+   The person who you removed no longer appears in the list.
+
+
+*******************************
+Provide Guidelines for Learners
+*******************************
+
+You can develop a set of best practices for discussion participation and make
+them available to learners as a course handout file or on a defined page in
+your course. These guidelines can define your expectations and optionally
+introduce features of edX discussions.
+
+.. only:: Partners
+
+ You can also refer learners to the :ref:`learners:Course Discussions Index`
+ section in the *EdX Learner's Guide*. Consider referring learners in your
+ courses to that section, which describes the structure and features of edX
+ course discussions, and provides useful information to help learners make the
+ most of their participation in course discussions.
+
+.. only:: Open_edX
+
+ You can also refer learners to the :ref:`openlearners:Course Discussions
+ Index` section in the *Open EdX Learner's Guide*. Consider referring learners
+ in your courses to that section, which describes the structure and features of
+ edX course discussions, and provides useful information to help learners make
+ the most of their participation in course discussions.
+
+.. For a template that you can use to develop your own guidelines, see
+.. :ref:`Discussion Forum Guidelines`.
+
+
+.. _Develop a Positive Discussion Culture:
+
+***************************************
+Develop a Positive Discussion Culture
+***************************************
+
+Team members who are moderating discussions can cultivate qualities in their
+own discussion interactions to make their influence positive and their time
+productive.
+
+* Encourage quality contributions: thank learners whose posts have a positive
+  impact and who answer questions.
+
+* Check links, images, and videos in addition to the text of each message. Edit
+  offensive or inappropriate posts quickly, and explain why.
+
+* Review posts with a large number of votes and recognize "star posters"
+  publicly and regularly.
+
+* Stay on topic yourself: before responding to a post, be sure to read it
+  completely.
+
+* Maintain a positive attitude. Acknowledge problems and errors without
+  assigning blame.
+
+* Provide timely responses. More time needs to be scheduled for answering
+  discussion questions when deadlines for homework, quizzes, and other
+  milestones approach.
+
+* Discourage redundancy: before responding to a post, search for similar posts.
+  Make your response to the most pertinent or active post and then copy its URL
+  and use it to respond to the redundant threads.
+
+* Publicize issues raised in the discussions: add questions and their answers
+  to an FAQ topic, or announce them on the **Home** page.
+
+For a template that you can use to develop guidelines for your course
+moderators, see :ref:`Guidance for Discussion Moderators`.
+
+.. _Find Question Posts and Discussion Posts:
+
+********************************
+Find Questions and Discussions
+********************************
+
+When learners create posts, they specify the type of post to indicate whether
+they are asking for concrete information (a question) or starting an open-ended
+conversation (a discussion).
+
+On the **Discussion** page, a question mark image identifies posts that ask
+questions, and a conversation bubble image identifies posts that start
+discussions. When an answer is provided and marked as correct for a question, a
+check or tick mark image replaces the question mark image. For more
+information, see :ref:`Answer Questions`.
+
+The titles and icons of posts that you have not yet read appear in blue, with
+a blue vertical bar on the post's left side. Posts that you have read have
+dark gray titles and icons. When new responses and comments are made on posts
+that you have read, a "new" indicator displays with the number of new
+responses or comments that you have not yet read.
+
+.. image:: ../../../shared/images/Discussion_ReadUnreadNew.png
+  :width: 300
+  :alt: The discussion navigation pane, showing some unread and some read
+     posts, including a post that has been read but now has additional new
+     responses or comments.
+
+In addition to these visual cues, filters can help you find questions and
+discussions that need review. In the discussion navigation pane on the
+**Discussion** page, you can also select the following options from the **Show
+all** drop-down menu.
+
+* **Unread**, to list only the discussions and questions that you have not yet
+  viewed.
+
+* **Unanswered**, to list only questions that do not yet have any responses
+  marked as answers.
+
+* **Flagged**, to list only posts that learners have reported as inappropriate.
+
+
+****************
+Edit Messages
+****************
+
+Team members with the Discussion Moderator, Discussion Admin, Community TA or
+Group Community TA role can edit the content of posts, responses, and
+comments. Messages that include spoilers or solutions, or that contain
+inappropriate or off-topic material, should be edited quickly to remove text,
+images, or links.
+
+.. removed note for open edx re edit behavior in mobile apps. Posts can
+.. now be edited in the mobile apps (though ability depends on permissions)
+.. CT April 25, 2016
+
+#. View the live version of the course.
+
+#. On the **Discussions** page, open the post with the content that requires
+   editing. You can select a single topic from the drop-down list of
+   discussion topics, apply a filter, or search to locate the post.
+
+#. For the post or for the response or comment that you want to edit, select
+   the "More" icon and then **Edit**.
+
+#. Remove the problematic portion of the message, or replace it with standard
+   text such as "[REMOVED BY MODERATOR]".
+
+#. Communicate the reason for your change. For example, "Posting a solution
+   violates the honor code."
+
+****************
+Delete Messages
+****************
+
+Team members with the Discussion Moderator, Discussion Admin, Community TA or
+Group Community TA role can delete posts, responses, or comments. It might be
+more appropriate to delete rather than edit posts that consist of spam or
+include abusive language.
+
+.. removed note for open edx re deletion behavior in mobile apps. Posts can
+.. now be deleted in the mobile apps (though ability depends on permissions)
+.. CT April 25, 2016
+
+#. View the live version of the course.
+
+#. On the **Discussion** page, open the post with the content that requires
+   deletion. You can select a single topic from the drop-down list of
+   discussion topics, apply a filter, or search to locate the post.
+
+#. For the post or for the response or comment that you want to delete, select
+   the "More" icon and then **Delete**.
+
+#. Select **OK** to confirm the deletion.
+
+.. important:: If a message is threatening or indicates serious harmful
+ intent, contact campus security at your institution. Report the incident
+ before taking any other action.
+
+
+********************************
+Respond to Reports of Misuse
+********************************
+
+Learners have the option to report contributions that they find inappropriate.
+Team members with the Discussion Moderator, Discussion Admin, Community TA or
+Group Community TA role can check for messages that have been flagged in this
+way and edit or delete them as needed.
+
+.. removed note for open edx re flag behavior in mobile apps. Posts can
+.. now be flagged in the mobile apps. CT April 25, 2016
+
+#. View the live version of your course and select **Discussion** at the top of
+   the page.
+
+#. In the discussion navigation pane at the side of the page, use the filter
+   drop-down list (set to **Show all** by default) to select **Flagged**.
+
+#. Review listed posts. A post is listed if it or any of its responses or
+   comments has been reported. The reported contribution includes a
+   **Reported** identifier.
+
+#. Edit or delete the post, response, or comment. Alternatively, remove the
+   flag: select the "More" icon and then **Unreport**.
+
+
+*****************************************************
+View Profile Information for Discussion Participants
+*****************************************************
+
+To find out more about a specific discussion participant, you can view that
+learner's edX profile from their linked username on discussion posts.
+
+To access a learner's profile from a discussion post that they contributed,
+follow these steps.
+
+#. On the **Discussion** page, select a username in a post, response, or
+   comment.
+
+#. On the discussion page for that learner, select the linked username.
+
+   The learner's account profile page opens. Learners can have either a limited
+   profile or a full profile.
+
+For more information about profiles, see :ref:`learners:SFD Dashboard`.
+
+
+****************
+Block Users
+****************
+
+If a learner repeatedly misuses course discussions despite being warned, you
+can unenroll that learner from the course. For more information, see
+:ref:`unenroll_student`. The learner cannot re-enroll in the course if the
+enrollment period for the course is over.

--- a/en_us/shared/manage_discussions/running_discussions.rst
+++ b/en_us/shared/manage_discussions/running_discussions.rst
@@ -1,0 +1,282 @@
+.. _Running_discussions:
+
+
+############################
+Running Course Discussions
+############################
+
+On an ongoing basis, the members of your :ref:`discussion
+team<Assigning_discussion_roles>` run the course discussion by adding posts
+and responses, marking answers as correct, and guiding learner messages into
+pertinent threads. The information and suggested techniques in this section
+can help you to make discussions in your course successful.
+
+For information about moderating discussions, see
+:ref:`Moderating_discussions` and :ref:`Guidance for Discussion Moderators`.
+
+.. contents::
+ :local:
+ :depth: 1
+
+.. _Elements of discussions:
+
+******************************************
+Understanding the Elements of a Discussion
+******************************************
+
+Learners and the course team use course discussions to share ideas, exchange
+views, consider different viewpoints, and ask questions. In course discussions
+there are three hierarchical levels of interaction.
+
+* A post is the first level of interaction. A post opens a new subject. Posts
+  can be made as questions, to solicit a concrete answer, or as discussions,
+  to start a conversation. When participants add a post, they must choose an
+  existing topic to associate it with, and decide whether to add it as a
+  **Question** or as a **Discussion**.
+
+* A response is the second level of interaction. A response is a reply made
+  directly to a post to provide a solution or continue the conversation.
+
+* A comment is the third level of interaction. A comment is often a
+  clarification or side note made to a specific response, rather than to the
+  post as a whole.
+
+The dialog created by a post, its responses, and the comments on those
+responses is sometimes called a thread. Discussion threads are saved as part
+of the course history.
+
+.. only:: Partners
+
+ For information about participating in discussions, see the
+ :ref:`learners:Course Discussions Index` section in the *EdX Learner's Guide*.
+ Consider referring learners in your courses to that section, which describes
+ the structure and features of edX course discussions, and provides useful
+ information to help learners make the most of their participation in course
+ discussions.
+
+.. only:: Open_edX
+
+ For information about participating in discussions, see the
+ :ref:`openlearners:Course Discussions Index` section in the *Open edX
+ Learner's Guide*. Consider referring learners in your courses to that section,
+ which describes the structure and features of course discussions, and provides
+ useful information to help learners make the most of their participation in
+ course discussions.
+
+
+************************************************
+Using Naming Conventions for Discussion Topics
+************************************************
+
+To identify certain types of messages and make them easier to find, you can
+define a set of standard tags to include in the subject of a post or in the
+body of a response or comment. Examples follow.
+
+* Use "[OFFICIAL]" at the start of announcements about course details or
+  changes.
+
+* Provide information about corrections in course assignments with a subject
+  that begins "[CORRECTION]" or "[ERRORS]".
+
+* Ask learners to use "[STAFF]" in the subject of each post that needs the
+  attention of a course team member.
+
+Both the discussion team and your learners can use tags like these to search
+the discussions more effectively.
+
+When a post is created its type must be selected: either "question" or
+"discussion". Members of the discussion team should be thoughtful when
+selecting the type for their posts, and encourage learners to do the same. For
+more information, see :ref:`Find Question Posts and Discussion Posts`.
+
+.. future: changing the type of a post, maybe resequence or separate  conventions from post types
+
+**************************
+Seeding Discussion Topics
+**************************
+
+To help learners learn how to get the most out of course discussions, and find
+the best discussion topic to use for their questions and conversations, you can
+seed discussion topics in course-wide discussion topics before the course
+starts.
+
+Some examples follow.
+
+* In the "General" topic (which is included in every course by default), add an
+  [INTRO] post to initiate a thread for learner and course team introductions.
+
+* For each course-wide discussion topic that you create, add an initial post
+  to describe the way you intend that discussion to be used. In addition to
+  providing guidance, these initial messages can act as models for learners to
+  follow when they create their own posts.
+
+EdX strongly recommends that you do not create seed posts in content-specific
+discussion topics before the course starts or before the containing unit is
+released. The category and subcategory names for content-specific discussion
+topics are subject to the release visibility of their containing unit, and are
+not visible until the unit is released. For more details, see :ref:`Visibility
+of Discussion Topics`.
+
+
+*******************************
+Minimizing Thread Proliferation
+*******************************
+
+To encourage longer, threaded discussions rather than many similar, separate
+posts, the discussion team can use the following techniques. However, be aware
+that very long threads (with more than 200 responses and comments) can be
+difficult to read, and might result in an unsatisfactory experience in the
+discussion.
+
+.. note:: You can only pin or close posts and mark questions as answered when
+   you work in a web browser. You cannot complete these activities when you
+   work in the edX mobile app.
+
+* Pin posts. Pinning a post makes it appear at the top of the list of posts in
+  the discussion navigation pane on the **Discussion** page. As a result, it is
+  more likely that learners will see and respond to pinned posts. You can write
+  your own post and then pin it, or pin a post by any author. Select the "More"
+  icon and then **Pin**.
+
+  .. image:: ../../../shared/images/Discussion_Pin.png
+   :alt: The pin icon for discussion posts.
+
+* Mark responses as answered or endorsed. Depending on whether a post is a
+  question or a discussion, you use the same option to mark a response either
+  as the answer to the posted question, or to endorse a response. Marking a
+  question as answered makes it easier for learners to find answers to already
+  asked questions, rather than ask the same question again. Endorsing a
+  response confirms that it adds value to a discussion.
+
+  To mark a response as answered or endorsed, select the "check mark" icon.
+  You cannot mark your own responses as answers or as endorsed.
+
+  .. image:: ../../../shared/images/Discussion_MarkAsAnswer.png
+   :alt: The "check mark" icon for marking a response as the correct answer
+         to a question.
+
+* Vote for posts or responses. Learners can sort discussions by posts with the
+  most votes, so posts and responses with many votes are more likely to be
+  read and responded to. Select the "plus" icon for the response. You cannot
+  vote for your own posts.
+
+  .. image:: ../../../shared/images/Discussion_vote.png
+   :alt: The "plus" icon for voting for discussion posts.
+
+* Close posts. You can respond to a redundant post by (optionally) pasting in
+  a link to the post that you prefer learners to contribute to, and prevent
+  further interaction by closing the post. Select the "More" icon and then
+  **Close**.
+
+* Provide post/response/comment guidelines. You can post information from the
+  :ref:`overview<Overview_discussions>` in this section, or the :ref:`anatomy of
+  edX discussions<Anatomy of edX Course Discussions>` in the next section, in a
+  course-wide discussion topic (such as "General") to provide guidance about
+  when to start a new thread by adding a post, responding to an existing post,
+  or commenting on a response.
+
+
+.. _Close_discussions:
+
+********************
+Closing Discussions
+********************
+
+You can close the discussions for your course so that learners cannot add
+messages to topics. Course discussions can be closed temporarily, such as
+during an exam period, or permanently, such as when a course ends.
+
+.. note:: When you close discussions, make sure you communicate with learners
+   in your course to let them know why they cannot contribute to discussions,
+   and the dates that discussions are affected. You can post a course update
+   to the **Home** page as well as add a pinned information post to a course-wide
+   discussion topic.
+
+When you close the discussions for a course, all discussion topics in course
+units and all course-wide topics are affected.
+
+* Existing discussion contributions remain viewable.
+
+* Learners cannot add posts, respond to posts, or comment on responses.
+  However, learners can continue to vote on existing threads, follow threads,
+  or report messages for misuse.
+
+* Course team members who have any of the Staff, Admin, Discussion Admin,
+  Discussion Moderator, Community TA, or Group Community TA roles are not
+  affected when you close the discussions for a course. Users with these roles
+  can continue to add to discussions.
+
+
+============================================
+Specify When Discussions Are Closed
+============================================
+
+.. note:: You can only close discussions when you work in a web browser. You
+   cannot close discussions when you work in an edX mobile app.
+
+To define when discussions are closed to new contributions and when they
+reopen, follow these steps.
+
+#. Open your course in Studio.
+
+#. Select **Settings**, and then select **Advanced Settings**.
+
+#. Locate the **Discussion Blackout Dates** field.
+
+#. If the **Discussion Blackout Dates** field is empty, place your cursor
+   between the brackets ``([ ])``.
+
+   If the field already contains one or more blackout dates, place your cursor
+   before the final bracket ``(])``.
+
+#. Enter a pair of start and end dates for the time period during which you want
+   discussions to be closed, in the following format.
+
+   ``["YYYY-MM-DDTHH:MM", "YYYY-MM-DDTHH:MM"]``
+
+   .. note:: To close the course discussions permanently, specify an end date
+     and time far in the future.
+
+   * Within each date-time value, separate the date from the time with an
+     uppercase letter "T".
+
+   * Enclose each date-time value in double quotation marks.
+
+   * Separate the start date-time from end date-time with a comma and a space.
+
+   * Enclose each pair of start and end dates in square brackets.
+
+   For example, to close course discussions temporarily for a final exam period
+   from July 22, 2017 to July 25, 2017, you enter this pair of start and end
+   dates.
+
+   ``["2017-07-22T08:00", "2017-07-25T18:00"]``
+
+   To close course discussions permanently on August 9, 2017 after the
+   temporary exam period closure, you add an additional pair of start and end
+   dates.
+
+   ``["2017-07-22T08:00", "2017-07-25T18:00"], ["2017-08-09T00:00", "2099-08-09T00:00"]``
+
+   You enter these values between an additional pair of square brackets which
+   are supplied for you in Studio.
+
+#. Select **Save Changes**.
+
+   Studio checks the syntax of your entry and reformats your entry to add line
+   feeds and indentation. A message lets you know whether your changes were
+   saved successfully.
+
+For examples of email messages that you can send to let learners know when the
+course discussions are closed (or open), see :ref:`Example Messages to
+Students`.
+
+
+``["YYYY-MM-DDTHH:MM", "YYYY-MM-DDTHH:MM"]``
+
+.. note:: The dates and times that you enter are in Coordinated Universal
+   Time (UTC), not in your local time zone. You might want to verify that you
+   have specified the times that you intend by using a time zone converter.
+
+
+

--- a/en_us/shared/manage_discussions/set_up_divided_discussions.rst
+++ b/en_us/shared/manage_discussions/set_up_divided_discussions.rst
@@ -42,13 +42,25 @@ Discussion topics that are not divided are unified, meaning that all learners
 in the course can see and respond to posts, responses, and comments from any
 other learner in the course.
 
-If you divide discussions, a good practice is to also apply a naming
-convention so that learners clearly see the audience for the discussion topics
-before they add posts to that topic. For information about naming conventions,
-see :ref:`Apply Naming Conventions to Discussion Topics`.
+=======================================
+Best Practices for Divided Discussions
+=======================================
 
-For more information about managing divided discussions, see :ref:`Managing
-Divided Discussion Topics`.
+If you divide discussions, a good practice is to use a naming convention for
+discussion topics, so that learners clearly understand the audience for a
+discussion topic before they add posts to that topic. For information about
+naming conventions, see :ref:`Apply Naming Conventions to Discussion Topics`.
+
+You can also choose to appoint learners as Community TAs or Group Commmunity
+TAs to help you to moderate course discussions. You might choose to use Group
+Community TAs if the content of discussion topics by one group should not be
+shared with another group. Group Community TAs are themselves members of
+groups that you use in your course (such as cohorts or enrollment tracks). As
+discussion moderators, they can only see and respond to posts by other members
+of their own group. For information, see :ref:`Assigning_discussion_roles`.
+
+For more information about managing discussions, see :ref:`Managing Divided
+Discussion Topics` and :ref:`Running_discussions`.
 
 .. note::
 
@@ -72,16 +84,17 @@ In this example, you are developing a course that has two enrollment tracks:
 enrollment track, so that learners in each track have a complete course
 experience, but have different assignments and projects.
 
-You will need to decide whether any of the course-wide discussion topics and
-content-specific discussion topics should be divided based on enrollment
-track.
+You will need to decide whether any of the :ref:`course-wide discussion
+topics<Create CourseWide Discussion Topics>` and :ref:`content-specific
+discussion topics<Create ContentSpecific Discussion Topics>` should be divided
+based on enrollment track.
 
 =============================
 Course-Wide Discussion Topics
 =============================
 
-As you develop your course, you add three new course-wide discussion topics,
-so that in addition to the default General topic, you have a total of four
+As you develop your course, you add three new course-wide discussion topics, so
+that in addition to the default "General" topic, you have a total of four
 course-wide discussion topics.
 
 * General

--- a/en_us/shared/releasing_course/beta_testing.rst
+++ b/en_us/shared/releasing_course/beta_testing.rst
@@ -318,16 +318,16 @@ To add multiple beta testers:
 
 #. To send an email message to the beta testers, leave **Notify users by
    email** selected. An example of the message that is sent to a beta tester
-   who is not enrolled in the course follows.
+   who is not enrolled in the course follows.::
 
-   ::
-      Dear betatester,
+    Dear betatester,
 
-      You have been invited to be a beta tester for *course* at edge.edx.org
-      by a member of the course team.
+    You have been invited to be a beta tester for *course* at edge.edx.org
+    by a member of the course team.
 
-      Visit https://edge.edx.org/courses/course-name/about to join the course
-      and begin the beta test.
+    Visit https://edge.edx.org/courses/course-name/about to join the course
+    and begin the beta test.
+
 
 #. Select **Add beta testers**.
 
@@ -335,30 +335,38 @@ To remove the Beta Tester role from one or more users, enter their email
 addresses in the **Batch Add Beta Testers** field and then select **Remove beta
 testers**.
 
-.. note:: The **Auto Enroll** option has no effect when you select **Remove
- beta testers**. The user's role as a beta tester is removed; course
- enrollment is not affected.
+.. note:: When you select **Remove beta testers**, the **Auto Enroll** option is
+   not affected. The user's role as a beta tester is removed, but they remain
+   enrolled in the course.
+
 
 ================================
 Add Beta Testers Individually
 ================================
 
-#. View the live version of your course.
 
-#. Select **Instructor** then **Membership**.
+#. View the live version of the course.
 
-#. In the **Administration List Management** section, use the drop-down list to
-   select **Beta Testers**.
+#. Select **Instructor**, and then select **Membership**.
 
-#. Under the list of users who currently have that role, enter an email address
-   or username and click **Add Beta Tester**.
+#. In the **Course Team Management** section, select **Beta Testers**.
 
-   If the beta test starts before the **Enrollment Start Date** of your course,
-   you can also enroll the beta tester. See :ref:`Enrollment`.
+#. Under the list of users who currently have that role, enter the email address
+   or username of the person you want to add.
+
+#. Select **Add Beta Tester**.
+
+   The person who you added appears in the list of beta testers.
+
+
+.. note::  If the beta test starts before the **Enrollment Start Date** of your
+   course, you can also enroll the beta tester. See :ref:`Enrollment`.
+
 
 To remove the Beta Tester role from users individually, find the user in the
 list of beta testers, and then select **Revoke access** to the right of that
 user's email address.
+
 
 .. _Issue_Reporting_During_Course:
 

--- a/en_us/shared/set_up_course/planning_course_run_information/staffing.rst
+++ b/en_us/shared/set_up_course/planning_course_run_information/staffing.rst
@@ -92,9 +92,27 @@ Administrative Team Roles
 ****************************
 
 To provide access to features on the instructor dashboard in the LMS, you
-assign the Staff role or the Admin role.
+can assign the Staff role or the Admin role to course team members.
 
-Team members with the **Staff** role can complete the following tasks.
+Team members who have either of these roles can work on your course in Studio
+immediately, and can also use the LMS and Insights. For more information about
+assigning roles while you run your course, see :ref:`Course_Staffing`.
+
+You can also designate teams of people to beta test your course and to
+moderate and manage its discussions by assigning other LMS roles. The beta
+testers and discussion administrators must be enrolled in your course, but
+they do not need to have Staff or Admin access. For more information, see
+:ref:`Beta_Testing` and :ref:`Assigning_discussion_roles`.
+
+For more information about how to add course team members, see
+:ref:`Studio_Course_Staffing`.
+
+
+==================
+The Staff Role
+==================
+
+Course team members who have the Staff role can complete the following tasks.
 
 * View the course before the course start date.
 
@@ -109,36 +127,32 @@ Team members with the **Staff** role can complete the following tasks.
 
 * Activate course certificates.
 
-Course team members who have the **Admin** role can complete all the tasks that
-course team members who have the Staff role can complete. They can also
-complete the following tasks.
+==================
+The Admin Role
+==================
+
+Course team members who have the Admin role can complete all the tasks that team
+members who have the Staff role can complete. In addition, they can complete the
+following tasks.
 
 * Access and modify grades for all learners in a course. For example, users
   with the Admin role can reset all learners' attempts to answer a question.
 
-* Add and remove staff.
+* Add team members to, and remove them from, the Staff role.
 
-* Add and remove other admins.
+* Add team members to, and remove them from, the Admin role.
 
-* Add and remove beta testers.
+* Add and remove team members as beta testers.
 
-* Add and remove discussion admins, discussion moderators, and discussion
-  community TAs.
+* Add team members to, and remove them from, the Discussion Admin or
+  Discussion Moderator role.
 
-  .. note:: To moderate course discussions, team members must have one
-   of these discussion roles assigned to them *in addition to* the Staff or
-   Admin role. For more information, see :ref:`Assigning_discussion_roles`.
+* Add enrolled learners to, and remove them from, the Community TA or Group
+  Community TA role.
 
-Regardless of where the role is assigned, these administrative team members can
-work on your course in Studio immediately, and use the LMS and Insights after
-enrollment. For more information about assigning roles while you run your
-course, see :ref:`Course_Staffing`.
+  .. note:: To moderate course discussions, team members must explicitly be
+     added to a discussion moderation role in addition to having the course
+     team Staff or Admin role. For more information, see
+     :ref:`Assigning_discussion_roles`.
 
-You can also designate teams of people to beta test your course and to
-moderate and manage its discussions by assigning other LMS roles. The beta
-testers and discussion administrators must be enrolled in your course, but
-they do not need to have Staff or Admin access. For more information, see
-:ref:`Beta_Testing` and :ref:`Assigning_discussion_roles`.
 
-For more information about how to add course team members, see
-:ref:`Studio_Course_Staffing`.

--- a/en_us/shared/set_up_course/studio_add_course_information/studio_course_staffing.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/studio_course_staffing.rst
@@ -14,39 +14,6 @@ For more information about selecting course team members, see
   :local:
   :depth: 1
 
-.. _Assign Course Team Roles:
-
-*************************
-Assign Course Team Roles
-*************************
-
-Assigning a course team role to a user both adds the user to the course team
-and assigns the role to that user.
-
-Before you can assign the Staff or Admin role to a team member, you must meet
-these prerequisites.
-
-* You must have the Admin role.
-
-* You need the email address or username of each team member you want to add.
-
-* Each of those team members must register a user account for that email
-  address or username, activate the account, and enroll in your course.
-
-To assign a privileged role to a course team member, follow these steps.
-
-#. View the live version of your course.
-
-#. Select **Instructor**, and then select **Membership**.
-
-#. In the **Course Team Management** section, select **Staff** or **Admin**.
-
-#. Under the list of users who currently have that role, enter an email
-   address or username, and then select **Add** for the role type.
-
-To remove an assigned role, view the list of users and then select **Revoke
-access**.
-
 
 .. _Add Course Team Members:
 
@@ -54,11 +21,10 @@ access**.
 Add Course Team Members
 ************************
 
-Course team members are users who help you build your course. Before you can
-assign Staff or Admin access to a team member, you must meet these
-prerequisites.
+Course team members are users who help you build your course. To add someone
+to the course team, you must meet these prerequisites.
 
-* You must be an Admin.
+* You must have the Admin role in the course.
 
 * The team member that you want to add must register a user account and
   activate the account.
@@ -90,5 +56,41 @@ The new team member can now work on the course in Studio.
 
 You can also assign privileged roles to users when you work in the LMS by
 selecting **Instructor** and then **Membership**.
+
+
+.. _Assign Course Team Roles:
+
+*************************
+Assign Course Team Roles
+*************************
+
+Assigning a course team role to a user both adds the user to the course team
+and assigns the role to that user.
+
+To assign the Staff or Admin role to a team member, you must meet these
+prerequisites.
+
+* You must have the Admin role in the course.
+
+* You need the email address or username of each team member you want to add.
+
+* Each of those team members must register a user account for that email
+  address or username, activate the account, and enroll in your course.
+
+To assign a privileged role to a course team member, follow these steps.
+
+#. View the live version of your course.
+
+#. Select **Instructor**, and then select **Membership**.
+
+#. In the **Course Team Management** section, select **Staff** or **Admin**.
+
+#. Under the list of users who currently have that role, enter an email
+   address or username, and then select **Add** for the role type.
+
+To remove an assigned role, view the list of users and then select **Revoke
+access**.
+
+
 
 


### PR DESCRIPTION
## [DOC-3798](https://openedx.atlassian.net/browse/DOC-3798)
## [DOC-3683](https://openedx.atlassian.net/browse/DOC-3683)
## [DOC-3684](https://openedx.atlassian.net/browse/DOC-3684)

Add new Group Community TA discussion role.
Also, break existing long topics into shorter ones.
Make sure styles/formats for role names are consistent, here and in http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/set_up_course/planning_course_run_information/staffing.html

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @staubina 
- [x] Subject matter expert: @ssemenova 
- [x] Doc team review: @grantgoodmanedX 
- [x] Product review: @sstack22 

FYI: @dhixonedx, @jhendersonedx, @mmacfarlane

### HTML Version
- [x] http://draft-ca-groupcommunityta-role.readthedocs.io/en/latest/manage_discussions/index.html

### Testing
- [x] Ran ./run_tests.sh with no errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

