### PR TITLE
Transcript fallback feature flag

### DIFF
--- a/en_us/install_operations/source/configuration/index.rst
+++ b/en_us/install_operations/source/configuration/index.rst
@@ -24,6 +24,7 @@ configuration options.
    ora2/index
    enable_prerequisites
    enable_licensing
+   transcripts
    lti/index
    enable_socialsharing_icons
    tpa/index

--- a/en_us/install_operations/source/configuration/transcripts.rst
+++ b/en_us/install_operations/source/configuration/transcripts.rst
@@ -1,0 +1,40 @@
+.. _Configure Transcripts:
+
+####################################
+Configuring Transcript Behavior
+####################################
+
+As a best practice, transcripts should always be provided, so that course
+videos meet accessibility requirements. Video transcripts are displayed in the
+language selected by the learner in the video player if they are available in
+that language. Otherwise, by default video transcripts fall back to an English
+language transcript. In cases where no transcript is available, you can
+configure Open edX so that the video player does not display the caption and
+transcript buttons.
+
+You can configure the default transcript behavior using the
+``FALLBACK_TO_ENGLISH_TRANSCRIPTS`` feature flag. By default, this feature
+flag is set to ``TRUE``. If you set it to ``FALSE``, then the video transcript
+will not fall back to an English language transcript and if no transcript is
+available, the caption and transcript buttons are not displayed in the video
+player.
+
+***************************************
+Configuring the Transcript Feature Flag
+***************************************
+
+.. Note::
+  Before proceeding, review :ref:`Guidelines for Updating the Open edX
+  Platform`.
+
+To set the ``FALLBACK_TO_ENGLISH_TRANSCRIPTS`` feature flag, you modify the
+``lms.env.json`` and ``cms.env.json``files, which are located one level above
+the ``edx-platform`` directory.
+
+#. In the ``lms.env.json`` and ``cms.env.json`` files, in the ``FEATURES``
+   dictionary, change the value of ``FALLBACK_TO_ENGLISH_TRANSCRIPTS`` to
+   ``FALSE``.
+
+#. Save the ``lms.env.json`` and ``cms.env.json`` files.
+
+.. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -206,6 +206,9 @@ platform.
    * - ENTRANCE_EXAMS
      - Supported
      - FALSE
+   * - FALLBACK_TO_ENGLISH_TRANSCRIPTS
+     - Supported
+     - TRUE
    * - FORCE_UNIVERSITY_DOMAIN
      - Deprecated
      - FALSE


### PR DESCRIPTION
## [DOC-3770](https://openedx.atlassian.net/browse/DOC-3770)

Video transcripts are displayed in the user's selected language if they are available in that language. Otherwise, by default video transcripts fall back to an English language transcript. 

With OSPR-1811 / PR 15475 , Open edX admins can configure the default transcript fallback behavior using the FALLBACK_TO_ENGLISH_TRANSCRIPTS feature flag. By default, this feature flag is set to TRUE. If you set it to FALSE, then the video transcript will not fall back to an English language transcript and if no transcript is available, the transcript button is not displayed in the video player.

### Date Needed

The corresponding code in OSPR-1811 has been reviewed and seems close to ready for release.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @omarIthawi
- [ ] Subject matter expert: @muzaffaryousaf
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

