### PR TITLE
Update info about grade report

### DIFF
--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -233,11 +233,23 @@ columns that provide the following information.
   current and valid.
 
 * The **Certificate Eligible** column indicates whether a learner is eligible
-  for a certificate for your course. The value in this column is "Y" for
-  learners who attained a passing grade before this report was requested, and
-  for all whitelisted learners, regardless of grade attained. The value is "N"
-  for learners who did not attain a passing grade and for those who live in
-  embargoed countries.
+  for a certificate for your course.
+
+  The value in this column is "Y" for the following learners.
+
+  * Verified learners who attained a passing grade before this report was
+    requested. For example, the learner could have earned a passing grade in an
+    earlier session, or run, of the course.
+
+  * All whitelisted learners, regardless of grade or enrollment track.
+
+  The value is "N" for the following learners.
+
+  * Learners who did not attain a passing grade.
+
+  * Learners who are in the audit track.
+
+  * Learners who live in embargoed countries.
 
 * For learners who are eligible to receive a certificate, the **Certificate
   Delivered** column has a value of "Y" when the certificates for a course have


### PR DESCRIPTION
## [DOC-3916](https://openedx.atlassian.net/browse/DOC-3916)

Update information about the "Certificate Eligible" column in the learner grade report per [EDUCATOR-2774](https://openedx.atlassian.net/browse/EDUCATOR-2774).

### Date Needed (optional)

3 May 2018

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @awaisdar001 or @Rabia23 
- [x] Doc team review (copy edit): @edx/doc
- [ ] Product review: @sstack22 
- [ ] Partner support: @jaakana

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

