### PR TITLE
Use 3-depth navigation on the left-hand side

### DIFF
--- a/shared/conf.py
+++ b/shared/conf.py
@@ -62,6 +62,10 @@ html_theme = 'edx_theme'
 
 html_theme_path = [edx_theme.get_html_theme_path()]
 
+html_theme_options = {
+    'navigation_depth': 3
+}
+
 html_favicon = os.path.join(edx_theme.get_html_theme_path(), 'edx_theme', 'static', 'css', 'favicon.ico')
 
 # Help and Feedback links.  These are customized for the category and audience

--- a/shared/travis_requirements.txt
+++ b/shared/travis_requirements.txt
@@ -1,3 +1,3 @@
 # Used for documentation gathering
-edx-sphinx-theme==1.2.0
+edx-sphinx-theme==1.3.0
 sphinx==1.4.9


### PR DESCRIPTION
This changes the left-hand navbar to include entries down to three-numbered headings.  This matches the doc convention of sometimes starting new pages at three-numbered headings, but never starting new pages on four-numbered headings.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @jmbowman 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

