### PR TITLE
Add mobile to list of devices for edx.forum.thread.viewed event

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs.rst
@@ -4170,7 +4170,7 @@ complete, the server emits an ``edx.forum.thread.created`` event.
 *********************************
 
 A user views a thread in the course discussions on a desktop, laptop, or tablet
-computer.
+computer, or on the edX mobile apps.
 
 **Component**: Discussion
 


### PR DESCRIPTION
## [DOC-3657](https://openedx.atlassian.net/browse/DOC-3657)

Mention that the event is emitted for mobile devices.

### Date Needed (optional)

13 Jul 17

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
 
- [ ] Doc team review (sanity check): @edx/doc


### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

