### PR TITLE
remove broken link in Ginkgo release notes

### DIFF
--- a/en_us/open_edx_release_notes/source/ginkgo.rst
+++ b/en_us/open_edx_release_notes/source/ginkgo.rst
@@ -14,9 +14,6 @@ website.
 Changes listed for July 7, 2017 and before are included in the Ginkgo release
 of Open edX. Changes after that point will be in future Open edX releases.
 
-For information about upgrading an existing Open edX installation from the
-Ficus relesae to the Ginkgo release, see :ref:`opencoursestaff:upgrade_ficus`.
-
 .. contents::
  :depth: 1
  :local:


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

Removing a broken link in the Ginkgo release docs.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

