### PR TITLE
Add ENABLE_HTML... to feature flag list

### DIFF
--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -116,6 +116,9 @@ platform.
    * - ENABLE_FEEDBACK_SUBMISSION
      - Supported
      - FALSE
+   * - ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA
+     - Supported
+     - FALSE
    * - ENABLE_INSTRUCTOR_ANALYTICS
      - Deprecated
      - FALSE


### PR DESCRIPTION
## [DOC-3803](https://openedx.atlassian.net/browse/DOC-3803)

This just adds ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA to the list of supported feature flags. It doesn't actually document what the feature flag is for. I'll probably need to do that in Confluence.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @pomegranited 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

