### PR TITLE
API account requirements - regular account

### DIFF
--- a/en_us/course_catalog_api_user_guide/source/authentication/index.rst
+++ b/en_us/course_catalog_api_user_guide/source/authentication/index.rst
@@ -95,18 +95,6 @@ The following example shows a client ID and client secret.
     API Client Secret: wDSbvs7vs5Xj9P9oE73pAV6L4iZxfPdPjagkBdmLzqtQ6lqu2IMXuTt
     upD2TmaMB3MPmrKEZbtaFMUqjZKzg98xMu5QzboPDQSBL72hjQ7r7IfrutVMZF8AGXn9LqZmk
 
-.. _Obtain EdX User Account and Sign In:
-
-===================================
-Obtain EdX User Account and Sign In
-===================================
-
-To obtain an edX user account, contact the edX marketing team. The team will
-send you an account username and instructions for setting your password.
-
-To sign in to edX and change your password, go to
-https://courses.edx.org/login.
-
 
 .. _CC API Complete Access Request Form:
 
@@ -114,8 +102,10 @@ https://courses.edx.org/login.
 Complete the EdX API Access Request Form
 ========================================
 
-After you have signed in to edX, follow these steps.
+To request access to the edX Course Catalog API, follow these steps.
 
+#. Sign in to edX at https://courses.edx.org/login. If you don't already have
+   an edX account, create an account.
 #. Go to http://courses.edx.org/api-admin.
 #. On the **EdX API Access Request** page, enter the information for your
    organization. All fields are required.


### PR DESCRIPTION
## [DOC-3736](https://openedx.atlassian.net/browse/DOC-3736)

I removed a short section about obtaining an edX account to use the catalog API. Users should just use their regular edX account, or create one if for some reason they don't already have one.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check, copy edit): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

