### PR TITLE
Add info about Other Course Settings option for OE

### DIFF
--- a/en_us/install_operations/source/configuration/enable_custom_course_settings.rst
+++ b/en_us/install_operations/source/configuration/enable_custom_course_settings.rst
@@ -1,0 +1,25 @@
+.. _Enable Custom Course Settings:
+
+####################################
+Enabling Custom Course Settings
+####################################
+
+To enable course developers to add custom fields to a course on your instance 
+of Open edX, you must configure the ``cms.env.json`` file in the edX platform.
+
+.. Note::
+  Before proceeding, review :ref:`Guidelines for Updating the Open edX
+  Platform`.
+
+#. Stop the LMS server.
+
+#. Create or update the file ``cms.env.json`` to include the custom course 
+   settings feature flag.
+
+   .. code-block:: yaml
+
+     'ENABLE_OTHER_COURSE_SETTINGS': true,
+
+#. Restart the LMS server.
+
+.. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/index.rst
+++ b/en_us/install_operations/source/configuration/index.rst
@@ -21,6 +21,7 @@ configuration options.
    enable_certificates
    enable_pacing
    enable_ccx
+   enable_custom_course_settings
    enable_discussion_notifications
    enable_entrance_exams
    ora2/index

--- a/en_us/shared/set_up_course/planning_course_information/additional_course_information.rst
+++ b/en_us/shared/set_up_course/planning_course_information/additional_course_information.rst
@@ -247,3 +247,26 @@ To be effective, a testimonial should contain no more than 25-50 words.
 
   You can add the learner testimonial to your course About page. For more
   information, see :ref:`Creating a Course About Page`.
+
+.. only:: Open_edX
+
+  .. _Course Metadata:
+
+  ***************
+  Course Metadata
+  ***************
+
+  You may need to be able to make certain custom information about your course
+  available to entities such as customer relationship management (CRM)
+  software, a marketing site, or other external systems. This information is
+  not visible to learners.
+
+  For example, you might want to make the following information available.
+
+  * The course difficulty
+  * The course ID in an external system
+  * Course prerequisites
+
+  You add this information as a JSON dictionary in Studio. For more
+  information, see :ref:`Add Course Metadata`.
+

--- a/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
@@ -172,4 +172,23 @@ In Studio and the LMS, your course number changes to the value that you specify
 in the **Course Number Display String** field. The URL for your course does not
 change.
 
+.. only:: Open_edX
+
+  .. _Add Course Metadata:
+
+  *******************
+  Add Course Metadata
+  *******************
+
+  To make certain information about your course available to entities such as
+  customer relationship management (CRM) software, a marketing site, or other
+  external systems, follow these steps.
+
+  #. Create a JSON dictionary that contains the metadata that you want to add.
+  #. In Studio, open your course, and then select **Advanced Settings** on the
+     **Settings** menu.
+  #. In the **Other Course Settings** field, paste your JSON dictionary.
+
+
+
 .. include:: ../../../../links/links.rst

--- a/en_us/shared/set_up_course/studio_add_course_information/studio_course_staffing.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/studio_course_staffing.rst
@@ -1,7 +1,7 @@
 .. _Studio_Course_Staffing:
 
 ####################################
-Add Course Team Members in Studio
+Adding Course Team Members in Studio
 ####################################
 
 .. only:: Partners


### PR DESCRIPTION
## [DOC-3946](https://openedx.atlassian.net/browse/DOC-3946)

Document the new **Other Course Settings** field on the **Advanced Settings** page (note this setting is for Open edX only) per [platform PR 17699](https://github.com/edx/edx-platform/pull/17699).

### Date Needed

This was deployed August 6. The JIRA ticket is [OSPR-2303](https://openedx.atlassian.net/browse/OSPR-2303).

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @bradenmacdonald 
- [ ] Subject matter expert: @schenedx 
- [ ] Subject matter expert: @clemente  
- [x] Doc team review:
- [ ] Product review:
- [ ] Partner support: 


