### PR TITLE
Add info about weekly course highlight persistence for re-runs

### DIFF
--- a/en_us/shared/developing_course/course_sections.rst
+++ b/en_us/shared/developing_course/course_sections.rst
@@ -278,6 +278,9 @@ Set Section Highlights for Weekly Highlight Emails
 
   For more information, contact your Open edX system administrator.
 
+.. note::
+   The highlights that you specify persist when you re-run your course.
+
 .. only:: Partners
 
   .. _Weekly Course Highlight Message Text:


### PR DESCRIPTION
## [DOC-3850](https://openedx.atlassian.net/browse/DOC-3850)

Adds "Note: The highlights that you specify persist when you re-run your course." to "Set Section Highlights for Weekly Highlight Emails".

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (copy edit?): @edx/doc
- [ ] Product review: @shamck 
- [ ] PM review: @mmacfarlane

FYI: Tag anyone else who might be interested in this PR here.


### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

