### PR TITLE
Update Publisher docs following automation of Studio URL

### DIFF
--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_course_run.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_course_run.rst
@@ -31,7 +31,7 @@ In Publisher, a course run contains the following information.
 
        Pacing
 
-       ㅤEnrollment track (default is audit)
+       ㅤ:ref:`Enrollment track<enrollment_track_g>` (default is audit)
 
        Content language
 
@@ -74,7 +74,6 @@ The course run creation process in Publisher includes the following steps.
 #. :ref:`Create the course run<Pub Create a Course Run>`. In this step, you
    provide only basic information about the course run, and Publisher creates a
    page for the course run.
-#. :ref:`Receive a Studio URL <Pub Receive a Studio URL>` from the edX PC.
 #. :ref:`Edit the course run <Pub Edit a Course Run>`, adding all required
    information for the About page.
 #. :ref:`Send the course run to the edX PC for review <Pub Send a Course for
@@ -122,41 +121,9 @@ At the top of the course run page, "breadcrumbs" are visible that list the name
 of the course and the course run. For example, the breadcrumbs may be ``Courses
 > Creating an edX Course > Self-paced: June 1, 2017``.
 
-You can edit course run information at any time before you send the course run
-to the edX PC for review. For more information, see :ref:`Pub Edit a Course
-Run`.
-
-.. _Pub Receive a Studio URL:
-
-**************************************
-Receive a Studio URL for a Course Run
-**************************************
-
-.. note::
- You can edit a course run before you receive a Studio URL for the course run.
- However, the course run must have a Studio URL before you send the course run
- to the PC for review.
-
-When you create a course run, Publisher automatically sends a notification to
-the edX PC. The edX PC then creates a Studio URL for the course run. This
-process can take up to two business days.
-
-When the edX PC creates the Studio URL, this information automatically appears
-in the **Studio URL** field on the course run page. Additionally, Publisher
-sends an email notification to the course team that the Studio URL has been
-created. The email notification contains a link to the course run in Studio and
-to the course run page in Publisher.
-
-After the edX PC has created the Studio URL for the course run, the course team
-has the the following options.
-
-* Enter content for the course run in Studio. To access the course run in
-  Studio, select the link in the notification email, or select the **Studio
-  URL** link on the course run page.
-* Continue editing the course run in Publisher. For more information, see
-  :ref:`Pub Edit a Course Run`.
-* Send the course run to the edX PC for review. For more information, see
-  :ref:`Pub Send a Course Run for Review`.
+After you create a course run, you can edit course run information in Publisher
+or add course information in Studio. For more information, see :ref:`Pub Edit a
+Course Run`.
 
 .. _Pub Edit a Course Run:
 
@@ -164,12 +131,22 @@ has the the following options.
 Edit a Course Run
 *******************
 
-.. note::
- You can edit a course run before you receive a Studio URL for the course run.
- However, the course run must have a Studio URL before you send the course run
- to the PC for review.
+When you create a course run in Publisher, Studio automatically creates a URL
+for the course run. The course team then has two options.
 
- Additionally, you do not have to enter all of the required information for the
+* Enter content for the course run in Studio. For more information, see
+  :ref:`Pub Access the Course Run in Studio`.
+* Continue editing the course run in Publisher. For more information, see
+  :ref:`Pub Edit a Course Run in Publisher`.
+
+.. _Pub Edit a Course Run in Publisher:
+
+==============================
+Edit a Course Run in Publisher
+==============================
+
+.. note::
+ You do not have to enter all of the required information for the
  course run at one time. You can return to the course run page and add
  information at any time before you send the course run for review.
 
@@ -197,6 +174,24 @@ To edit a course run, follow these steps.
      opens.
 
 #. When you have made your changes, select **Update Course Run**.
+
+.. _Pub Access the Course Run in Studio:
+
+===============================
+Access the Course Run in Studio
+===============================
+
+When you create a course run in Publisher, the Studio URL for the course run
+immediately appears in the **Studio URL** field on the course run page.
+Additionally, Publisher sends an email notification to the course team. The
+email notification contains a link to the course run in Studio and to the
+course run page in Publisher.
+
+To access the course run in Studio, select the link in the notification email,
+or select the **Studio URL** link on the course run page.
+
+For more information about what content and information to enter in Studio, see
+:ref:`Partner Add Studio Information`.
 
 .. _Pub Send a Course Run for Review:
 

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_introduction.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_introduction.rst
@@ -70,12 +70,6 @@ the following process. You can click the image to enlarge it.
 #. :ref:`Create the course run <Pub Creating a Course Run>`.
 
    #. The course team creates a course run for the course.
-   #. The edX PC creates a Studio URL for the course run.
-
-      .. note::
-        After the edX PC creates a Studio URL, the course team can add course
-        content, such as lessons, in Studio at any time.
-
    #. The course team edits the course run, adding any additional required
       information.
    #. The edX PC reviews the course run.

--- a/en_us/shared/set_up_course/planning_course_run_information/additional_course_run_information.rst
+++ b/en_us/shared/set_up_course/planning_course_run_information/additional_course_run_information.rst
@@ -58,6 +58,13 @@ Optionally, you can also specify additional languages for course videos.
     If you do not specify an enrollment track, only an audit enrollment track
     is created.
 
+    .. note::
+      For courses that offer a verified enrollment track, by default, the
+      deadline for learners to upgrade to the verified track is 10 days before
+      the course end date. The deadline for learners in the verified track to
+      submit ID verification is the course end date. To request different
+      deadlines, contact your edX project coordinator (PC).
+
     For information about how to add this information in Publisher, see
     :ref:`Pub Creating a Course Run`.
 


### PR DESCRIPTION
## [DOC-3777](https://openedx.atlassian.net/browse/DOC-3777) and [DOC-3784](https://openedx.atlassian.net/browse/DOC-3784)

Add information about the automatic creation of a Studio URL and default deadlines for upgrade and verification.

### Date Needed (optional)

6 Oct 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @clintonb 
- [ ] Doc team review (copy edit): @edx/doc
- [ ] Product review: @sstack22 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

