### PR TITLE
Add ENABLE_AUTOADVANCE_VIDEOS flag

### DIFF
--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -197,6 +197,9 @@ platform.
    * - ENABLE_VIDEO_BUMPER
      - Supported
      - FALSE
+   * - ENABLE_AUTOADVANCE_VIDEOS
+     - Supported
+     - FALSE
    * - ENABLE_XBLOCK_VIEW_ENDPOINT
      - Supported
      - FALSE


### PR DESCRIPTION
**DEPENDS ON edx/edx-platform#15803**

This documents a new flag called `ENABLE_AUTOADVANCE_VIDEOS`, implemented in edx/edx-platform#15803, and which allows to see an "auto-advance" button in every video. When this button is enabled and the course setting also enabled, the browser will go to the next page after a video finishes.
If `ENABLE_AUTOADVANCE_VIDEOS` is off, the behaviour and interface are not affected. 

### Date Needed: N/A

### Reviewers

- [ ] @bdero 
- [ ] etc.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors.  @clemente: not yet, but change is minimal

### HTML Version: N/A

### Sandbox: N/A

### Post-review

- [ ] This will need to be announced in the release notes
- [X] Squash commits
