### PR TITLE
CA: Certificates are also on the Profile page

### DIFF
--- a/en_us/shared/student_progress/checking_student_progress.rst
+++ b/en_us/shared/student_progress/checking_student_progress.rst
@@ -50,14 +50,10 @@ Issuing Certificates
    :ref:`installation:Enable Certificates` in *Installing, Configuring, and
    Running the Open edX Platform*.
 
-.. After EDUCATOR-1101 merges (around 8/25), change "the learner dashboard and
-.. the **Progress** page" to "the learner dashboard, the **Course** page, and
-.. the **Progress** page".
-
 Studio automatically generates certificates for both self-paced courses and
 instructor-paced courses. When certificates become available, options for
-learners to view their certificates are available on the learner dashboard and
-the course **Progress** page.
+learners to view their certificates are available on the learner dashboard,
+the learner **Profile** page, and the course **Progress** page.
 
 You can specify when you want to make certificates available.
 


### PR DESCRIPTION
## [DOC-3763](https://openedx.atlassian.net/browse/DOC-3763)

In the certificates doc for course authors, mention that learners can also find their certificates on their Profile page. 

I also deleted a comment from Sylvia that's no longer relevant.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (sanity check, copy edit, or dev edit?): @catong 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

