### PR TITLE
Removing release notes from the build-rtd-documents script

### DIFF
--- a/utilities/build-rtd-documents.sh
+++ b/utilities/build-rtd-documents.sh
@@ -29,8 +29,7 @@ then
             open-edx-building-and-running-a-course
             open-edx-learner-guide
             edx-developer-guide
-            edx-release-notes
-            "
+           "
 else
    DOC_IDS=${1}
 fi
@@ -41,6 +40,7 @@ fi
 # edx-open-learning-xml - Removed from list, moved to Inactive status
 # course-catalog-api-guide - Removed from list, moved to Inactive status
 # xblock-tutorial - Removed from list, moved to Inactive status
+# edx-release-notes - Removed from list 9 Feb 2018 because it's inactive
 
 for DOC_ID in ${DOC_IDS}
 do


### PR DESCRIPTION
We don't create new release notes anymore, and changes to documentation can cause errors in the old release notes. Removing the release notes from the automatic build script.