### PR TITLE
DOC-3872 Can use ORA for prereqs

### DIFF
--- a/en_us/shared/course_features/cohorts/cohorts_overview.rst
+++ b/en_us/shared/course_features/cohorts/cohorts_overview.rst
@@ -23,6 +23,9 @@ topics.
 
 For information about discussions in general, see :ref:`Discussions`.
 
+For information about offering different content to different cohorts of
+learners, see :ref:`Offering Different Content Based on Cohort`.
+
 
 *********
 Overview

--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -203,11 +203,6 @@ prerequisite subsections. If a subsection has a prerequisite, it is displayed
 in the course outline with a lock icon and learners cannot view the subsection
 content, until they have earned a minimum score in the prerequisite subsection.
 
-.. note::
-
-   You cannot use :ref:`open response assessments<Open Response Assessments 2>`
-   as the prerequisite for other course subsections.
-
 
 .. _enabling_subsection_gating:
 

--- a/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
+++ b/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
@@ -9,8 +9,7 @@ through a series of assessment steps (such as peer assessment and self
 assessment) to complete the assignment.
 
 
-.. note:: ORA assignments cannot be used as the prerequisite when you configure
-   :ref:`prerequisite course subsections<configuring_prerequisite_content>`.
+.. note:: 
 
    Open response assessments that are visible to all learners do not respect
    cohorts. In other words, it is possible for learners in one cohort to be


### PR DESCRIPTION
## [DOC-3872](https://openedx.atlassian.net/browse/DOC-3872)

Updates the B&R guide to no longer say that you cannot use ORA assignments as prerequisites to gated subsections. See https://openedx.atlassian.net/browse/TNL-5230

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [x] Doc team review: 
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

