### PR TITLE
Clear proctored and timed exam attempts DOC-3820

### DIFF
--- a/en_us/shared/course_features/proctored_exams/proctored_managing.rst
+++ b/en_us/shared/course_features/proctored_exams/proctored_managing.rst
@@ -11,8 +11,8 @@ Rules>`, or to :ref:`learners:SFD_ProctoredExams` in the *edX Learner’s Guide*
 to answer their questions.
 
 If learners need accommodations for disabilities, or have a technical problem
-with the exam, you work with edX support to determine a solution on a case by
-case basis.
+with the exam, you work with edX support to determine a solution on a
+case by case basis.
 
 .. _Respond to Learner Concerns about Proctored Exams:
 
@@ -49,17 +49,34 @@ reviewer takes the special allowance or extra time into account.
 .. _Requests for Retaking a Proctored Exam:
 
 ******************************************
-Allow a Learner to Retake a Proctored Exam
+Allow Learners to Retake a Proctored Exam
 ******************************************
 
-If a learner needs to retake a proctored exam for any reason, instruct the
-learner to contact edX Support.
+If a learner needs to retake a proctored exam for any reason, you can clear
+their existing exam attempt and allow them to retake the exam.
 
 .. note::
 
-  When a learner retakes an exam, the learner starts the exam from the
-  beginning. The learner must set up the proctoring software, answer exam
-  questions, and complete all other steps again.
+  When you clear a learner's exam attempt, all of a learner's previous answers
+  in the exam are cleared, and the learner starts the exam from the beginning.
+  The learner must set up the proctoring software, answer exam questions, and
+  complete all other steps again.
+
+To clear a proctored exam attempt, follow these steps.
+
+#. View the live version of your course.
+#. Select **Instructor**, and then select **Special Exam**.
+#. Expand **Student Special Exam Attempts**. A list of timed and proctored exam
+   attempts appears.
+#. Search for the learner's username to locate their exam attempts.
+#. In the **Exam Name** column, locate the name of the specific exam for which
+   you are cleaning the learner's exam attempt.
+#. In the **Actions** column, select **X**. A message displays asking you
+   to confirm that you want to remove the learner's exam attempt.
+#. Select **OK**. The learner's exam attempt is removed from the list.
+
+   .. Warning:: Clearing an exam attempt removes all learner answers in an
+      exam and is a permanent action that cannot be undone.
 
 .. _CA_Situations_Learners_Encounter_Proctored_Exams:
 

--- a/en_us/shared/course_features/timed_exams.rst
+++ b/en_us/shared/course_features/timed_exams.rst
@@ -153,6 +153,35 @@ extra time to complete a timed exam.
 
 
 *****************************************
+Allow Learners to Retake a Timed Exam
+*****************************************
+
+If a learner needs to retake a timed exam for any reason, you can clear
+their exam attempt and allow them to retake the exam.
+
+.. note::
+
+  When you clear a learner's exam attempt, all of the learner's previous
+  answers in the exam are cleared, and the learner starts the exam from the
+  beginning.
+
+To clear a timed exam attempt, follow these steps.
+
+#. View the live version of your course.
+#. Select **Instructor**, and then select **Special Exam**.
+#. Expand **Student Special Exam Attempts**. A list of timed and proctored exam
+   attempts appears.
+#. Search for the learner's username to locate their exam attempts.
+#. In the **Exam Name** column, locate the name of the specific exam for which
+   you are cleaning the learner's exam attempt.
+#. In the **Actions** column, select **X**. A message displays asking you
+   to confirm that you want to remove the learner's exam attempt.
+#. Select **OK**. The learner's exam attempt is removed from the list.
+
+   .. Warning:: Clearing an exam attempt removes all learner answers in an
+      exam and is a permanent action that cannot be undone.
+
+*****************************************
 Hide a Timed Exam After Its Due Date
 *****************************************
 

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -833,6 +833,16 @@ P
   For more information, see :ref:`partnercoursestaff:Working with Problem
   Components` and :ref:`partnercoursestaff:Exercises and Tools Index`.
 
+.. _Proctored Exam_g:
+
+**proctored exam**
+
+  At edX, proctored exams are timed, impartially and electronically monitored
+  exams designed to ensure the identity of the test taker and determine the
+  security and integrity of the test taking environment. Proctored exams are
+  often required in courses that offer verified certificates or academic
+  credit. For more information, see :ref:`partnercoursestaff:Managing
+  Proctored Exams`.
 
 .. _Program:
 
@@ -961,6 +971,13 @@ S
   information about third party authentication, see
   :ref:`Third Party Authentication<T>`.
 
+.. _Special Exam_g:
+
+**special exam**
+
+  A general term that applies to proctored and timed exams in edX courses. See
+  :ref:`Timed Exam<T>` and :ref:`Proctored Exam<P>`.
+
 .. _Split_Test:
 
 **split test**
@@ -994,6 +1011,16 @@ T
   against a specified expected answer.
 
   For more information, see :ref:`partnercoursestaff:Text Input`.
+
+.. _Timed Exam_g:
+
+**timed exam**
+
+  Timed exams are sets of problems that a learner must complete in the amount
+  of time you specify. When a learner begins a timed exam, a countdown timer
+  displays, showing the amount of time allowed to complete the exam.
+  If needed, you can grant learners additional time to complete the exam.
+  For more information, see :ref:`partnercoursestaff:Timed Exams`.
 
 .. _TPA_g:
 


### PR DESCRIPTION
Added instructions on how to clear an exam attempt, in order to allow learners to retake a proctored or timed exam. Also, added three glossary definitions:
 - proctored exam
 - timed exam
- special exam

### Date Needed (optional)

1 December 2017

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @Rabia23
- [ ] Subject matter expert: 
- [ ] Doc team review (copy edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PC review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors


### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

