### PR TITLE
DOC-3907: fix Prof Ed terminology

### DIFF
--- a/en_us/students/source/SFD_enrolling.rst
+++ b/en_us/students/source/SFD_enrolling.rst
@@ -133,7 +133,7 @@ sessions, be aware of the following policies and timeframes.
   After you join a course session in the verified track (including if we
   automatically add you to a session as a result of your program purchase), you
   can change to another session or leave the session within 14 days, as long as
-  you have not completed the course. For Professional Certificate courses only,
+  you have not completed the course. For Professional Education courses only,
   you must change sessions or leave the session within 2 days.
 
   .. note:: When you change sessions, your course progress is not carried from
@@ -150,7 +150,7 @@ sessions, be aware of the following policies and timeframes.
   entirely and get a refund of your course purchase, as long as you have not
   been in a course session for more than 14 days. 
 
-  .. note:: For Professional Certificate courses only, you must not have been in
+  .. note:: For Professional Education courses only, you must not have been in
      a course session for more than 2 days, to be able to unenroll.
 
   If the refund eligibility period has passed (meaning that you will not


### PR DESCRIPTION
## [DOC-3907](https://openedx.atlassian.net/browse/DOC-3907)

Prof Cert refers to a type of program; Prof Ed to a type of course. 

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Doc team review: @edx/doc 


### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

