### PR TITLE
Add note about LaTeX previewing in ORA2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Kyle Boots <indagation@gmail.com>
 Dennis Jen <djen@edx.org>
 Justin Leong <justin.leong@ubc.ca>
 Brian Jacobel <bjacobel@edx.org>
+Brandon DeRosier <x@bdero.me>

--- a/en_us/shared/students/SFD_ORA.rst
+++ b/en_us/shared/students/SFD_ORA.rst
@@ -168,6 +168,12 @@ steps.
       For information about uploading images or other files in your ORA
       assignment, see :ref:`Submit a File with Your Response`.
 
+   .. note::
+
+      For assignments that require LaTeX responses, a **Preview in LaTeX**
+      option is available that you can use to preview your work before you
+      submit your response.
+
 #. When you have finished answering all of the questions, select **Submit
    your response and move to the next step**.
 


### PR DESCRIPTION
## [DOC-3718](https://openedx.atlassian.net/browse/DOC-3718)

This PR adds a note about the LaTeX previewing feature an ORA2, which was expanded in [this PR](https://github.com/edx/edx-ora2/pull/1022) and fixed in [this PR](https://github.com/edx/edx-ora2/pull/1016)

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @e-kolpakov 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

