### PR TITLE
DOC-3901: Update link to DemoX

### DIFF
--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -4,7 +4,7 @@
 
 .. EdX Links
 
-.. _Math Formatting in Course Discussions: https://courses.edx.org/courses/edX/DemoX.1/2014/wiki/edX.DemoX.1.2014/math-formatting-course-discussions/
+.. _Math Formatting in Course Discussions: https://courses.edx.org/courses/course-v1:edX+DemoX.1+2T2017/wiki/edx/adding-math-expressions-course-discussion-post/
 
 .. _change log for the Backbone.js library: https://github.com/jashkenas/backbone/blob/master/index.html#L4299
 


### PR DESCRIPTION
## [DOC-3901](https://openedx.atlassian.net/browse/DOC-3901)

Update the link to DemoX wiki article on math expressions so that it goes to the 2017 version of the DemoX course.


### Reviewers
- [x] Doc team review (sanity check): @edx/doc


### Testing
- [x] Ran ./run_tests.sh without warnings or errors


### Post-review
- [ ] Squash commits

