### PR TITLE
Add edx.course.home.resume_course.clicked

### DIFF
--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -94,6 +94,8 @@ D, E, F
      - :ref:`enrollment`
    * - ``edx.course.enrollment.upgrade.succeeded``
      - :ref:`enrollment`
+   * - ``edx.course.home.resume_course.clicked``
+     - :ref:`navigational`
    * - ``edx.course.student_notes.added``
      - :ref:`notes`
    * - ``edx.course.student_notes.deleted``

--- a/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
@@ -688,6 +688,76 @@ This section includes descriptions of the following events.
   :depth: 1
 
 =============================================================================
+``edx.course.home.resume_course.clicked``
+=============================================================================
+
+The browser emits this event when a user clicks the **Resume/Start Course**
+button on the **Course** page in the LMS. The button is labelled **Start
+Course** if a learner is accessing the course for the first time. Clicking the
+**Start Course** button takes a learner to the first unit in the course. The
+button is labelled **Resume Course** when learners return to a course that they
+have already started. Clicking **Resume Course** takes a learner to the most
+recent location that they have accessed in the course.
+
+**History**: Added 11 August 2017.
+
+**Component**: LMS
+
+**Event Source**: Browser
+
+``event`` **Member Fields**:
+
+The ``edx.course.home.resume_course.clicked`` includes the following ``event``
+member fields. For more information about these common fields, see :ref:`common`.
+
+``event`` **Member Fields**:
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+
+   * - ``event_type``
+     - string
+
+     - ``start`` if the user clicked **Start Course**, ``resume`` if the user
+       clicked **Resume Course**.
+
+       .. note:: A "start course" link previously existed on the deprecated
+          **Course Info** page. If a user clicked the link from the deprecated
+          page, this ``event_type`` field is not included.
+
+   * - ``url``
+     - string
+     - The URL of the page in the course that the user visited most recently.
+       In the case of users who accessed the course for the first time, this
+       is the URL of the first page in the course.
+
+
+=============================================================================
+Example ``edx.course.home.resume_course.clicked`` Event
+=============================================================================
+
+The following example shows the relevant fields of the event that is emitted
+when a user clicks **Resume Course** or **Start Course** from the **Course**
+page in the LMS.
+
+.. code-block:: json
+
+ {
+     "name": "edx.ui.lms.link_clicked",
+     "event_type": "edx.ui.lms.link_clicked",
+     "event": {
+         "event_type": "resume",
+         "url": "/courses/course-v1:edX+DemoX+Demo_Course/courseware/48ecb924d7fe4b66a230137626bfa93e/",
+              }
+ }
+
+
+=============================================================================
 ``edx.ui.lms.link_clicked``
 =============================================================================
 

--- a/en_us/students/source/SFD_certificates.rst
+++ b/en_us/students/source/SFD_certificates.rst
@@ -169,7 +169,7 @@ visible on your dashboard and on the course **Progress** page.
 ..  :alt:
 
 You can also print or share your certificate. For more information, see
-:ref:`SFD Sharing or Printing a Certificate`.
+:ref:`SFD Sharing a Certificate`.
 
 .. _Receive a Certificate for a Program:
 


### PR DESCRIPTION
## [DOC-3746](https://openedx.atlassian.net/browse/DOC-3746)

Document the edx.course.home.resume_course.clicked event as a course navigation event in the Research Guide.

### Date Needed
ASAP: already released

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @HarryRein or @robrap 
- [ ] Subject matter expert: @stroilova 
- [x] Doc team review: @edx/doc
- [ ] Product review: @marcotuts 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version for Review

- [x] http://draftresearch-guide-resumecourse-click.readthedocs.io/en/latest/internal_data_formats/tracking_logs/student_event_types.html#course-navigation-events

### Post-review

- [x] Squash commits

