### PR TITLE
Update Publisher docs to reflect certificate info on course page

### DIFF
--- a/en_us/course_authors/source/set_up_course/planning_course_information/title_number_guidelines.rst
+++ b/en_us/course_authors/source/set_up_course/planning_course_information/title_number_guidelines.rst
@@ -1,1 +1,60 @@
+.. _Course Title Number and Enrollment Track:
+
+##########################################
+Course Title, Number, and Enrollment Track
+##########################################
+
+The course title (sometimes also called the course name) and number are
+important identifiers for your course. It is a good idea to use titles and
+numbers that are easy to understand and remember.
+
+The course enrollment track specifies the type of certificate, if any, that the
+course offers. For more information about each enrollment track, see
+:ref:`enrollment track<enrollment_track_g>`.
+
+A course title, number, and enrollment track are required to create an About
+page.
+
+* For courses on edx.org, you enter this information in Publisher. For more
+  information, see :ref:`Pub Creating a Course`.
+* For courses on Edge, you enter this information in Studio. For more
+  information, see :ref:`Creating a New Course`.
+
+For guidelines for determining a course title, number, and enrollment track,
+see the following topics.
+
+.. contents::
+  :local:
+  :depth: 1
+
 .. include:: ../../../../shared/set_up_course/planning_course_information/title_number_guidelines.rst
+
+.. _Enrollment Track Guidelines:
+
+***************************
+Enrollment Track Guidelines
+***************************
+
+The enrollment track specifies the certificate type, if any, that is
+available for the course, as well as whether the course has a fee. All
+enrollment tracks other than the audit enrollment track have a fee.
+
+The edX platform offers the following enrollment tracks.
+
+* audit
+* credit
+* professional
+* verified
+
+For more information about each enrollment track, see :ref:`enrollment
+track<enrollment_track_g>` in the glossary.
+
+.. note::
+  For courses that offer a verified enrollment track, by default, the
+  deadline for learners to upgrade to the verified track is 10 days before
+  the course end date. The deadline for learners in the verified track to
+  submit ID verification is the course end date. To request different
+  deadlines, contact your edX project coordinator (PC).
+
+For information about how to specify an enrollment track, see :ref:`Pub
+Create a Course`.

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/index.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/index.rst
@@ -19,10 +19,10 @@ When you are ready to create a course and course run on edx.org, you add
 information in the Publisher tool. The information that you enter depends on
 your goal.
 
-* **If your goal is to enter course content in Studio**, you enter a small
-  amount of specific course and course run information in Publisher. EdX will
-  then create a Studio URL for a course run, and you can add content and modify
-  settings in Studio. For more information, see :ref:`Pub Access a
+* **If your goal is to enter course content in Studio immediately**, you enter
+  a small amount of specific course and course run information in Publisher.
+  EdX will then create a Studio URL for a course run, and you can add content
+  and modify settings in Studio. For more information, see :ref:`Pub Access a
   Course Run in Studio`.
 
 * **If your goal is to create a course About page**, you enter all required

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_course_creation.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_course_creation.rst
@@ -20,10 +20,14 @@ In Publisher, a course contains the following information.
      - Additional subjects
    * - Number
      - Learner testimonials
-   * - Short and long description
+   * - Enrollment track (also called certificate type)
      - FAQ
-   * - What learners will learn
+   * - Price of a certificate (if the course offers a certificate)
      - Syllabus
+   * - Short and long description
+     -
+   * - What learners will learn
+     -
    * - Primary subject
      -
    * - Image

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_create_course.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course/pub_create_course.rst
@@ -16,11 +16,16 @@ To create a course in Publisher, follow these steps.
    * On the **Courses** page, select **Courses**, and then select **Create New
      Course**.
 
-#. On the **Create New Course** page, enter the following information.
+#. On the **Create New Course** page, specify the following information.
 
    * The name of the course administrator for your organization.
    * The course title.
    * The course number.
+   * The enrollment track (also called certificate type) that the course
+     offers. For more information, see :ref:`enrollment
+     track<enrollment_track_g>`.
+   * The price for a certificate in the course. If the course does not offer
+     certificates, leave the default value of 0 in the **Price** field.
 
 #. Select the action that you want to take after you create a course.
 

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_access_course_run_studio.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_access_course_run_studio.rst
@@ -23,21 +23,23 @@ course run page in Publisher.
 Information Required for a Studio URL
 *************************************
 
-To create a course run URL that you can access in Studio, Publisher needs the
-following information.
+To create a course run URL that you can access in Studio, you must enter the
+following information in Publisher.
 
 **Course Information**
 
    * The name of the course administrator for your organization.
    * The course title.
    * The course number.
+   * The course enrollment tracks.
+   * The price of a certificate for the course, if the course offers
+     certificates.
 
 **Course Run Information**
 
    * The course start and end dates. Times are in universal coordinated time
      (UTC).
    * Course pacing.
-   * Available certificate types, if any, and the prices for the certificates.
 
 You enter this information when you create a course and course run. For
 information about how to create a course and a course run, see :ref:`Pub Create

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_course_run_creation.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_course_run_creation.rst
@@ -18,10 +18,8 @@ In Publisher, a course run contains the following information.
      - Estimated effort
    * - Pacing
      - Length
-   * - :ref:`Enrollment track<enrollment_track_g>` (default is audit)
-     - Video language
    * - Content language
-     -
+     - Video language
    * - Transcript languages
      -
 
@@ -33,8 +31,8 @@ In Publisher, a course run contains the following information.
 For more information about how to determine this information for your course
 run, see :ref:`Planning Course Run Information`.
 
-After you have determined and gathered this information for your course, you
-use the following process to create the course in Publisher.
+After you have determined and gathered this information for your course run,
+you use the following process to create the course run in Publisher.
 
 #. :ref:`Create the course run<Pub Create a Course Run>`. In this step, you
    provide only basic information about the course run, and Publisher creates a

--- a/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_create_course_run.rst
+++ b/en_us/course_authors/source/set_up_course/pub_create_ann_course/pub_create_edit_course_run/pub_create_course_run.rst
@@ -28,7 +28,6 @@ To create a course run in Publisher, follow these steps.
    * The course start and end dates. Times are in universal coordinated time
      (UTC).
    * Course pacing.
-   * Available certificate types, if any, and the prices for the certificates.
 
 #. Select **Create New Course Run**.
 

--- a/en_us/open_edx_course_authors/source/set_up_course/planning_course_information/title_number_guidelines.rst
+++ b/en_us/open_edx_course_authors/source/set_up_course/planning_course_information/title_number_guidelines.rst
@@ -1,1 +1,21 @@
+.. _Course Title and Number:
+
+#######################
+Course Title and Number
+#######################
+
+The course title (sometimes also called the course name) and number are
+important identifiers for your course. It is a good idea to use titles and
+numbers that are easy to understand and remember.
+
+For information about how to add your course title and number, see
+:ref:`Creating a New Course`.
+
+For guidelines for determining a course title and number, see the following
+topics.
+
+.. contents::
+  :local:
+  :depth: 1
+
 .. include:: ../../../../shared/set_up_course/planning_course_information/title_number_guidelines.rst

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -422,8 +422,8 @@ E
 
 **enrollment track**
 
-  Also called **course mode**, **course track**, **course type**, **enrollment
-  mode**, or **seat type**.
+  Also called **certificate type**, **course mode**, **course seat**, **course
+  track**, **course type**, **enrollment mode**, or **seat type**.
 
   The enrollment track specifies the following items about a course.
 
@@ -433,31 +433,41 @@ E
       a webcam and a photo ID.
     * Whether the course requires a fee.
 
-  The edX platform offers the following enrollment tracks.
+  * **audit**: This is the default enrollment track when learners enroll in a
+    course. This track does not offer certificates, does not require identity
+    verification, and does not require a course fee.
 
-  * **audit**: The default enrollment track. This track does not offer
-    certificates, does not require identity verification, and does not require
-    a course fee.
+  * **professional**: This enrollment track is only used for specific
+    professional education courses. The professional enrollment track offers
+    certificates, requires identity verification, and requires a fee. Fees for
+    the professional enrollment track are generally higher than fees for the
+    verified enrollment track. Courses that offer the professional track do not
+    offer a free enrollment track.
+
+    .. note::
+       If your course is part of a MicroMasters or professional certificate
+       program, your course uses the verified track. These courses do not use
+       the professional enrollment track.
 
   * **verified**: This enrollment track offers verified certificates to
     learners who pass the course, verify their identities, and pay a required
     course fee. A course that offers the verified enrollment track also
     automatically offers a free non-certificate enrollment track.
 
-  * **honor**: This enrollment track offers an honor code certificate to
-    learners who pass the course. This track does not require identity
-    verification and does not require a fee. Note, however, that as of December
-    2015, edx.org no longer offers honor code certificates. For more
-    information, see `News About edX Certificates`_.
+  * **honor**: This enrollment track was offered in the past and offered an
+    honor code certificate to learners who pass the course. This track does not
+    require identity verification and does not require a fee. Note, however,
+    that as of December 2015, edx.org no longer offers honor code certificates.
+    For more information, see `News About edX Certificates`_.
+
+  .. only:: Partners
+
+    * **credit**: In this enrollment track, learners who pass the course and
+      comply with additional requirements, including identity verification, can
+      receive academic credit for the course. For more information, see
+      :ref:`partnercoursestaff:Academic Course Credit`.
 
   .. only:: Open_edX
-
-    * **professional**: This enrollment track is used for professional
-      education courses. The professional enrollment track offers certificates,
-      requires identity verification, and requires a fee. Fees for the
-      professional enrollment track are generally higher than fees for the
-      verified enrollment track. Courses that offer the professional track do
-      not offer a free enrollment track.
 
     * **professional (no ID)**: Like the professional enrollment track, this
       track offers certificates and requires a fee. However, this track does

--- a/en_us/shared/set_up_course/planning_course_information/description_guidelines.rst
+++ b/en_us/shared/set_up_course/planning_course_information/description_guidelines.rst
@@ -70,9 +70,9 @@ An effective long description follows these guidelines.
  page opens. Learners can select "See More" to view the full description.
 
 
-========================
-Example Long Descriptons
-========================
+=========================
+Example Long Descriptions
+=========================
 
 The following long description is a content-based example.
 

--- a/en_us/shared/set_up_course/planning_course_information/title_number_guidelines.rst
+++ b/en_us/shared/set_up_course/planning_course_information/title_number_guidelines.rst
@@ -1,30 +1,6 @@
-.. _Course Title and Number:
-
-#######################
-Course Title and Number
-#######################
-
-The course title (sometimes also called the course name) and number are
-important identifiers for your course. It is a good idea to use titles and
-numbers that are easy to understand and remember.
-
-.. only:: Partners
-
- A course title and number are required to create an About page.
-
- * For courses on edx.org, you enter this information in Publisher.
-   For more information, see :ref:`Pub Creating a Course`.
- * For courses on Edge, you enter this information in Studio. For more
-   information, see :ref:`Creating a New Course`.
-
-.. only:: Open_edX
-
- For information about how to add your course title and number, see
- :ref:`Creating a New Course`.
-
-.. contents::
-  :local:
-  :depth: 1
+.. For the introduction to this topic, see the individual
+.. title_number_guidelines.rst files in the course_authors and
+.. open_edx_course_authors guides.
 
 .. _Course Title Guidelines:
 
@@ -46,12 +22,12 @@ When you determine the title of your course, consider the following guidelines.
 
 .. only:: Partners
 
- For more information about adding a course name, see :ref:`Pub Creating a
- Course`.
+ For more information about how to add your course name, see :ref:`Pub Creating
+ a Course`.
 
 .. only:: Open_edX
 
- For information about how to add your course title, see
+ For information about how to add your course name, see
  :ref:`Creating a New Course`.
 
 .. note::
@@ -96,6 +72,16 @@ Course numbers have the following guidelines.
   the way that your course number appears in Studio and the LMS, see
   :ref:`Change the Course Number`.
 
+.. only:: Partners
+
+ For more information about how to add your course number, see :ref:`Pub
+ Creating a Course`.
+
+.. only:: Open_edX
+
+ For information about how to add your course number, see
+ :ref:`Creating a New Course`.
+
 ======================
 Example Course Numbers
 ======================
@@ -103,4 +89,3 @@ Example Course Numbers
 * CS002x
 * BIO1.1x and BIO1.2x
 * 6.002.1x and 6.002.2x
-

--- a/en_us/shared/set_up_course/planning_course_run_information/additional_course_run_information.rst
+++ b/en_us/shared/set_up_course/planning_course_run_information/additional_course_run_information.rst
@@ -33,36 +33,6 @@ You are required to specify a language or languages for the following content.
 
 Optionally, you can also specify additional languages for course videos.
 
-
-.. only:: Partners
-
-    .. _Enrollment Track Guidelines:
-
-    ***************************
-    Enrollment Track Guidelines
-    ***************************
-
-    The enrollment track specifies the following items about a course run.
-
-        * The type of certificate, if any, that learners receive if they pass
-          the course.
-        * Whether learners must verify their identity to earn a certificate,
-          using a webcam and a photo ID.
-        * Whether the course requires a fee.
-
-    For more information, see :ref:`enrollment track<enrollment_track_g>`.
-
-    If you do not specify an enrollment track, only an audit enrollment track
-    is created.
-
-    .. note::
-      For courses that offer a verified enrollment track, by default, the
-      deadline for learners to upgrade to the verified track is 10 days before
-      the course end date. The deadline for learners in the verified track to
-      submit ID verification is the course end date. To request different
-      deadlines, contact your edX project coordinator (PC).
-
-
 .. _Effort Guidelines:
 
 *****************


### PR DESCRIPTION
## [DOC-3890](https://openedx.atlassian.net/browse/DOC-3890)

This PR reflects LEARNER-3768. Information about enrollment tracks and certificate prices in Publisher has moved from the course run page to the course page. 

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @dabdul-hathi
- [ ] Doc team review (copy edit): @edx/doc 
- [ ] PC review: @edenpirog

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

