### PR TITLE
DOC-3348 and DOC-3503: Fix devstack instructions

### DIFF
--- a/en_us/install_operations/source/configuration/enable_certificates.rst
+++ b/en_us/install_operations/source/configuration/enable_certificates.rst
@@ -14,8 +14,8 @@ This topic describes how to enable certificates in your instance of Open edX.
 Overview
 *********
 
-Organizations and course teams can generate certificates for learners who pass
-a course. Learners can view, print, or share their certificates.
+Organizations and course teams can choose to generate certificates for learners
+who pass a course. Learners can view, print, or share their certificates.
 
 For information about certificates, see :ref:`opencoursestaff:Setting Up
 Certificates` in *Building and Running an Open edX Course* or

--- a/en_us/install_operations/source/installation/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/installation/devstack/install_devstack.rst
@@ -117,6 +117,9 @@ To install devstack, follow these steps.
     information about the latest Open edX releases and the Git tag names for
     them, see `Open edX Releases Wiki page`_.
 
+    Set ``OPENEDX_RELEASE`` to ``master`` to create devstack from master instead
+    of a named Open edX release.
+
     For example, ``open-release/eucalyptus.1`` is the Git tag name for the
     first Eucalyptus release. The following command sets the value of the
     ``OPENEDX_RELEASE`` environment variable to ``open-release/eucalyptus.1``.
@@ -125,9 +128,6 @@ To install devstack, follow these steps.
 
       export OPENEDX_RELEASE="open-release/eucalyptus.1"
 
-    If you do not set this environment variable, Vagrant will install the most
-    recent snapshot version of the Open edX platform. The snapshot version is
-    not a supported release.
 
 #. Download the install script.
 


### PR DESCRIPTION
## [DOC-3348](https://openedx.atlassian.net/browse/DOC-3348)
## [DOC-3503](https://openedx.atlassian.net/browse/DOC-3503)

Update the devstack installation instructions in the ICR guide - use "master" for the OPENEDX_RELEASE env var to create devstack using master.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @amangano-edx 
- [x] Doc team review (sanity check): @edx/doc 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

