### PR TITLE
Update organization selection info in Publisher docs

### DIFF
--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_course_creation.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_course_creation.rst
@@ -43,8 +43,8 @@ use the following process to create the course in Publisher.
 
 #. :ref:`Create the course in Publisher <Pub Create a Course>`. In this step,
    you provide basic information to create a page for the course in Publisher.
-#. :ref:`Edit the course <Pub Edit a Course>`, adding all required information
-   for the About page on the page for the course in Publisher.
+#. :ref:`Edit the course <Pub Edit a Course in Publisher>`, adding all required
+   information for the About page on the page for the course in Publisher.
 #. :ref:`Send the course to the edX marketing team <Pub Send a Course for
    Marketing Review>` for review.
 #. After the edX marketing team reviews the course, :ref:`review the edX

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_create_course.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_create_course.rst
@@ -37,7 +37,7 @@ To create a course in Publisher, follow these steps.
    information that you have entered and the additional course information that
    is required for edX to create an About page. You can edit course information
    at any time before you send the course to edX marketing for review. For more
-   information, see :ref:`Pub Edit a Course`.
+   information, see :ref:`Pub Edit a Course in Publisher`.
 
    If you selected **I want to add a run to this course at this time**, the
    page for a course run of this course opens when you select **Create New

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_add_course_run_staff.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_add_course_run_staff.rst
@@ -150,27 +150,24 @@ To specify an organization for an instructor, follow these steps.
    * Follow the steps in :ref:`Pub Edit an Instructor`.
 
 #. Next to **Organization**, click to open the drop-down list of organizations.
-#. Select the organization that you want.
 
-.. The following feature will be implemented ~late November/early December 2017. Uncomment this section and delete step 3 above when the feature is live.
+#. If the organization that you want is listed, select that organization.
 
-.. #. If the organization that you want is listed, select that organization.
+   If the organization that you want is not listed, or you want to specify more
+   than one organization for the instructor, follow these steps.
 
-..   If the organization that you want is not listed, or you want to specify more
-..   than one organization for the instructor, follow these steps.
+   #. Under the **Instructor** field, select **Enter a different
+      organization**.
+   #. In the **Organization** field, type the name of the organization or
+      organizations that are associated with the instructor. For example, you
+      might enter the following information.
 
-..   #. Under the **Instructor** field, select **Enter a different
-..      organization**.
-..   #. In the **Organization** field, type the name of the organization or
-..      organizations that are associated with the instructor. For example, you
-..      might enter the following information.
+      ``MIT and Harvard``
 
-..        MIT and Harvard
-
-..        note
-..        Only enter the name of the organization or organizations and words such
-..        as "and". Do not enter additional text, such as "This instructor is
-..        affiliated with MIT and Harvard".
+      .. note::
+        Only enter the name of the organization or organizations and words such
+        as "and". Do not enter additional text, such as "This instructor is
+        affiliated with MIT and Harvard".
 
 
 .. _Pub Add an Instructor Image:

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_edit_course_run.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_edit_course_run.rst
@@ -9,7 +9,7 @@ When you create a course run in Publisher, Studio automatically creates a URL
 for the course run. The course team then has two options.
 
 * Enter content for the course run in Studio. For more information, see
-  :ref:`Pub Access the Course Run in Studio`.
+  :ref:`Pub Access a Course Run in Studio`.
 * Continue editing the course run in Publisher. For more information, see
   :ref:`Pub Edit a Course Run in Publisher`.
 


### PR DESCRIPTION
## [DOC-3844](https://openedx.atlassian.net/browse/DOC-3844)

Quick change to organization selection information in the Publisher docs.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (copy edit): @edx/doc
### Testing

- [ ] Ran ./run_tests.sh without warnings or errors


### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

