### PR TITLE
Research Guide: Update description of 'location' in upgrade.clicked event

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
@@ -2216,7 +2216,7 @@ event type also includes the following ``context`` member field.
    * - ``location``
      - string
      - The location in the LMS where the student clicked an upgrade link or
-       button: 'date-sidebar', 'hero', 'learner_dashboard', or 'sock'.
+       button.
    * - ``mode``
      - string
      - Enrollment mode when the user clicked an upgrade link or button:


### PR DESCRIPTION
## [DOC-3865](https://openedx.atlassian.net/browse/DOC-3865)

Changes to the description of the 'location' field, from https://openedx.atlassian.net/wiki/spaces/AN/pages/53510700/Course+Home+Page+Event+Design?focusedCommentId=471400694#comment-471400694

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @robrap 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

