### PR TITLE
Add info for edx.grades.subsection.score_overridden event

### DIFF
--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -152,6 +152,8 @@ D, E, F
      - :ref:`grading_events`
    * - ``edx.grades.subsection.grade_calculated``
      - :ref:`grading_events`
+   * - :ref:`edx_grades_subsection_score_overridden`
+     - :ref:`grading_events`
    * - ``edx.instructor.report.downloaded``
      - :ref:`course_reporting_events`
    * - ``edx.instructor.report.requested``

--- a/en_us/data/source/internal_data_formats/tracking_logs/course_team_event_types.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs/course_team_event_types.rst
@@ -756,6 +756,53 @@ this event as they do for the :ref:`edx_grades_course_grade_calculated` event.
 * ``event_transaction_id``
 * ``event_transaction_type``
 
+.. _edx_grades_subsection_score_overridden:
+
+==========================================
+``edx.grades.subsection.score_overridden``
+==========================================
+
+The server emits this event when a member of edX support staff overrides or
+removes the override of a learner's subsection score by performing one of the
+following actions.
+
+* Selecting "Suspicious" as the status of a proctored exam review.
+* Changing the status of a proctored exam review to from "Suspicious" to
+  "Clean".
+
+**Event Source**: Server
+
+**History**: Added 25 Aug 2017.
+
+``event`` **Member Fields**:
+
+The ``edx.grades.subsection.score_overridden`` event includes the
+:ref:`common<context>` ``context`` member fields.
+
+The ``edx.grades.subsection.score_overridden`` event also includes the
+following ``event`` member fields. These fields serve the same purpose for this
+event as they do for the :ref:`edx_grades_course_grade_calculated` and
+:ref:`edx_grades_problem_rescored` events.
+
+* ``problem_id``
+* ``event_transaction_id``
+* ``event_transaction_type``
+* ``only_if_higher``
+
+Additionally, the ``edx.grades.subsection.score_overridden`` event includes the
+following ``event`` member field.
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+   * - ``override_deleted``
+     - Boolean
+     - If ``true``, an edX support staff member has deleted a previous override
+       of a learner's score.
 
 .. _instructor_enrollment:
 


### PR DESCRIPTION
## [DOC-3745](https://openedx.atlassian.net/browse/DOC-3745)

This PR adds documentation for the edx.grades.subsection.score_overridden event, which is added to the platform as part of the work for EDUCATOR-409.

TO DO: Replace XX with date of event release.

### Date Needed (optional)

10 Aug 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @thallada 
- [ ] Doc team review (copy edit): @edx/doc
- [ ] Product review: @katymyw

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

