### PR TITLE
Updated ecommerce Add Site documentation

### DIFF
--- a/en_us/install_operations/source/ecommerce/install_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/install_ecommerce.rst
@@ -163,7 +163,10 @@ partner and site configuration with the specified options.
     .. code-block:: bash
 
       $ sudo su ecommerce
-      $ python manage.py create_or_update_site --site-id=1 --site-domain=localhost:8002 --partner-code=edX --partner-name='Open edX' --lms-url-root=localhost:8000 --theme-scss-path=sass/themes/edx.scss --payment-processors=cybersource,paypal --client-id=[change to OIDC client ID] --client-secret=[change to OIDC client secret]
+      $ python manage.py create_or_update_site --site-id=1 --site-domain=localhost:8002 --partner-code=edX --partner-name='Open edX' --lms-url-root=http://localhost:8000 --theme-scss-path=sass/themes/edx.scss --payment-processors=cybersource,paypal --client-id=[change to OIDC client ID] --client-secret=[change to OIDC client secret]
+
+.. note::
+    The ``--lms-url-root`` option must start with the desired protocol (e.g. ``http://``).
 
 .. _Add Another Site Partner and Site Configuration:
 


### PR DESCRIPTION
## [Configure a Site, Partner, and Site Configuration](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#configure-a-site-partner-and-site-configuration)

I installed local devstack, release `ginko.1`, and followed the provided instructions on enabling ecommerce. The screenshot describes the issue I got when the ecommerce service tried redirecting to the login page. 

<img width="921" alt="screen shot 2017-09-22 at 12 25 00" src="https://user-images.githubusercontent.com/16685686/30740502-80f59d0e-9f91-11e7-826c-bf4537a37818.png">

The issue occurs because of the missing `http://` for `--lms-url-root` option in `create_or_update_site` command.

This PR should save some time for developers.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

