### PR TITLE
Add discussion notification info to list of automatic edX emails

### DIFF
--- a/en_us/shared/manage_live_course/automatic_email.rst
+++ b/en_us/shared/manage_live_course/automatic_email.rst
@@ -42,8 +42,10 @@ of automatic email messages.
      next course "week", or section. Is not sent if the course team has not
      added highlights for the section in Studio. For more information, see
      :ref:`Set Section Highlights for Weekly Course Highlight Messages`.
-
-
+ * - :ref:`Discussion Notification`
+   - Instructor-paced and self-paced
+   - Unspecified
+   - Notifications that a user has responded to a post on a discussion.
 
 *****************************
 Automatic Email Message Text
@@ -161,4 +163,29 @@ Course Highlight Messages`.
 
 .. include:: ../../../shared/developing_course/course_highlight_message_text.rst
 
+.. _Discussion Notification:
 
+================================
+Discussion Notification
+================================
+
+After a learner or course team member creates a post in the course discussions,
+edX sends the following email message the first time a learner or course team
+member replies to the original post.
+
+::
+
+  Subject: Response to <title of post>
+
+  <edX username> replied to <title of post>:
+
+    <text of comment>
+
+The message also contains a **View discussion** option that takes the learner
+to the discussion post.
+
+EdX does not send individual messages for any additional replies on the post.
+However, the learner automatically receives a daily digest email message that
+summarizes additional activity on the post. For more information, see
+:ref:`learners:Receiving Discussion Notifications` and
+:ref:`learners:Receiving Daily Digests`.


### PR DESCRIPTION
## [DOC-3833](https://openedx.atlassian.net/browse/DOC-3833)

This PR adds discussion notification info to the list of email messages that edX sends automatically.

Note: I had to create a separate PR for this because the topic that has the list of automatic email messages didn't exist when I wrote the original docs for this feature, which are in [PR 1620](https://github.com/edx/edx-documentation/pull/1620).

Note 2: This PR has a failing test because it links to topics that haven't been published yet. They'll be published at the same time as the changes in this PR.

### Date Needed (optional)

30 November 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @iloveagent57 or @ssemenova 
- [ ] Subject matter expert: 
- [x] Doc team review (copy edit?): @edx/doc
- [ ] Product review: @shamck 
- [ ] Partner support: 
- [ ] PC review: Eden Pirog (GitHub account pending)

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors


### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

