### PR TITLE
DOC-3757 Update ShoppingCart references to reflect that it is deprecated

### DIFF
--- a/en_us/install_operations/source/configuration/sites/configure_site.rst
+++ b/en_us/install_operations/source/configuration/sites/configure_site.rst
@@ -75,8 +75,6 @@ An example of the properties that you define to configure a site follows.
     "COURSE_ABOUT_VISIBILITY_PERMISSION":"see_about_page",
     "ENABLE_COMBINED_LOGIN_REGISTRATION":true,
     "ENABLE_PAID_COURSE_REGISTRATION":true,
-    "ENABLE_SHOPPING_CART":true,
-    "ENABLE_SHOPPING_CART_BULK_PURCHASE":false,
     "course_email_template_name":"my-site",
     "course_email_from_addr":"my-site@example.com",
     "ALLOW_AUTOMATED_SIGNUPS":true,

--- a/en_us/install_operations/source/configuration/tpa/tpa_advanced_features.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_advanced_features.rst
@@ -108,8 +108,8 @@ specified course.
 For example, the following URL would auto-enroll the user who clicks this link
 into the edX Demo course (that course's ID,
 ``course-v1:edX+DemoX+Demo_Course``, has been url-encoded as the value of the
-``course_id`` parameter). If the user is not signed in, they must sign in or
-register first, and then they will be auto-enrolled.
+``course_id`` parameter). If the user is not signed in, they are auto-enrolled
+after they sign in or register.
 
 ::
 
@@ -117,27 +117,29 @@ register first, and then they will be auto-enrolled.
 
 You can include the following parameters.
 
-* ``enrollment_action``: This is required to trigger the auto-enrollment
-  behavior. It must be set to either ``enroll`` (for free courses) or
-  ``add_to_cart`` (for paid courses). If ``add_to_cart`` is used, the user will
-  be directed to the shopping cart page rather than instantly enrolled.
+* ``enrollment_action``: This is required so that the auto-enrollment behavior
+  is triggered. It must be set to either ``enroll`` (for free courses) or
+  ``add_to_cart`` (for paid courses). If ``add_to_cart`` is used, learners
+  are directed to the e-commerce basket page rather than being instantly
+  enrolled.
 
 * ``course_id``: This is required. The ID of the course to enroll the user in,
-  or add to cart, etc. It must be URL-encoded.
+  or add to cart, etc. The value must be URL-encoded.
 
-* ``course_mode``: one of ``audit``, ``honor``, ``verified``, etc. Only applies
-  if enrollment_action is ``enroll``. If it's not specified, and the course has
-  more than one mode, the user will be sent to the "track selection" page where
-  they can choose which track/mode to use. If ``honor`` or ``audit`` is
-  specified, the user will be instantly enrolled. If any other mode is
-  specified, the user will be sent to the payment/verification flow.
+* ``course_mode``: One of ``audit``, ``honor``, ``verified``, etc. This
+  parameter applies only if ``enrollment_action`` is ``enroll``. If
+  ``course_mode`` is not specified, and the course has more than one mode,
+  learners are sent to the track selection page, where they can choose which
+  track of the course to enroll in. If ``honor`` or ``audit`` is specified,
+  learners are instantly enrolled. If any other mode is specified, learners
+  are sent to the payment/verification flow.
 
 * ``email_opt_in``: Can be ``true`` or ``false``. If true, this indicates that
   the user has consented to receiving marketing emails from Open edX and the
   course partner.
 
-This feature can also be combined with :ref:`hinted sign in<Hinted Sign In>`,
-if you create a URL such as the following example.
+The auto-enrollment feature can be combined with :ref:`hinted sign in<Hinted
+Sign In>`, if you create a URL such as the following example.
 
 ::
 

--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -290,14 +290,19 @@ steps.
 Switch from ShoppingCart to E-Commerce
 *****************************************
 
-By default, the ShoppingCart service is enabled when you install an Open edX
-instance. To use the E-Commerce service to handle ecommerce-related tasks
-instead of ShoppingCart, follow these steps.
+.. note:: The ShoppingCart service was deprecated in the Dogwood release of
+   Open edX. Ecommerce-related tasks are now handled by the E-Commerce
+   service.
+
+If you are upgrading from an earlier version of Open edX, follow these steps
+to use the E-Commerce service for ecommerce-related tasks instead of
+ShoppingCart.
 
 #. Sign in to the Django administration console for your base URL. For example,
    ``http://{your_URL}/admin``.
 
-#. In the **Commerce** section, next to **Commerce configuration**, select **Add**. 
+#. In the **Commerce** section, next to **Commerce configuration**, select
+   **Add**.
 
 #. Select **Enabled**.
 
@@ -314,6 +319,7 @@ instead of ShoppingCart, follow these steps.
 #. Select the site for which you want to enable the E-Commerce service.
 
 #. Select **Save**.
+
 
 .. _Development Outside Devstack:
 

--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -171,7 +171,7 @@ platform.
      - Supported
      - FALSE
    * - ENABLE_SHOPPING_CART
-     - Supported
+     - Deprecated
      - FALSE
    * - ENABLE_SPECIAL_EXAMS
      - Supported


### PR DESCRIPTION
## [DOC-3757](https://openedx.atlassian.net/browse/DOC-3757)

In the Open edX Installing, Configuring, and Running guide, update ShoppingCart references to make it clear that this service is deprecated.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @mjfrey 
- [x] Doc team review: @edx/doc 
- [ ] Product review: @dabdul-hathi

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

