### PR TITLE
Add info for learners about discussion notifications

### DIFF
--- a/en_us/shared/students/sfd_discussions/keep_up.rst
+++ b/en_us/shared/students/sfd_discussions/keep_up.rst
@@ -46,8 +46,8 @@ Sorting by Votes
 ==================
 
 In the discussion navigation pane you can sort posts by the number of votes
-received. To do this, select the drop-down list of sorting options at the top of
-the discussion navigation pane, and select **by most votes**.
+received. To do this, select the drop-down list of sorting options at the top
+of the discussion navigation pane, and select **by most votes**.
 
 Sorting by the most votes changes the order of the posts so that posts that
 have received the most votes appear at the top of the list. In this view,
@@ -58,17 +58,62 @@ number.
 For more information about voting for posts, see :ref:`Vote for Posts or
 Responses`.
 
+.. _Receiving Discussion Notifications:
 
-****************************
+*****************************
+Receiving Notifications
+*****************************
+
+When you add a post to a discussion, you can receive an email notification
+about the first reply to the post. You can also receive a digest email message
+each day that summarizes activity for the posts that you are following.
+
+==============================
+Receiving Email Notifications
+==============================
+
+By default, the first time another learner or member of the course team
+responds to a post that you have made, you receive an email notification.
+
+If you do not want to receive this email notification, clear the **Receive
+updates** checkbox before you add your post.
+
+You only receive an email notification for the first response. For additional
+responses and comments, you automatically receive information in a daily digest
+email message. For more information, see :ref:`Receiving Daily Digests`.
+
+.. _Receiving Daily Digests:
+
+=======================
 Receiving Daily Digests
-****************************
+=======================
 
-You have the option to receive an email message each day that summarizes
-discussion activity for the posts you are following. To receive this daily
-digest, select **Discussion** to go to the discussions home page, and then
-select the **Receive updates** check box in the **How to use edX discussions**
-graphic.
+You can subscribe to a daily digest to receive an email message each day that
+summarizes discussion activity for the posts you are following. To subscribe to
+the daily digest, follow these steps.
+
+#. In your course, select **Discussion**.
+#. In the **How to use edX discussions** graphic, select the **Receive
+   updates** checkbox.
 
 .. image:: ../../../shared/images/Discussion_ReceiveUpdates.png
   :width: 600
-  :alt: Discussion how to graphic with the Receive Updates check box circled
+  :alt: "How to use edX discussions" graphic with the Receive Updates checkbox
+      circled.
+
+================================
+Unsubscribing from Notifications
+================================
+
+If you want to unsubscribe from notifications, complete either of the following
+actions.
+
+* If you received an email message, select **Unsubscribe** in the message.
+* On the **Discussion** page in your course, clear the **Receive updates**
+  checkbox in the **How to use edX discussions** graphic.
+
+.. note::
+    These actions unsubscribe you from daily digest email messages. If you
+    create a new post, you will still receive an email message the first time
+    that a learner responds to that post. To prevent an email notification for
+    a post, clear the **Receive updates** checkbox before you add the post.


### PR DESCRIPTION
## [DOC-3815](https://openedx.atlassian.net/browse/DOC-3815)

Add info for learners about discussion notifications, including info about how to unsubscribe.

### Date Needed (optional)

13 November 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @sanfordstudent, @iloveagent57, or @ssemenova 
- [x] Doc team review (copy edit): @edx/doc
- [ ] Product review: @shamck 
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

