### PR TITLE
Fix broken links on a11y best practices page

### DIFF
--- a/en_us/shared/accessibility/best_practices_course_content_dev.rst
+++ b/en_us/shared/accessibility/best_practices_course_content_dev.rst
@@ -12,9 +12,9 @@ methods. We welcome any comments and questions.
 
 * Send an email message to accessibility@edx.org.
 * Submit a comment on the edX `Website Accessibility Policy
-  <http://www.edx.org/accessibility>` page.
+  <http://www.edx.org/accessibility>`_ page.
 * Submit a comment on the `Individualized Accessibility Process for Course
-  Creators <https://studio.edx.org/accessibility>` page.
+  Creators <https://studio.edx.org/accessibility>`_ page.
 
 .. Do not modify wording of the following note. Exact wording is from Legal.
 


### PR DESCRIPTION
Fixes broken links on the [Accessibility Best Practices for Developing Course Content](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/accessibility/best_practices_course_content_dev.html) page.

### Date Needed (optional)

ASAP

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (sanity check): @edx/doc


### Testing

- [ ] Ran ./run_tests.sh without warnings or errors



