### PR TITLE
Moved location of email opt-in report

### DIFF
--- a/en_us/data/source/internal_data_formats/institution_data.rst
+++ b/en_us/data/source/internal_data_formats/institution_data.rst
@@ -1,7 +1,7 @@
 .. _Institution_Data:
 
 #######################
-Institution-wide Data
+Email Opt-in Report
 #######################
 
 The data package includes a report of data collected across all of an
@@ -12,20 +12,16 @@ useful to administrative or marketing teams, rather than research teams.
 
 .. _Email Opt In Report:
 
-*********************
-Email Opt In Report
-*********************
-
-When students enroll in a course on edx.org, they can specify whether they
+When learners enroll in a course on edx.org, they can specify whether they
 want to receive email from the organization that presents the course.
 
-The ``{org}-email_opt_in-{site}-analytics.csv`` file reports the email
-preference selected by each student enrolled in your institution's courses.
-You can use this information to develop a distribution list for campaigns that
-introduce new or related courses to students.
+The ``email-opt-in/{org}-email_opt_in-{site}-analytics.csv`` file reports the
+email preference selected by each learner enrolled in your institution's
+courses. You can use this information to develop a distribution list for
+campaigns that introduce new or related courses to learners.
 
-.. note:: Your data package includes a .csv file for the edx.org site only. 
-  At this time, students can specify an email preference only on edx.org.
+.. note:: Your data package includes a ``.csv`` file only for the edx.org
+   site. Learners can specify an email preference only on edx.org.
 
 The file contains data in these columns.
 
@@ -38,7 +34,7 @@ The file contains data in these columns.
 user_id
 =========
 
-The learner's ID in ``auth_user.id``. For more information, see 
+The learner's ID in ``auth_user.id``. For more information, see
 :ref:`auth_user`.
 
 **History**: This column was added in Jan 2017.
@@ -47,8 +43,8 @@ The learner's ID in ``auth_user.id``. For more information, see
 username
 =========
 
-The learner's username in ``auth_user.username``. For more information, see 
-:ref:`auth_user`. 
+The learner's username in ``auth_user.username``. For more information, see
+:ref:`auth_user`.
 
 **History**: This column was added in Jan 2017.
 
@@ -56,7 +52,7 @@ The learner's username in ``auth_user.username``. For more information, see
 email
 =========
 
-The email address that the student used to register a user account on the
+The email address that the learner used to register a user account on the
 site. For more information, see the ``auth_user.email``
 :ref:`column<auth_user>`.
 
@@ -64,14 +60,14 @@ site. For more information, see the ``auth_user.email``
 full_name
 =========
 
-The name that the student supplied. For more information, see the
+The name that the learner supplied. For more information, see the
 ``auth_userprofile.name`` :ref:`column<auth_userprofile>`.
 
 =========
 course_id
 =========
 
-The ID of the course run in which the student is enrolled. For more
+The ID of the course run in which the learner is enrolled. For more
 information, see the ``student_courseenrollment.course_id``
 :ref:`column<student_courseenrollment>`.
 
@@ -79,15 +75,15 @@ information, see the ``student_courseenrollment.course_id``
 is_opted_in_for_email
 ===========================
 
-True or False. By default, this preference is set to True. If a student is
-enrolled in more than one course, the option that the student selected most
+True or False. By default, this preference is set to True. If a learner is
+enrolled in more than one course, the option that the learner selected most
 recently applies to all of the courses.
 
 ===========================
 preference_set_datetime
 ===========================
 
-Indicates when the student selected this preference. If a student is enrolled
+Indicates when the learner selected this preference. If a learner is enrolled
 in more than one of your institution's courses, the date and time when the
-student most recently selected an email preference applies to all of the
+learner most recently selected an email preference applies to all of the
 courses.

--- a/en_us/data/source/using/package.rst
+++ b/en_us/data/source/using/package.rst
@@ -90,6 +90,9 @@ Data package files are located at the following Amazon S3 destinations:
 * The **s3://course-data** bucket contains the weekly ``{org}-{date}.zip``
   database snapshot.
 
+* The **s3://course-data/email-opt-in** folder contains the report listing
+  learners who have consented to be contacted by email.
+
 For information about accessing Amazon S3, see :ref:`Access Amazon S3`.
 
 .. _Download Data Packages from Amazon S3:
@@ -145,6 +148,23 @@ Download Weekly Database Files
 #. Download the ``{org}-{date}.zip`` database data file from the
    **s3://course-data** bucket.
 
+========================================
+Download the Learner Email Opt-in Report
+========================================
+
+#. To download the report listing learners who have consented to be contacted
+   by email, connect to the edX **s3://course-data** bucket on Amazon S3 using
+   the AWS Command Line Interface or a third-party tool.
+
+   For information about providing your credentials to connect to Amazon S3,
+   see :ref:`Access Amazon S3`.
+
+#. Navigate within the **s3://course-data** bucket to the
+   **s3://course-data/email-opt-in** folder.
+
+#. Download the ``{org}-{date}.zip`` file from the
+   **s3://course-data/email-opt-in** folder.
+
 
 .. _Data Package Contents:
 
@@ -187,8 +207,8 @@ institution, you complete these steps.
    :ref:`Decrypt an Encrypted File`.
 
 The result of extracting and decrypting the ``{org}-{date}.zip`` file is the
-following set of .sql, .csv, and .mongo files. Note that the .sql files are
-tab separated.
+following set of ``.sql``, ``.csv``, and ``.mongo`` files. Note that the
+``.sql`` files are tab separated.
 
 .. contents::
    :local:
@@ -234,12 +254,6 @@ courses). See :ref:`courseware_studentmodule`.
 
 This file lists the role that every enrolled user has for course discussions.
 See :ref:`django_comment_client_role_users`.
-
-``{org}-email_opt_in-{site}-analytics.csv``
-***********************************************
-
-This file reports the email preference selected by learners who are enrolled
-in any of your institution's courses. See :ref:`Institution_Data`.
 
 ``{org}-{course}-{run}-student_courseaccessrole-{site}-analytics.sql``
 **********************************************************************
@@ -355,6 +369,29 @@ Information about the articles added to the course wiki. See
 
 Changes and deletions affecting course wiki articles. See
 :ref:`wiki_articlerevision`.
+
+========================================================
+Extracted Contents of ``email-opt-in/{org}-{date}.zip``
+========================================================
+
+After you download the ``{email-opt-in/org}-{date}.zip`` file for your
+institution, you complete these steps.
+
+#. Extract the contents of the file. When you extract (or unzip) this file,
+   the contents are a single file that ends in ``.gpg``, which indicates that
+   it is encrypted.
+
+#. Use your private key to decrypt the extracted file. See
+   :ref:`Decrypt an Encrypted File`.
+
+The result of extracting and decrypting the ``{org}-{date}.zip`` file is the
+following ``.csv`` file.
+
+``{org}-email_opt_in-{site}-analytics.csv``
+***********************************************
+
+This file reports the email preference selected by learners who are enrolled
+in any of your institution's courses. See :ref:`Institution_Data`.
 
 
 .. include:: ../../../links/links.rst


### PR DESCRIPTION
## [DOC-3819](https://openedx.atlassian.net/browse/DOC-3819)

I updated the Research Guide to reflect EDUCATOR-1436, which makes the email opt-in report available separately, in its own folder on S3.

### Date Needed (optional)

This feature goes into effect about November 11.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @iloveagent57 
- [x] Subject matter expert: @stroilova 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

