### PR TITLE
Add xref from RTD Feature Flag doc to edX wiki page

### DIFF
--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -5,10 +5,11 @@ Index of Open EdX Feature Flags
 ###############################
 
 The following list includes feature flags that are available in the Open edX
-platform.
+platform. For more information abut feature flags, see `edX Feature Flags`_
+in the Open edX wiki.
 
 .. list-table::
-   :widths: 15 15 70
+   :widths: 70 15 15
    :header-rows: 1
 
    * - Name
@@ -266,3 +267,5 @@ platform.
    * - USE_MICROSITES
      - Supported
      - FALSE
+
+.. include:: ../../../links/links.rst

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -222,7 +222,7 @@
 
 .. _Open edX Native Installation: https://openedx.atlassian.net/wiki/x/g4G6C
 
-
+.. _edX Feature Flags: https://openedx.atlassian.net/wiki/spaces/OpenDev/pages/34734726/edX+Feature+Flags
 
 .. THIRD PARTY LINKS
 


### PR DESCRIPTION
## [DOC-3803](https://openedx.atlassian.net/browse/DOC-3803)

Since most of the actual feature flag info is in the edX wiki, I added a link from the RTD page to the wiki page.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

