### PR TITLE
Remove references to the edx-platform-api docs

### DIFF
--- a/en_us/open_edx_release_notes/source/eucalyptus.rst
+++ b/en_us/open_edx_release_notes/source/eucalyptus.rst
@@ -506,9 +506,6 @@ deprecated.
 * Use the ``/api/user/v1/accounts/`` web service instead of the deprecated
   profile image web service.
 
-For more information about supported and deprecated web services,
-see :ref:`openplatformapi:Open edX Platform APIs`.
-
 ==================================
 Deprecated Tools and Problem Types
 ==================================

--- a/en_us/release_notes/source/2015/analytics/analytics_1001_2015.rst
+++ b/en_us/release_notes/source/2015/analytics/analytics_1001_2015.rst
@@ -1,5 +1,5 @@
 
 A course team member can now use the Enrollment API to find out which of his
 or her courses a particular learner is enrolled in. For more information, see
-:ref:`openplatformapi:edX Platform Enrollment API`. (OSPR-754)
+*edX Platform Enrollment API*. (OSPR-754)
 

--- a/en_us/release_notes/source/2015/documentation/doc_0415_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0415_2015.rst
@@ -30,9 +30,8 @@ structure file.
 Open edX Platform APIs
 ==================================
 
-Added sections for :ref:`openplatformapi:EdX Platform Course Structure API
-Version 0`, :ref:`openplatformapi:edX Platform Enrollment API`, and
-:ref:`openplatformapi:edX Platform User API`.
+Added sections for edX Platform Course Structure API Version 0, edX Platform
+Enrollment API, and edX Platform User API.
 
 ==================================
 Open edX Developer's Guide

--- a/en_us/release_notes/source/2015/documentation/doc_0428_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0428_2015.rst
@@ -13,7 +13,7 @@ Building and Running an edX Course
 EdX Platform APIs
 ==================================
 
-* Updated the example responses in the :ref:`openplatformapi:edX Platform
-  Enrollment API` documentation to include new ``enrollment_start``
+* Updated the example responses in the *edX Platform
+  Enrollment API* documentation to include new ``enrollment_start``
   and ``enrollment_end`` fields.
 

--- a/en_us/release_notes/source/2015/documentation/doc_0512_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0512_2015.rst
@@ -12,7 +12,6 @@ certificate statuses. For more information, see
 Open edX Platform APIs
 ==================================
 
-* Updated the :ref:`openplatformapi:edX Platform User API` to
-  Version 1.
+* Updated the edX Platform User API to Version 1.
 
-* Added the :ref:`openplatformapi:User Preferences API`.
+* Added the User Preferences API.

--- a/en_us/release_notes/source/2015/documentation/doc_0610_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0610_2015.rst
@@ -81,4 +81,4 @@ Open EdX Platform APIs
 ========================
 
 A new section of the *EdX Platform APIs* guide is now available for the
-:ref:`openplatformapi:Profile Images API Version 1.0`.
+Profile Images API Version 1.0.

--- a/en_us/release_notes/source/2015/documentation/doc_0616_2015.rst
+++ b/en_us/release_notes/source/2015/documentation/doc_0616_2015.rst
@@ -3,7 +3,6 @@
 Open EdX Platform APIs
 ========================
 
-In the *EdX Platform APIs* guide, the :ref:`openplatformapi:edX Platform
-Enrollment API` section has been updated to reflect the addition of
-a new GET parameter that will include expired course modes. For details, see
-:ref:`openplatformapi:Get the Users Enrollment Status in a Course`.
+In the *EdX Platform APIs* guide, the *edX Platform
+Enrollment API* section has been updated to reflect the addition of
+a new GET parameter that will include expired course modes.

--- a/en_us/release_notes/source/2015/openedx/openedx_0415_2015.rst
+++ b/en_us/release_notes/source/2015/openedx/openedx_0415_2015.rst
@@ -1,8 +1,8 @@
 
-The following APIs are now available.
+The following edX Platform APIs are now available.
 
-* :ref:`openplatformapi:EdX Platform Course Structure API Version 0`
+* Course Structure API Version 0
 
-* :ref:`openplatformapi:edX Platform Enrollment API`
+* Enrollment API
 
-* :ref:`openplatformapi:edX Platform User API`
+* User API

--- a/en_us/release_notes/source/2016/openedx/openedx_0411_2016.rst
+++ b/en_us/release_notes/source/2016/openedx/openedx_0411_2016.rst
@@ -25,4 +25,4 @@ deprecated.
   profile image web service.
 
 For more information about supported and deprecated web services,
-see :ref:`openplatformapi:Open edX Platform APIs`.
+see *Open edX Platform APIs*.

--- a/en_us/release_notes/source/reusables/documentation.rst
+++ b/en_us/release_notes/source/reusables/documentation.rst
@@ -13,12 +13,12 @@ The following documentation is available for edX Partners.
 * :ref:`data:edX Research Guide`
 
 The following documentation is available for Open edX users.
-  
+
 * :ref:`openreleasenotes:Open edX Release Notes`
-  
+
 * :ref:`installation:Installing, Configuring, and Running the Open edX
   Platform`
-  
+
 * :ref:`opencoursestaff:Building and Running an Open edX Course`
 
 * :ref:`openlearners:Open edX Learner's Guide`
@@ -31,8 +31,6 @@ The following documentation is available for Open edX users.
 
 * :ref:`olx:edX Open Learning XML Guide`
 
-* :ref:`openplatformapi:Open edX Platform APIs`
-  
 * :ref:`opendataapi:Open edX Data Analytics API`
 
 

--- a/en_us/shared/dev/Section_XBlock_URL.rst
+++ b/en_us/shared/dev/Section_XBlock_URL.rst
@@ -23,10 +23,6 @@ LMS, including viewing either the staff debug info or the page source. For more
 information, see
 :ref:`opencoursestaff:Finding the Usage ID for Course Content`.
 
-In addition, API developers can call the Course Blocks API
-``/api/courses/v1/blocks`` to find the ``usage_id`` for a course's XBlocks. For
-more information, see :ref:`openplatformapi:Courses API Overview`.
-
 ===================
 Example XBlock URLs
 ===================

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -155,7 +155,6 @@ intersphinx_mapping = {
     'learners' : ('http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/', None),
     'openlearners' : ('http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/', None),
     'opendevelopers' : ('http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/', None),
-    'openplatformapi' : ('http://edx.readthedocs.io/projects/edx-platform-api/en/latest/', None),
     'opendataapi' : ('http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/', None),
     'openreleasenotes' : ('http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/', None),
     'partnerreleasenotes': ('http://edx.readthedocs.io/projects/edx-release-notes/en/latest/', None),


### PR DESCRIPTION
## 

I removed references to the edx-platform-api docs, which have been deleted.

### Date Needed

This is causing build errors, so soon would be good.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

