### PR TITLE
DOC-3897: SFD Change entitlement duration from 15 months to 24 months

### DIFF
--- a/en_us/students/source/SFD_enrolling.rst
+++ b/en_us/students/source/SFD_enrolling.rst
@@ -120,10 +120,10 @@ sessions, be aware of the following policies and timeframes.
   in the verified track for the course, in the current session. You can change
   to a different session if the one we enrolled you in does not work for you.
 
-* **Join a Session Within 15 Months**
+* **Join a Session Within 24 Months**
 
-  After you purchase the verified track for a course, you have 15 months from
-  the date of purchase to join a course session. After 15 months, if you have
+  After you purchase the verified track for a course, you have 24 months from
+  the date of purchase to join a course session. After 24 months, if you have
   not joined a session, your purchase expires, and you can no longer access the
   course.
 


### PR DESCRIPTION
## [DOC-3897](https://openedx.atlassian.net/browse/DOC-3897)
Learners will have 24 months (was 15 months) to enroll in a course session

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @dabdul-hathi
- [x] Doc team review (sanity check): @edx/doc

FYI Support: @dhixonedx

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

