### PR TITLE
DOC-3753 Add Programs, Program Offers, Apple Pay, Theming to Open edX Install/Config Guide

### DIFF
--- a/en_us/install_operations/source/configuration/customize_registration_page.rst
+++ b/en_us/install_operations/source/configuration/customize_registration_page.rst
@@ -33,7 +33,7 @@ files are located one level above the ``edx- platform`` directory.
 
 To add custom fields to the registration page, follow these steps.
 
-#. Start the LMS and sign in to your instance of Open edX.
+#. :ref:`Start the LMS<Start the LMS>` and sign in to your instance of Open edX.
 
 #. Use Python to create a Django form that contains the fields that you want to
    add to the page, and then create a Django model to store the information

--- a/en_us/install_operations/source/ecommerce/additional_features/apple_pay.rst
+++ b/en_us/install_operations/source/ecommerce/additional_features/apple_pay.rst
@@ -1,0 +1,47 @@
+Apple Pay
+#########
+
+Apple Pay support is available when you use the CyberSource processor. Apple Pay
+allows learners to check out quickly without having to manually fill out the
+payment form. If you are not familiar with Apple Pay, take a moment to read the
+following documents to understand the user flow and necessary configuration.
+
+* `Apple Pay JS <https://developer.apple.com/documentation/applepayjs>`_
+* `CyberSource Simple Order API <https://www.cybersource.com/developers/integration_methods/apple_pay/>`_
+
+Apple Pay is available only to learners using Safari on the following platforms:
+
+* iOS 10+ on devices with a Secure Element
+* macOS 10.12+. The user must have an iPhone, Apple Watch, or a MacBook Pro with
+  Touch ID that can authorize the payment.
+
+An exhaustive list of devices that support Apple Pay is available on
+`Wikipedia <https://en.wikipedia.org/wiki/Apple_Pay>`_.
+
+.. note::
+
+    The Apple Pay button is not displayed to users with incompatible hardware
+    and software.
+
+Settings
+--------
+Apple Pay is configured via the ``PAYMENT_PROCESSOR_CONFIG`` dictionary in settings. The following keys are required.
+
+.. list-table::
+    :header-rows: 1
+
+    * - Name
+      - Purpose
+    * - apple_pay_merchant_identifier
+      - Merchant identifier created at the `Apple Developer portal`_
+    * - apple_pay_country_code
+      - Two-letter `ISO 3166 country code <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ for your
+        business/merchant account
+    * - apple_pay_merchant_id_domain_association
+      - Domain verification text obtained from the `Apple Developer portal`_
+    * - apple_pay_merchant_id_certificate_path
+      - Filesystem path to the merchant identity certificate (used to authenticate with Apple to start sessions). This
+        file should be kept in a secure location that is only accessible by administrators and the application'
+        service user.
+
+.. _Apple Developer portal: https://developer.apple.com/account/ios/identifier/merchant

--- a/en_us/install_operations/source/ecommerce/additional_features/index.rst
+++ b/en_us/install_operations/source/ecommerce/additional_features/index.rst
@@ -14,6 +14,7 @@ data if one of your usual processors is unavailable.
 
    send_notifications
    change_processors
+   apple_pay
    track_data
    gate_ecommerce
    maintain_ecommerce

--- a/en_us/install_operations/source/ecommerce/create_products/create_coupons.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_coupons.rst
@@ -29,8 +29,8 @@ Creating a coupon code has several steps.
    :local:
 
 You create coupons and their associated discount or enrollment codes on the
-**Create New Coupon** page in the coupon administration tool, which is located
-at ``http://localhost:8002/coupons/``. In the tool, you enter basic
+**Create New Coupon** page in the E-Commerce Coupon Administration tool, which
+is located at ``http://localhost:8002/coupons/``. In the tool, you enter basic
 information and select the options for your coupon.
 
 .. _Enter Basic Coupon Information:
@@ -42,11 +42,15 @@ Enter Basic Information
 Each coupon requires some basic information. To enter basic information for
 your coupon, follow these steps.
 
-#. Follow the steps in :ref:`Create Products Overview` to start your E-Commerce
-   server.
+#. Start the E-Commerce Service on your site. For details, see :ref:`Start
+   ECommerce Service`.
+
 #. In a browser on your E-Commerce server, go to
-   ``http://localhost:8002/coupons/`` to open the coupon administration tool,
-   and then select **Create Coupon**.
+   ``http://localhost:8002/coupons/`` to access the E-Commerce Coupon
+   Administration tool.
+
+#. On the **Coupon Codes** page, select **Create Coupon**.
+
 #. On the **Create New Coupon** page, enter the following information.
 
    * **Coupon Name**: The name you want to give the coupon, such as "January
@@ -265,20 +269,22 @@ To specify usage limitations, follow these steps.
      you create enough discount or enrollment codes so that each person receives
      one code.
 
-   * **Can be used once by multiple customers** or **Can be used multiple times
-     by multiple customers**
+   * **Can be used once by multiple customers** or
+   * **Can be used multiple times by multiple customers**
 
-     If you select one of these options, the **Maximum Number of Usages** field
-     is visible. In this field, specify the number of times customers can use
-     the coupon code.
+     If you select one of these options, the **Maximum Number of Uses** field is
+     visible. In this field, specify the number of times customers can use the
+     coupon code.
 
-     For example, if you want to create a coupon code that is available for 10
-     different customers, and each customer can use the code only one time,
-     enter **10** for **Can be used once by multiple customers**.
+     For example, if you want to create a single coupon code that is available
+     for use by 10 different customers, and each customer can use the code
+     only one time, select **Can be used once by multiple customers** , ``1``
+     for **Number of Codes**, and ``10`` for **Maximum Number of Uses**.
 
-     If you want to create a coupon code that is available for 10 uses, whether
-     by one customer or multiple customers, enter **10** for **Can be used
-     multiple times by multiple customers**.
+     If you want to create a coupon code that is available for 10 uses,
+     whether by one customer or multiple customers, select **Can be used
+     multiple times by multiple customers**, ``1`` for **Number of Codes**,
+     and ``10`` for **Maximum Number of Uses**.
 
 After you specify usage limitations, you must specify invoicing options for
 your coupon.
@@ -374,7 +380,7 @@ The .csv file for your coupon lists the following information.
      - The number of times that the discount code or enrollment code that is
        associated with the coupon can be used. For single-use coupons, this
        value is 1. For multi-use coupons, this is the value that you specified
-       in the **Maximum Number of Usages** field.
+       in the **Maximum Number of Uses** field.
    * - **Redemption Count**
      - The number of times the coupon has been redeemed. The initial value is
        0, and the value is incremented each time that a discount code or
@@ -453,7 +459,7 @@ You edit a coupon by using the coupon administration tool.
  * **Single course** or **Multiple courses**
  * **Seat Type**
  * **Usage Limitations**
- * **Number of Codes** or **Maximum Number of Usages**
+ * **Number of Codes** or **Maximum Number of Uses**
 
 #. In your browser, go to ``http://localhost:8002/coupons/`` to open the coupon
    administration tool.

--- a/en_us/install_operations/source/ecommerce/create_products/create_course_seats.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_course_seats.rst
@@ -9,24 +9,31 @@ mode. For information about the enrollment tracks that edX offers, see
 :ref:`enrollment track<enrollment_track_g>`.
 
 You create course seats by creating a course on the **Create New Course** page
-in the course administration tool, which is located at
+in the E-Commerce Course Administration tool, which is located at
 ``http://localhost:8002/courses/``. After you create a course, the E-Commerce
 service creates the course seats that are associated with that course.
 
 To create a course seat, follow these steps.
 
-#. Follow the steps in :ref:`Create Products Overview` to start your E-Commerce
-   server.
+#. Start the E-Commerce Service on your site. For details, see :ref:`Start
+   ECommerce Service`.
+
 #. In a browser on your E-Commerce server, go to
-   ``http://localhost:8002/courses`` to access the **Courses** page.
+   ``http://localhost:8002/courses/`` to access the E-Commerce Course
+   Administration tool.
+
 #. On the **Courses** page, select **Add New Course**.
-#. On the **Add New Course** page, enter the information for your course in the
-   following fields.
 
-   * **Course ID**
-   * **Course Name**
+#. On the **Create New Course** page, enter the following information for your
+   course.
 
-#. For **Course Type**, select a course type and the options for that course
+   * Course ID
+   * Course Name
+   * Course Type
+   * Course Seats
+   * Bulk :ref:`Enrollment Code<Enable and Create Enrollment Codes>` Yes/No
+
+*  For **Course Type**, select a course type and the options for that course
    type.
 
    * If you select **Free (Audit)**, you must specify whether you want to allow
@@ -47,6 +54,8 @@ To create a course seat, follow these steps.
      * **Price (in USD)**
      * **ID Verification Required?**
      * **Upgrade Deadline**
+     * **Verification Deadline**: This option is required if you select **Yes**
+       for **ID Verification Required?**
 
    * If you select **Credit**, you must add the following information.
 

--- a/en_us/install_operations/source/ecommerce/create_products/create_enrollment_codes.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_enrollment_codes.rst
@@ -4,18 +4,22 @@
 Enable and Create Enrollment Codes
 #####################################
 
-.. note::
-  The enrollment codes in this topic are not related to the enrollment codes in
-  the :ref:`Create and Manage Coupons` topic.
-
 Enrollment codes allow users to purchase bulk enrollments for a course.
+
+.. note::
+
+   Enrollment codes used for bulk enrollments, as described in this topic,  are
+   not related to the "enrollment code" coupon code type that is referred to in
+   the :ref:`Create and Manage Coupons` topic.
+
 
 ************************
 Enable Enrollment Codes
 ************************
 
-You must enable enrollment codes in the E-Commerce service and in individual
-courses.
+Before you create enrollment codes that can be used for bulk enrollments for a
+course, you must enable enrollment codes in the E-Commerce service and in
+individual courses.
 
 #. To enable enrollment codes in the E-Commerce service, run the site
    configuration command together with the following option.

--- a/en_us/install_operations/source/ecommerce/create_products/create_products_overview.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_products_overview.rst
@@ -7,24 +7,33 @@ Creating Products Overview
 The edX platform offers several types of products. You create these products in
 E-Commerce web pages.
 
-* Course seats represent an enrollment track. Each course seat has an
-  associated set of attributes, such as price and certificate availability. The
-  edX code uses course seats to determine how a given enrollment should be
-  handled. For more information, see :ref:`enrollment
-  track<enrollment_track_g>` or :ref:`Create Course Seats`.
+* Course seats represent an :ref:`enrollment track<enrollment_track_g>`. Each
+  course seat has an associated set of attributes, such as price and
+  certificate availability. The edX code uses course seats to determine how a
+  given enrollment should be handled. For more information, see :ref:`Create
+  Course Seats`.
 
-* Coupons allow users to offer learners a discount, either percentage or fixed
-  amount, off a course enrollment. For more information, see :ref:`Create and
+* Coupons allow you to offer learners a discount, either percentage or fixed
+  amount, on a course enrollment. For more information, see :ref:`Create and
   Manage Coupons`.
 
-* Enrollment codes allow users to purchase bulk enrollments for a course.
+* Enrollment codes allow users to purchase bulk enrollments for a course. For
+  more information, see :ref:`Enable and Create Enrollment Codes`.
+
+* Programs are collections of related courses. Learners can enroll in and
+  purchase courses separately, or you can configure programs to allow one-
+  click purchasing of all courses in a program. For more information, see
+  :ref:`Programs`.
+
+
+.. _Start ECommerce Service:
 
 ******************************
-Prepare to Create a Product
+Start the E-Commerce Service
 ******************************
 
-Before you create a product, complete the following steps to start the
-E-Commerce service on your site.
+Before you can create a product, you must start the E-Commerce service on your
+site. Follow these steps to start the E-Commerce service.
 
 #. In the ecommerce and LMS configuration files (``/edx/etc/ecommerce.yml`` and
    ``/edx/app/edxapp/lms.auth.json``, respectively), verify the following

--- a/en_us/install_operations/source/ecommerce/create_products/create_program_offers.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_program_offers.rst
@@ -1,0 +1,50 @@
+.. _Create Program Offers:
+
+#####################
+Create Program Offers
+#####################
+
+Program offers are discounts, either percentage or fixed amount discounts, that
+apply to a specific program. When a program offer is active for a program, the
+program's price appears discounted both on the program's purchase button and on
+the e-commerce checkout page.
+
+You create program offers on the **Create Program Offer** page in the E-Commerce
+Program Offers Administration tool, which is located at
+``http://localhost:8002/programs/offers``.
+
+.. note:: Each program can be associated with only one program offer.
+   To offer a new discount, edit the existing program offer for your program.
+
+To create a program offer, follow these steps.
+
+#. Start the E-Commerce Service on your site. For details, see :ref:`Start
+   ECommerce Service`.
+
+#. Obtain the Program UUID for the program for which you are creating an offer.
+   Find your program's UUID in the Discovery Service Django administration site,
+   under **Course Metadata > Programs**.
+
+#. In a browser on your E-Commerce server, go to
+   ``http://localhost:8002/programs/offers/`` to access the E-Commerce Program
+   Offers Administration tool.
+
+#. On the **Program Offers** page, select **Create Program Offer**.
+
+#. On the **Create Program Offer** page, enter the following information for
+   your program offer.
+
+   * Program UUID
+   * Start Date
+   * End Date
+   * Discount Type - either percentage or absolute.
+   * Discount Value - the value of the discount based on the discount type.
+
+.. note:: To ensure that your program discount is reflected even when only some,
+   not all, of a program's courses are in a learner's basket for checkout, you
+   must select the **Enable Partial Program Offer** setting in the E-Commerce
+   Service Django Administration site, under **Core > Site configurations**.
+
+#. Select **Create Program Offer**.
+
+.. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/ecommerce/create_products/create_programs.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_programs.rst
@@ -1,0 +1,90 @@
+.. _Programs:
+
+################
+About Programs
+################
+
+Programs are collections of related courses that you make available on your
+marketing site. Each program is of a particular type.
+
+The cost for a program is the sum of the cost for each of its courses. You can
+change the cost for a program by creating a program offer, which is a discount
+on the program price of either a percentage or fixed amount. For more details,
+see :ref:`Create Program Offers`.
+
+
+********************
+Create Program Types
+********************
+
+You add program types in the Discovery Service Django administration site for
+your Open edX instance.
+
+To add a program, follow these steps.
+
+#. Sign into the Discovery Service Django Administration site for your Open
+   edX instance. For example, ``https://<discovery-baseURL>/admin/``, or
+   ``localhost:18381`` if you are testing locally.
+
+#. In the **Course Metadata** section, select **Program types**.
+
+#. Select **Add Program Type**.
+
+#. On the **Add program type** page, specify a name for the new program type,
+   and select the seat types that are applicable to programs of this type.
+
+#. Optionally, add a program logo image and a slug for this program type for
+   use on the marketing site.
+
+#. When you have finished entering information for the program type, select one of
+   the **Save** options: **Save**, **Save and add another**, or **Save and
+   continue editing**.
+
+   You can now specify this program type when you create new programs.
+
+
+***************
+Create Programs
+***************
+
+You add programs and specify the courses that are in each program in the
+Discovery Service Django administration site for your Open edX instance.
+
+To add a program, follow these steps.
+
+#. Sign into the Discovery Service Django Administration site for your Open
+   edX instance. For example, ``https://<discovery-baseURL>/admin/``, or
+   ``localhost:18381`` if you are testing locally.
+
+#. In the **Course Metadata** section, select **Programs**.
+
+#. Select **Add Program**.
+
+   On the **Add Program** page, a UUID is assigned to the new program.
+
+#. Enter information for the new program. Required fields, for example
+   **Title**, **Status** and **Type**, have boldface names.
+
+   * In the **Courses** field, specify the courses that are part of the program.
+     Names of current courses are automatically matched as you continue to type.
+     To add a course that does not currently exist, click the plus sign (+) next
+     to the field to create a new course.
+
+   * To allow learners to purchase upgrades to the verified track for all
+     the courses in the program with one click, select **One click purchase
+     enabled**.
+
+#. When you have finished entering information for the program, select one of
+   the **Save** options: **Save**, **Save and add another**, or **Save and
+   continue editing**.
+
+.. This procedure completes the course and program structure. To provide "site
+.. functionality" for programs, the LMS and the marketing site also need to know
+.. about the program and the program offer, if any, that is associated with the
+.. program.
+
+.. Discovery service?
+
+
+
+.. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/ecommerce/create_products/index.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/index.rst
@@ -16,5 +16,7 @@ information, see the following topics.
    create_course_seats
    create_coupons
    create_enrollment_codes
+   create_programs
+   create_program_offers
 
 .. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/ecommerce/index.rst
+++ b/en_us/install_operations/source/ecommerce/index.rst
@@ -10,10 +10,23 @@ source Django ecommerce framework, to manage the edX product catalog and handle
 orders for those products. The following sections describe how to install and
 use the E-Commerce service with the Open edX platform.
 
+To complete the procedures that this section describes, you use both the
+E-Commerce Service's Django administration site and the E-Commerce
+Administration Tool (CAT). The CAT is a web app that is included with the
+E-Commerce service and enables you to configure and manage products that are
+associated with the courses and programs on your instance of the Open edX
+learning management system (LMS).
+
+In addition to these required steps, you can add optional features to the
+E-Commerce service for your instance of the Open edX platform. For more
+information, see :ref:`Additional Ecommerce Features`.
+
+
 .. toctree::
    :maxdepth: 2
 
    install_ecommerce
+   theming
    manage_assets
    create_products/index
    enable_receipt_page
@@ -22,15 +35,6 @@ use the E-Commerce service with the Open edX platform.
    test_ecommerce
    additional_features/index
 
-To complete the procedures that this section describes, you use both the Django
-administration site and the Course Administration Tool (CAT). The CAT is a web
-app that is included with the E-Commerce service. The CAT enables you to
-configure and manage products that are associated with the courses on your
-instance of the Open edX learning management system (LMS).
-
-In addition to these required steps, you can add optional features to the
-E-Commerce service for your instance of the Open edX platform. For more
-information, see :ref:`Additional Ecommerce Features`.
 
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -85,7 +85,7 @@ Create and Register a Client
 
 To create and register a new OIDC client, follow these steps.
 
-#. Start the LMS.
+#. :ref:`Start the LMS<Start the LMS>`.
 #. In your browser, go to ``http://127.0.0.1:8000/admin/oauth2/client/``.
 #. Select **Add client**.
 #. Leave the **User** field blank.
@@ -152,6 +152,13 @@ OIDC client's settings, as follows.
      - OIDC ID token decryption key, used to validate the ID
        token
      - The same value as ``SOCIAL_AUTH_EDX_OIDC_SECRET``.
+   * - ``SOCIAL_AUTH_EDX_OIDC_ISSUER``
+     - OIDC ID token issuer
+     - For example, ``http://127.0.0.1:8000/oauth2``.
+   * - ``SOCIAL_AUTH_EDX_OIDC_LOGOUT_URL``
+     - User logout URL
+     - For example, ``http://127.0.0.1:8000/logout``.
+
 
 To configure your default site, partner, and site configuration, use the
 appropriate settings module for your environment
@@ -286,8 +293,9 @@ steps.
 
    .. note::
      If you use a different port, make sure you update the OIDC client by using
-     the Django administration panel in the LMS. For more information about
+     the LMS Django Administration site. For more information about
      configuring the OIDC client, see :ref:`Configure OIDC`.
+
 
 *****************************************
 Switch from ShoppingCart to E-Commerce
@@ -301,7 +309,7 @@ If you are upgrading from an earlier version of Open edX, follow these steps
 to use the E-Commerce service for ecommerce-related tasks instead of
 ShoppingCart.
 
-#. Sign in to the Django administration console for your base URL. For example,
+#. Sign in to the LMS Administration Django site for your base URL. For example,
    ``http://{your_URL}/admin``.
 
 #. In the **Commerce** section, next to **Commerce configuration**, select

--- a/en_us/install_operations/source/ecommerce/test_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/test_ecommerce.rst
@@ -110,8 +110,7 @@ these tests, place your tests in the ``ecommerce/static/js/test/specs``
 directory, and add a ``_spec`` suffix. For example, your test name may be
 ``ecommerce/static/js/test/specs/course_list_view_spec.js``.
 
-All JavaScript code must adhere to the `edX JavaScript Style Guide`_. These
-standards are enforced using `JSHint`_ and `jscs`_.
+All JavaScript code must adhere to standards outlined in the `edX JavaScript Style Guide`_. These standards are enforced using `ESLint`_.
 
 * To run all JavaScript unit tests and linting checks, run the following
   command.
@@ -167,7 +166,7 @@ To configure the LMS, follow these steps.
 #. Verify that the following settings in ``/edx/app/edxapp/lms.auth.json`` are
    correct. ::
 
-       "ECOMMERCE_API_SIGNING_KEY": "lms-secret" // Must match the E-Commerce JWT_SECRET_KEY setting
+       "ECOMMERCE_API_SIGNING_KEY": "insecure-secret-key" // Must match the E-Commerce JWT_SECRET_KEY setting
        "EDX_API_KEY": "PUT_YOUR_API_KEY_HERE" // Must match the E-Commerce EDX_API_KEY setting
 
 #. Verify that an LMS account with staff and superuser permissions exists.
@@ -183,19 +182,27 @@ To configure the LMS, follow these steps.
        cd ~/edx-platform
        ./manage.py lms set_superuser staff --settings=devstack
 
-#. Start the LMS.
 
-   .. code:: sh
+   .. the ecomm version has these commands for granting superuser permissions
+   .. to the account:
 
-       cd ~/edx-platform
-       paver devstack lms
+      ..  ./manage.py lms shell --settings=devstack
+          from django.contrib.aut.models import User
+          u = User.objects.get(username-'staff')
+          u. is_superuser = True
+          u.save()
 
-#. Navigate to the Oauth2 Clients section of the Django administration console
+#. :ref:`Start the LMS<Start the LMS>`.
+
+
+#. Navigate to the OAuth2 Clients section of the Django administration console
    (e.g. http://localhost:8000/admin/oauth2/client/). Sign in using the
    superuser account you created earlier.
 
    Verify that an OAuth2 client with the following attributes exists.  If one
-   does not already exist, :ref:`create a new one <Create Register Client>`.
+   does not already exist, :ref:`create a new OAuth 2 client <Create Register
+   Client>`.
+
    The client ID and secret must match the values of the E-Commerce
    ``SOCIAL_AUTH_EDX_OIDC_KEY`` and ``SOCIAL_AUTH_EDX_OIDC_SECRET`` settings,
    respectively. ::
@@ -209,8 +216,7 @@ To configure the LMS, follow these steps.
        Logout url: http://localhost:8002/logout/
 
 #. Navigate to the Edx\_Oauth2\_Provider Trusted clients section of the Django
-   administration console (e.g.
-   http://localhost:8000/admin/edx_oauth2_provider/trustedclient/).
+   administration console (http://localhost:8000/admin/edx_oauth2_provider/trustedclient/).
 
    Verify that the OAuth2 client referred to above is designated as a
    trusted client (look for the Redirect URI). If this isn't already
@@ -221,17 +227,16 @@ To configure the LMS, follow these steps.
    to above. Make note of this token; it is required to run the
    acceptance tests.
 
-#. Make sure that the LMS instance that you will use for testing has at
-   least two courses that learners could enroll in. By default, most
-   LMS instances include the edX demonstration course. Use Studio to
-   create a second course.
+#. Make sure that the LMS instance that you will use for testing has at least
+   two courses that learners can enroll in. By default, most LMS instances
+   include the edX demonstration course. Use Studio to create a second course.
 
 
 Configure E-Commerce
 ********************
 
-You use the Course Administration Tool ("CAT") to finish configuring the
-two courses in your LMS instance.
+You use the E-Commerce Course Administration Tool ("ECAT") to finish
+configuring the two courses in your LMS instance.
 
 #. Become the ``ecommerce`` user.
 
@@ -287,11 +292,15 @@ two courses in your LMS instance.
        ./manage.py runserver 0.0.0.0:8002
 
 #. Get the course key from the LMS by navigating to a course and examining its
-   URL. It should look something like ``course-v1:edX+DemoX+Demo_Course``.
+   URL. The course key should look something like
+   ``course-v1:edX+DemoX+Demo_Course``.
 
-#. Navigate to the E-Commerce Courses section (e.g.
-   http://localhost:8002/courses/) and add a new course. Leave the default
-   values in all fields, with the exception of the following.
+#. Navigate to the E-Commerce Courses page (http://localhost:8002/courses/) to
+   add the two test courses that are on your LMS instance to E-Commerce. Configure
+   one course as a "Free (Audit)" course, and the second as a "Verified" course.
+
+#. To configure the "Verified" course, click **Add New Course**. Leave the
+   default values in all fields, with the exception of the following fields.
 
    ::
 
@@ -301,16 +310,16 @@ two courses in your LMS instance.
        Include Honor Seat: No
 
 #. Navigate to the learner dashboard (e.g. http://localhost:8000/dashboard) and
-   verify the course you added in E-Commerce now has a green "Upgrade to
+   confirm that the course you added in E-Commerce now has a green "Upgrade to
    Verified" badge, which you can select.
 
-#. In the CAT, add the second course on your LMS instance to E-Commerce.
-   Configure it as a "Free (Audit)" course.
+#. In the ECAT, add the second course on your LMS instance to E-Commerce.
+   Specify its course type as ``Free (Audit)``.
 
-#. So that you can test integration with external payment processors, update
-   the contents of the ``PAYMENT_PROCESSOR_CONFIG`` dictionary found in the
-   settings with valid credentials. To override the default values for
-   development, create a private settings module, ``private.py``, and set
+#. To test integration with external payment processors, update the contents
+   of the ``PAYMENT_PROCESSOR_CONFIG`` dictionary found in the settings with
+   valid credentials. To override the default values for development, create a
+   private settings module, ``private.py``, and set
    ``PAYMENT_PROCESSOR_CONFIG`` inside the module.
 
    .. note::
@@ -324,10 +333,13 @@ two courses in your LMS instance.
 Configure Acceptance Tests
 *********************************
 
-You configure acceptance tests by using the settings in the
-``e2e/config.py`` file. You can use the
-default values for most settings in this file. However, you must specify values
-for the following settings by using environment variables.
+You configure acceptance tests by using the settings in the ``e2e/config.py``
+file. You can use the default values for most settings in this file. However,
+for the following settings, you must specify values using environment
+variables.
+
+  .. ecomm version has this file path instead:
+  .. ecommerce/blobmaster/acceptance_tests/config.py
 
 .. list-table::
  :widths: 30 60
@@ -367,8 +379,11 @@ settings by using environment variables.
 Run Acceptance Tests
 ******************************
 
-Run all acceptance tests by executing ``make e2e``. To run a specific test,
-execute the following command.
+Run all acceptance tests by executing ``make e2e``.
+
+  .. ecomm version has ``make accept``?
+
+To run a specific test, execute the following command.
 
 .. code-block:: bash
 

--- a/en_us/install_operations/source/ecommerce/theming.rst
+++ b/en_us/install_operations/source/ecommerce/theming.rst
@@ -1,0 +1,308 @@
+.. _Comprehensive Theming:
+
+######################
+Comprehensive Theming
+######################
+
+Any application, including Otto, can be loosely divided into two parts:
+
+* the user interface ("how it looks"), and
+* the application logic ("how it works").
+
+Considerations of the Otto user interface include, for example, how the
+products are laid out on the page, how the selectors look, how the checkout
+button is labelled, what sort of fonts and colors are used to display the
+text, and so on. Considerations of Otto's application logic includes how Otto
+adjusts product price based on discount coupons, and how it records that
+information to be displayed in the future.
+
+Theming consists of changing the user interface without changing the
+application logic. When you set up an E-Commerce website for use with your
+Open edX site, you probably want to use your organization's own logo, modify
+the color scheme, change links in the header and footer for SEO (search engine
+optimization) purposes, and so on.
+
+However, although the user interface might look different, the application
+logic must remain the same so that Otto continues to work properly. A well-
+designed theme preserves the general layout and structure of the user
+interface, so that users of the website still find it familiar and easy to
+use. Be careful about making sweeping changes to the user interface without
+warning: your users will be very confused!
+
+The default Open edX theme is named "Comprehensive Theming". You can disable
+Comprehensive Theming by setting ``ENABLE_COMPREHENSIVE_THEMING`` to
+``False``, as shown in this example, then applying your custom theme.
+
+    .. code-block:: python
+
+        ENABLE_COMPREHENSIVE_THEMING = False
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+***************
+Theme Structure
+***************
+
+From a technical perspective, theming consists of overriding core templates,
+static assets, and Sass with themed versions of those resources.
+
+Every theme must conform to a directory structure that mirrors the Otto directory structure.
+
+.. code-block:: text
+
+    my-theme
+        ├── README.rst
+        ├── static
+        |      └── images
+        |      |     └── logo.png
+        |      |
+        |      └── sass
+        |            └── partials
+        |                   └── utilities
+        |                           └── _variables.scss
+        |
+        └── templates
+                └── oscar
+                |     └── dashboard
+                |             └── index.html
+                └── 404.html
+
+
+=========
+Templates
+=========
+
+Any template included in ``ecommerce/templates`` directory can be "themed".
+However, make sure not to override class names or ID values of HTML elements
+within a template, as these are used by JavaScript or CSS. Overriding these
+names and values can cause unwanted behavior.
+
+==================
+Static Assets
+==================
+
+Any static asset included in ``ecommerce/static`` can be overridden except for
+the CSS files in the ``ecommerce/static/css`` directory. CSS styles can be
+overridden via Sass overrides explained below.
+
+.. caution:: Theme names must be unique. The names of static assets or
+   directories must not be same as the theme's name, otherwise static assets
+   will not work correctly.
+
+=====
+Sass
+=====
+
+Sass overrides are a little different from static asset or template overrides.
+There are two types of styles included in ``ecommerce/static/sass``:
+
+* base
+* partials
+
+.. caution:: Styles present in ``ecommerce/static/sass/base`` should not be
+   overridden as overriding these could result in an unexpected behavior.
+
+Any styles included in ``ecommerce/static/sass/partials`` can be overridden.
+Styles included in this directory contain variable definitions that are used
+by main Sass files. Elements of the user interface such as header/footer,
+background, fonts, and so on, can be updated in this directory.
+
+
+*****************
+Enabling a Theme
+*****************
+
+To enable a theme, you must first install your theme onto the same server that
+is running Otto. If you are using devstack or fullstack to run Otto, you must
+be sure that the theme is present on the Vagrant virtual machine. It is up to
+you where to install the theme on the server, but a good default location is
+``/edx/app/ecommerce/ecommerce/themes``.
+
+.. note:: All themes must reside in the same physical directory.
+
+In order for Otto to use the installed themes, you must specify the location
+of the theme directory in Django settings by defining
+``COMPREHENSIVE_THEME_DIRS`` in your settings file, as shown in the example,
+where ``/edx/app/ecommerce/ecommerce/themes`` is the path to where you have
+installed the themes on your server.
+
+.. code-block:: python
+
+    COMPREHENSIVE_THEME_DIRS = ["/edx/app/ecommerce/ecommerce/themes", ]
+
+You can list all theme directories using this setting.
+
+After you install a theme, you associate it with your site by adding appropriate
+entries to the following tables.
+
+*  ``Site``
+*  ``Site Themes``
+
+For local devstack, if the Otto server is running at ``localhost:8002`` you can
+enable a ``my-theme`` by following these steps.
+
+#. Add a new site with the domain ``localhost:8002`` and the name "Otto My Theme".
+
+#. Add a site theme with the theme dir name ``my-theme``,  selecting
+   ``localhost:8002`` from the ``site`` dropdown.
+
+The Otto server can now be started, and you should see that ``my-theme`` has
+been applied. If you have overridden Sass styles and you are not seeing those
+overrides, then you need to compile Sass files as described in `Compiling
+Theme Sass`_.
+
+******************
+Disabling a Theme
+******************
+
+A theme can be disabled by removing its corresponding ``Site Theme`` entry
+using django admin.
+
+=======================================
+Creating or Updating Site and SiteTheme
+=======================================
+
+If you have already set up ``COMPREHENSIVE_THEME_DIRS``, you can use the
+management command for adding ``Site`` and ``SiteTheme`` directly from the
+terminal.
+
+.. code-block:: Bash
+
+    python manage.py create_or_update_site_theme --site-domain=localhost:8002 --site-name=localhost:8002 --site-theme=my-theme
+
+The ``create_or_update_site_theme`` command accepts the following optional
+arguments, listed below with examples.
+
+* settings: The settings file to use. The default file is
+  ``ecommerce.settings.devstack``.
+
+.. code-block:: Bash
+
+    python manage.py create_or_update_site_theme --settings=ecommerce.settings.production
+
+* site-id: The ID of the site that you want to update.
+
+.. code-block:: Bash
+
+    # update domain of the site with id 1 and add a new theme
+    # ``my-theme`` for this site
+    python manage.py create_or_update_site_theme --site-id=1 --site-domain=my-theme.localhost:8002 --site-name=my-theme.localhost:8002 --site-theme=my-theme
+
+* site-domain: The domain of the site to be created.
+
+.. code-block:: Bash
+
+    python manage.py create_or_update_site_theme --site-domain=localhost:8002 --site-theme=my-theme
+
+* site-name: The name of the site to be created. The default setting is  ``''``.
+
+.. code-block:: Bash
+
+    python manage.py create_or_update_site_theme --site-domain=localhost:8002 --site-name=localhost:8002 --site-theme=my-theme
+
+* site-theme: The theme dir for the new theme.
+
+.. code-block:: Bash
+
+    python manage.py create_or_update_site_theme --site-domain=localhost:8002 --site-name=localhost:8002 --site-theme=my-theme
+
+
+=====================
+Compiling Theme Sass
+=====================
+
+You use the management command ``update_assets`` to compile and collect themed
+Sass.
+
+.. code-block:: yaml
+
+    python manage.py update_assets
+
+The ``update_assets`` command accepts the following optional arguments, listed
+below with examples.
+
+* settings: The settings file to use. The default file is
+  ``ecommerce.settings.devstack``.
+
+.. code-block:: Bash
+
+    python manage.py update_assets --settings=ecommerce.settings.production
+
+* themes: The space-separated list of themes to compile Sass for. Possible
+  options are ``all`` for all themes, ``no`` to skip Sass compilation for
+  themes. The default option is ``all``.
+
+.. code-block:: Bash
+
+    # compile Sass for all themes
+    python manage.py update_assets --theme=all
+
+    # compile Sass for only given themes, useful for situations if you have
+    # installed a new theme and want to compile Sass for just this theme
+
+    python manage.py update_assets --themes my-theme second-theme third-theme
+
+    # skip Sass compilation for themes, useful for testing changes to system
+    # Sass, keeping theme styles unchanged
+
+    python manage.py update_assets --theme=no
+
+* output-style: The coding style for compiled CSS files. Possible options are
+  ``nested``, ``expanded``, ``compact`` and ``compressed``. The default option
+  is ``nested``.
+
+.. code-block:: Bash
+
+    python manage.py update_assets --output-style='compressed'
+
+* skip-system: This flag disables system Sass compilation.
+
+.. code-block:: Bash
+
+    # useful in cases where you have updated theme Sass, and system Sass is
+    # unchanged.
+
+    python manage.py update_assets --skip-system
+
+* enable-source-comments: This flag enables source comments in generated CSS
+  files.
+
+.. code-block:: Bash
+
+    python manage.py update_assets --enable-source-comments
+
+* skip-collect: Use this flag to skip the ``collectstatic`` call after Sass
+  compilation.
+
+.. code-block:: Bash
+
+    # useful if you just want to compile Sass, and call ``collectstatic`` later,
+    # possibly by a script
+
+    python manage.py update_assets --skip-collect
+
+
+******************
+Troubleshooting
+******************
+
+If you have gone through the preceding procedures and you are not seeing theme
+overrides, check the following areas.
+
+
+*  ``COMPREHENSIVE_THEME_DIRS`` must contain the path for the directory
+   containing themes. For example, if your theme is
+   ``/edx/app/ecommerce/ecommerce/themes/my- theme`` then the correct value
+   for ``COMPREHENSIVE_THEME_DIRS`` is
+   ``['/edx/app/ecommerce/ecommerce/themes']``.
+
+*  The ``domain`` name for site is the name that users will put in the browser
+   to access the site, and includes the port number. For example, if Otto is
+   running on ``localhost:8002`` then the value for ``domain`` should be
+   ``localhost:8002``.
+
+* The theme dir name is the name of the directory of your theme. For example,
+  for our ongoing example, ``my-theme`` is the correct theme dir name.

--- a/en_us/install_operations/source/installation/analytics/start_analytics.rst
+++ b/en_us/install_operations/source/installation/analytics/start_analytics.rst
@@ -27,11 +27,8 @@ Starting the Open edX LMS
 
      $ sudo su edxapp
 
-#. Start the LMS.
+#.  :ref:`Start the LMS<Start the LMS>`.
 
-   .. code-block:: bash
-
-     $ paver devstack lms
 
 ****************************************
 Starting the Open edX Analytics Data API

--- a/en_us/install_operations/source/installation/devstack/start_devstack.rst
+++ b/en_us/install_operations/source/installation/devstack/start_devstack.rst
@@ -45,6 +45,8 @@ Starting the Components
 After you connect to the devstack virtual machine as the **edxapp** user, you
 can start the individual components.
 
+.. _Start the LMS:
+
 ================
 Starting the LMS
 ================
@@ -77,6 +79,9 @@ To run the LMS on devstack, follow these steps.
 #. Open the LMS in your browser at ``http://localhost:8000/``.
 
    Vagrant forwards port 8000 to the LMS server running in the virtual machine.
+
+
+.. _Start Studio:
 
 ===============
 Starting Studio
@@ -122,6 +127,9 @@ To view all available commands for Studio, enter the following command.
 .. code-block:: bash
 
   ./manage.py cms -h --settings=devstack
+
+
+.. _Start Course Discussions:
 
 =================================
 Starting Course Discussions

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -834,6 +834,27 @@ P
   Components` and :ref:`partnercoursestaff:Exercises and Tools Index`.
 
 
+.. _Program:
+
+**program**
+
+  A program is a collection of related courses. Learners enroll in a program by
+  enrolling in any course that is part of a program, and earn a program
+  certificate by passing each of the courses in the program with a grade that
+  qualifies them for a verified certificate.
+
+  Several types of program are available on edx.org, including MicroMasters,
+  Professional Certificate, and XSeries programs.
+
+
+.. _Program Offer:
+
+**program offer**
+
+  A program offer is a discount offered for a specific program. The discount
+  can be either a percentage amount or an absolute (dollar) amount.
+
+
 .. _Progress Page:
 
 **Progress page**


### PR DESCRIPTION
## [DOC-3753](https://openedx.atlassian.net/browse/DOC-3753)

- Add info on programs, program offers to the eCommerce section in the "Installing, Configuring and Running the Open edX Platform.
- Bring in sync with updates made in edx/ecomm/docs but not in edx-doc: add Apple Pay, theming sections.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @mjfrey 
- [ ] Doc team review: @edx/doc 
- [ ] Product review: @dabdul-hathi

FYI: @clintonb 

### Draft HTML Output
- [ ] http://draft-icr-ecomm.readthedocs.io/en/latest/ecommerce/index.html

### Testing
- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review
- [ ] Squash commits

