### PR TITLE
Fix XBlock SDK database migration

### DIFF
--- a/en_us/xblock-tutorial/source/reusable/create_db.rst
+++ b/en_us/xblock-tutorial/source/reusable/create_db.rst
@@ -6,11 +6,11 @@ Before running the XBlock SDK the first time, you must create the SQLite
 database.
 
 #. In the ``xblock_development`` directory, run the following command to create
-   the database.
+   the database and the tables.
 
    .. code-block:: none
 
-      (venv) $ python xblock-sdk/manage.py syncdb
+      (venv) $ python xblock-sdk/manage.py migrate
 
 #. You are prompted to indicate whether or not to create a Django superuser.
 


### PR DESCRIPTION
The latest XBlock SDK version (v0.1.4) is compatible with Django 1.11,
but not Django 1.8. Consequently, the `syncdb` command will not work
with v0.1.4. To address this problem in the Open edX documentation, we
choose to stick with the same Django version as Ficus/Ginkgo.

Affected user: https://openedx.slack.com/archives/C0GF6FTHA/p1500890543190218
(I know another faced this problem before, but I can't remember who)

### Date Needed

It would be great if this change was pushed to the official documentation as soon as possible, because XBlock developer currently can't create new XBlocks by following the documentation. The error that they obtain is cryptic ("no such table: workbench_xblockstate").

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @mhoeber (wrote the rest of the documentation page)

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

```
********** All builds done ************
TOTAL SPHINX ERRORS: 0
TOTAL SPHINX WARNINGS: 8
OTHER BUILD ERRORS: 0
There were problems while building the following projects:
en_us/course_authors
en_us/open_edx_course_authors
```

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

