### PR TITLE
Course welcome message is dismissed automatically after 7 days

### DIFF
--- a/en_us/shared/course_assets/handouts_updates.rst
+++ b/en_us/shared/course_assets/handouts_updates.rst
@@ -13,8 +13,10 @@ the course, and of providing orienting information that helps learners succeed
 with the course.
 
 After learners have read the welcome message, they can dismiss the message.
-Learners can access the dismissed message and any other updates from the
-**Updates** link in the sidebar on the **Course** page.
+The message is automatically dismissed seven days after the learner first
+views it if the learner doesn't actively dismiss it first. Learners can access
+the dismissed message and any other updates from the **Updates** link in the
+sidebar on the **Course** page.
 
 Handouts are links to files that you upload in Studio, for example, a PDF
 version of the course syllabus, or an article that you want learners to read.


### PR DESCRIPTION
## [DOC-3795](https://openedx.atlassian.net/browse/DOC-3795)

With the release of LEARNER-2240  , the course welcome message is dismissed 7 days after the learner first views it, if they haven't already dismissed it first. 

### Date Needed (optional)

The fiature will be released October 6

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert:  @dianakhuang 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review: @marcotuts
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

