### PR TITLE
DOC-2853: Move "Testing Open edX Features" to Open edX Developer's Guide

### DIFF
--- a/en_us/developers/source/testing/index.rst
+++ b/en_us/developers/source/testing/index.rst
@@ -6,8 +6,8 @@ Testing is something that we take very seriously at edX: we even have a
 "test engineering" team at edX devoted purely to making our testing
 infrastructure even more awesome.
 
-This file is currently a stub: to find out more about our testing infrastructure,
-check out the `testing.rst`_ file on GitHub.
+To find out more about our testing infrastructure, check out the `testing.rst`_
+file on GitHub.
 
 .. toctree::
     :maxdepth: 2
@@ -15,5 +15,6 @@ check out the `testing.rst`_ file on GitHub.
     jenkins
     code-coverage
     code-quality
+    test_openedx_features
 
 .. _testing.rst: https://github.com/edx/edx-platform/blob/6d2468d0dcf782a7561ecc61946146d6fae2762f/docs/en_us/internal/testing.rst

--- a/en_us/developers/source/testing/test_openedx_features.rst
+++ b/en_us/developers/source/testing/test_openedx_features.rst
@@ -1,8 +1,8 @@
-.. _Test Features:
+.. _Test OpenedX Features:
 
-###############
-Test Features
-###############
+##########################
+Testing Open edX Features
+##########################
 
 .. This topic will move to a different section in the ICR guide after the reorg
 .. of the guide is complete.

--- a/en_us/install_operations/source/ecommerce/index.rst
+++ b/en_us/install_operations/source/ecommerce/index.rst
@@ -31,7 +31,6 @@ information, see :ref:`Additional Ecommerce Features`.
    create_products/index
    enable_receipt_page
    manage_orders
-   test_features
    test_ecommerce
    additional_features/index
 

--- a/en_us/install_operations/source/ecommerce/test_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/test_ecommerce.rst
@@ -9,7 +9,7 @@ create and run tests for the Open edX platform first, and then you run a set of
 tests that are specific to E-Commerce.
 
 For more information about tests for the Open edX platform, see
-:ref:`Test Features`.
+:ref:`opendevelopers:Test OpenedX Features` in the *Open edX Developer's Guide*.
 
 ********************
 Tests for E-Commerce


### PR DESCRIPTION
## [DOC-2853](https://openedx.atlassian.net/browse/DOC-2853)
The "Test Features" topic used to live within the "Ecommerce" section but it applied to all Open edX development. Moved the topic to the Open edX Developer's Guide as "Testing Open edX Features". Kept the link to that topic from the Testing eCommerce topic, but as a cross-publication link. 

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check, copy edit, or dev edit?): @grantgoodmanedX 

### Testing

- [x] Ran ./run_tests.sh with only the expected error in the anchor link until the Developer's Guide is published.

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

