### PR TITLE
Removing release notes from build-rtd-documents script

### DIFF
--- a/en_us/Makefile
+++ b/en_us/Makefile
@@ -20,10 +20,8 @@ clean:
 	@cd $(CURDIR)/open_edx_course_authors && make clean $(Q_FLAG)
 	@cd $(CURDIR)/open_edx_release_notes && make clean $(Q_FLAG)
 	@cd $(CURDIR)/open_edx_students && make clean $(Q_FLAG)
-	@cd $(CURDIR)/release_notes && make clean $(Q_FLAG)
 	@cd $(CURDIR)/students && make clean $(Q_FLAG)
 	@cd $(CURDIR)/xblock-tutorial && make clean $(Q_FLAG)
-	@cd $(CURDIR)/release_notes_2014 && make clean $(Q_FLAG)
 	$(MAKE html)
 
 
@@ -59,10 +57,6 @@ html:
 	@cd $(CURDIR)/open_edx_release_notes && make html $(Q_FLAG)
 	@echo edX Open edX Students
 	@cd $(CURDIR)/open_edx_students && make html $(Q_FLAG)
-	@echo edX Release notes
-	@cd $(CURDIR)/release_notes && make html $(Q_FLAG)
-	@echo edX 2014 Release notes
-	@cd $(CURDIR)/release_notes_2014 && make html $(Q_FLAG)
 	@echo edX Students
 	@cd $(CURDIR)/students && make html $(Q_FLAG)
 	@echo XBlock Tutorial

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -44,7 +44,6 @@ then
         "en_us/open_edx_release_notes"
         "en_us/open_edx_students"
         "en_us/ORA2"
-        "en_us/release_notes"
         "en_us/students"
     )
 fi

--- a/utilities/build-rtd-documents.sh
+++ b/utilities/build-rtd-documents.sh
@@ -29,7 +29,6 @@ then
             open-edx-building-and-running-a-course
             open-edx-learner-guide
             edx-developer-guide
-            edx-release-notes
             "
 else
    DOC_IDS=${1}
@@ -41,6 +40,8 @@ fi
 # edx-open-learning-xml - Removed from list, moved to Inactive status
 # course-catalog-api-guide - Removed from list, moved to Inactive status
 # xblock-tutorial - Removed from list, moved to Inactive status
+# edx-release-notes - Removed from list 9 Feb 2018 because it's inactive
+
 
 for DOC_ID in ${DOC_IDS}
 do


### PR DESCRIPTION
We don't create new release notes anymore, and changes to documentation can cause errors in the old release notes. Removing the release notes from the automatic build script.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

