### PR TITLE
Adding documentation for variable names

### DIFF
--- a/en_us/shared/exercises_tools/math_expression_input.rst
+++ b/en_us/shared/exercises_tools/math_expression_input.rst
@@ -265,6 +265,15 @@ Attributes
 
        ``<formularesponse samples="R_1,R_2,R_3@1,2,3:3,4,5#10">``
 
+Variable names must be at least one character long. They must start with a letter, which can be followed by letters, numbers and underscores. We strongly recommend only using one underscore, which renders to students as a subscript.
+
+Tensor notation is also supported, as ``Name_{ijk}^{123}``, where the name must start with a letter, but can otherwise contain letters or numbers, subscripts are contained in the lower braces, and superscripts are contained in the raised braces. Superscripts and subscripts must only be letters or numbers. No other underscores can appear in the name. Note that the subscript must come first, and the braces ensure that the superscripts are not confused with exponentiation.
+
+All variable names (standard and tensor formats) may contain one or more apostrophes (primes) at the end of the variable name, for example, to indicate a derivative or new coordinate system. Note that some students may have trouble entering primes, which some browsers/operating systems automatically convert to a "smart apostrophe" (tablets are most likely to have this issue). We recommend providing a variable name that students may copy and paste to get around this problem.
+
+The following are examples of valid variable names: ``V_out``, ``m_1``, ``G_{ij}``, ``H^{xy}``, ``f'``, ``x_1''``, and ``H_{ij}^{12}''``.
+
+
 Children
 ========
 


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

This documents what variable names are allowed in math input expressions. This is currently undocumented. The impetus for this is a recent change that expanded the possibilities for variable names in the platform (edx/edx-platform#17370).

This change will go live 3/6/18.

Apologies that I don't know what to put elsewhere in this PR description.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: @nedbat @pdpinch

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits
