### PR TITLE
Clarify date of first weekly course highlight email message

### DIFF
--- a/en_us/shared/developing_course/course_sections.rst
+++ b/en_us/shared/developing_course/course_sections.rst
@@ -243,6 +243,8 @@ Set Section Highlights for Weekly Highlight Emails
   When you add highlights for a section, keep the following information in
   mind.
 
+  * EdX sends the first highlight email seven days after the learner enrolls in
+    a course, and sends additional highlight emails every seven days.
   * Each highlight has a limit of 250 characters.
   * If you include a hyperlink in your highlights, we recommend that you use a
     URL shortener to shorten any long URLs, and then enter the shortened URL in


### PR DESCRIPTION
## [DOC-3874](https://openedx.atlassian.net/browse/DOC-3874)

This PR updates the weekly course highlight docs to specify when the first highlight is sent, per request from Anant.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (copy edit?): @edx/doc
- [x] Product review: @shamck 

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

