### PR TITLE
Update docs to reflect new Resume Course button behavior

### DIFF
--- a/en_us/shared/students/SFD_content_availability.rst
+++ b/en_us/shared/students/SFD_content_availability.rst
@@ -17,7 +17,7 @@ Below any messages from the course team, you see the course outline.
 Click **Start Course** to go to the first section of the course, or select any
 part of the course to jump to it. If you have already accessed or worked in
 the course, click **Resume Course** to jump to the part of the course that you
-last accessed.
+last completed.
 
 
 ********************************************************
@@ -62,7 +62,7 @@ Course Content Can Have Prerequisites
 Some courses include content that has prerequisite sections. A section with a
 prerequisite requires that you complete another, previous section before it
 becomes available. The course team sets a minimum score that you must earn in
-a prerequisite section before you can proceed to the following section. 
+a prerequisite section before you can proceed to the following section.
 
 If a section has a prerequisite, the course outline displays that
 section with a lock icon, and you cannot open that section until you have

--- a/en_us/shared/students/SFD_start_course.rst
+++ b/en_us/shared/students/SFD_start_course.rst
@@ -107,7 +107,7 @@ To start work in a course that is in progress, follow these steps.
 
    If you have already accessed or worked in the course, you see a **Resume
    Course** button instead of a **Start Course** button. Click **Resume
-   Course** to jump to the part of the course that you last accessed.
+   Course** to jump to the part of the course that you last completed.
 
 
 ==============================


### PR DESCRIPTION
## [DOC-3870](https://openedx.atlassian.net/browse/DOC-3870)

DOC-3870 updates the learner docs to reflect the new behavior of the Resume Course button ([EDUCATOR-2088](https://openedx.atlassian.net/browse/EDUCATOR-2088)). Instead of returning the learner to the last _accessed_ page, the button will now return the learner to the last _completed_ page. 

### Date Needed (optional)

26 January 2018

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @yro 
- [ ] Doc team review (sanity check): @edx/doc
- [ ] Product review: @shamck 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

