### PR TITLE
Fix typo in run_xsscommitlint.

### DIFF
--- a/en_us/developers/source/conventions/preventing_xss.rst
+++ b/en_us/developers/source/conventions/preventing_xss.rst
@@ -940,7 +940,7 @@ command.
 
 .. code-block:: bash
 
-    paver run_xssecommitlint
+    paver run_xsscommitlint
 
 To run the linter on the entire edx-platform repository, use the following
 command.


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

Fix minor typo.

FYI: @cahrens 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits