### PR TITLE
add user retirement docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ python:
 cache:
     directories:
         - $HOME/.cache/pip
+before_install:
+    - "sudo apt-get update"
+    - "sudo apt-get install -y graphviz"
+    # This line isn't needed until we are running latexpdf builds.
+    # MacTex is used locally (MacOSX) by the docs team,
+    # but since we are using a linux machine for travis,
+    # we can use texlive-full instead.
+    # - "sudo apt-get install -y texlive-full git python-dev"
 install:
     - "pip install -r requirements/base.txt"
 script: "./run_tests.sh"
@@ -13,11 +21,3 @@ branches:
         - master
 
 
-
-# This part isn't needed until we are running latexpdf builds.
-# before_install:
-#     MacTex is used locally (MacOSX) by the docs team,
-#     but since we are using a linux machine for travis,
-#     we can use texlive-full instead.
-#     - "sudo apt-get update"
-#     - "sudo apt-get install texlive-full git python-dev -y"

--- a/en_us/user_retirement/Makefile
+++ b/en_us/user_retirement/Makefile
@@ -1,0 +1,183 @@
+# Makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+PAPER         ?=
+BUILDDIR      ?= build
+
+# User-friendly check for sphinx-build
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+Q_FLAG        =
+
+ifeq ($(quiet), true)
+Q_FLAG = -Q
+endif
+
+# Internal variables.
+PAPEROPT_a4     = -D latex_paper_size=a4
+PAPEROPT_letter = -D latex_paper_size=letter
+ALLSPHINXOPTS   = $(Q_FLAG) -d $(BUILDDIR)/doctrees -c source $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+# the i18n builder cannot share the environment and doctrees with the others
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  html       to make standalone HTML files"
+	@echo "  dirhtml    to make HTML files named index.html in directories"
+	@echo "  singlehtml to make a single large HTML file"
+	@echo "  pickle     to make pickle files"
+	@echo "  json       to make JSON files"
+	@echo "  htmlhelp   to make HTML files and a HTML help project"
+	@echo "  qthelp     to make HTML files and a qthelp project"
+	@echo "  devhelp    to make HTML files and a Devhelp project"
+	@echo "  epub       to make an epub"
+	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
+	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
+	@echo "  text       to make text files"
+	@echo "  man        to make manual pages"
+	@echo "  texinfo    to make Texinfo files"
+	@echo "  info       to make Texinfo files and run them through makeinfo"
+	@echo "  gettext    to make PO message catalogs"
+	@echo "  changes    to make an overview of all changed/added/deprecated items"
+	@echo "  xml        to make Docutils-native XML files"
+	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
+	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+
+clean:
+	rm -rf $(BUILDDIR)/*
+
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+dirhtml:
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+singlehtml:
+	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
+	@echo
+	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+
+pickle:
+	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
+	@echo
+	@echo "Build finished; now you can process the pickle files."
+
+json:
+	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
+	@echo
+	@echo "Build finished; now you can process the JSON files."
+
+htmlhelp:
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
+	@echo
+	@echo "Build finished; now you can run HTML Help Workshop with the" \
+	      ".hhp project file in $(BUILDDIR)/htmlhelp."
+
+qthelp:
+	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
+	@echo
+	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
+	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/getting_started.qhcp"
+	@echo "To view the help file:"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/getting_started.qhc"
+
+devhelp:
+	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
+	@echo
+	@echo "Build finished."
+	@echo "To view the help file:"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/getting_started"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/getting_started"
+	@echo "# devhelp"
+
+epub:
+	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	@echo
+	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+
+latex:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo
+	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
+	@echo "Run \`make' in that directory to run these through (pdf)latex" \
+	      "(use \`make latexpdf' here to do that automatically)."
+
+latexpdf:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through pdflatex..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+latexpdfja:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through platex and dvipdfmx..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+text:
+	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
+	@echo
+	@echo "Build finished. The text files are in $(BUILDDIR)/text."
+
+man:
+	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	@echo
+	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+
+texinfo:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo
+	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
+	@echo "Run \`make' in that directory to run these through makeinfo" \
+	      "(use \`make info' here to do that automatically)."
+
+info:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo "Running Texinfo files through makeinfo..."
+	make -C $(BUILDDIR)/texinfo info
+	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+
+gettext:
+	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	@echo
+	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+
+changes:
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
+	@echo
+	@echo "The overview file is in $(BUILDDIR)/changes."
+
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	@echo
+	@echo "Link check complete; look for any errors in the above output " \
+	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+doctest:
+	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	@echo "Testing of doctests in the sources finished, look at the " \
+	      "results in $(BUILDDIR)/doctest/output.txt."
+
+xml:
+	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
+	@echo
+	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
+
+pseudoxml:
+	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
+	@echo
+	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/en_us/user_retirement/source/conf.py
+++ b/en_us/user_retirement/source/conf.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+import sys
+
+sys.path.append('../../../')
+
+from shared.conf import *
+
+project = u'User Retirement Guide for Open edX Administrators'
+
+set_audience(OPENEDX, DEVELOPERS)
+
+extensions = ['sphinx.ext.graphviz']

--- a/en_us/user_retirement/source/driver_setup.rst
+++ b/en_us/user_retirement/source/driver_setup.rst
@@ -1,0 +1,124 @@
+.. _driver-setup:
+
+******************************
+Setting Up the Driver Scripts
+******************************
+
+The User Retirement Driver Scripts
+**********************************
+
+Tubular (`edx/tubular on github <https://github.com/edx/tubular>`_) is a
+repository of Python 3 scripts designed to plug into various automation
+tooling.  Among them are two scripts intended to drive the user retirement
+workflow.
+
+``scripts/get_learners_to_retire.py``
+    Generates a list of users that are ready for immediate retirement.  Users
+    are "ready" after a certain number of days spent in the ``PENDING`` state,
+    specified by the ``--cool_off_days`` argument.  Produces an output intended
+    for consumption by Jenkins in order to spawn separate downstream builds for
+    each user.
+``scripts/retire_one_learner.py``
+    Retires the user specified by the ``--username`` argument.
+
+These two scripts share a required ``--config_file`` argument, which specifies
+the driver configuration file for your environment (e.g., production).  This
+configuration file is a YAML file that contains LMS auth secrets, API URLs,
+and retirement pipeline stages specific to that environment.  For example:
+
+.. code-block:: yaml
+
+   client_id: <client ID for the retirement service user>
+   client_secret: <client secret for the retirement service user>
+
+   base_urls:
+       lms: https://courses.example.com/
+       ecommerce: https://ecommerce.example.com/
+       credentials: https://credentials.example.com/
+
+   retirement_pipeline:
+       - ['RETIRING_EMAIL_LISTS', 'EMAIL_LISTS_COMPLETE', 'LMS', 'retirement_retire_mailings']
+       - ['RETIRING_ENROLLMENTS', 'ENROLLMENTS_COMPLETE', 'LMS', 'retirement_unenroll']
+       - ['RETIRING_LMS_MISC', 'LMS_MISC_COMPLETE', 'LMS', 'retirement_lms_retire_misc']
+       - ['RETIRING_LMS', 'LMS_COMPLETE', 'LMS', 'retirement_lms_retire']
+
+The ``client_id`` and ``client_secret`` keys contain the oauth credentials
+which are simply copied from the output of the ``create_dot_application``
+management command outlined in :ref:`retirement-service-user`.
+
+The ``base_urls`` section defines the mappings of IDA to base URLs used by the
+scripts to construct API URLs.  Only the LMS is mandatory here, but if any of
+your pipeline states contain API calls to other services, they must
+also be present in the ``base_urls`` section.
+
+The ``retirement_pipeline`` section defines the steps, state names, and order
+of execution for each environment.  Each item is a list in the form of:
+
+#. start state name
+#. end state name
+#. IDA to call against (LMS, ECOMMERCE, or CREDENTIALS currently)
+#. method name to call in Tubular's
+   `edx_api.py <https://github.com/edx/tubular/blob/master/tubular/edx_api.py>`_
+
+For example: ``['RETIRING_CREDENTIALS', 'CREDENTIALS_COMPLETE', 'CREDENTIALS',
+'retire_learner']`` will set the user's state to ``RETIRING_CREDENTIALS``, call
+a pre-instantiated ``retire_learner`` method in the CredentialsApi, then set
+the user's state to ``CREDENTIALS_COMPLETE``.
+
+Examples
+--------
+
+The following are some examples of how to use the driver scripts.
+
+Setup your execution environment:
+
+.. code-block:: bash
+
+   git clone https://github.com/edx/tubular.git
+   cd tubular
+   virtualenv --python=`which python3` venv
+   source venv/bin/activate
+
+Generate a list of learners that are ready for retirement (those learners who
+have selected and confirmed account deletion and have been in the ``PENDING``
+state for the time specified ``cool_off_days``).
+
+.. code-block:: bash
+
+   mkdir learners_to_retire
+   scripts/get_learners_to_retire.py \
+       --config_file=path/to/config.yml \
+       --output_dir=learners_to_retire \
+       --cool_off_days=5
+
+The ``learners_to_retire`` directory now contains several INI files, each
+containing a single line in the form of ``USERNAME=<username-of-learner>``.
+Iterate over these files while executing the ``retire_one_learner.py`` on each
+learner:
+
+.. code-block:: bash
+
+   scripts/retire_one_learner.py \
+       --config_file=path/to/config.yml \
+       --username=<username-of-learner-to-retire>
+
+
+Using the Driver Scripts in an Automated Framework
+**************************************************
+
+At edX we call the user retirement scripts from
+`Jenkins <https://jenkins.io/>`_ jobs on one of our internal Jenkins
+services.  The user retirement driver scripts are intended to be agnostic,
+about which automation framework you use, but they were only fully tested
+from Jenkins.
+
+For more information about how we execute these scripts at edX, see the
+following wiki articles:
+
+* `User Retirement Jenkins Implementation <https://openedx.atlassian.net/wiki/spaces/PLAT/pages/704872737/User+Retirement+Jenkins+Implementation>`_
+* `How to: retirement Jenkins jobs development and testing <https://openedx.atlassian.net/wiki/spaces/PLAT/pages/698221444/How+to+retirement+Jenkins+jobs+development+and+testing>`_
+
+And check out the Groovy DSL files we use to seed these jobs:
+
+* `platform/jobs/RetirementJobs.groovy in edx/jenkins-job-dsl <https://github.com/edx/jenkins-job-dsl/blob/master/platform/jobs/RetirementJobs.groovy>`_
+* `platform/jobs/RetirementJobEdxTriggers.groovy in edx/jenkins-job-dsl <https://github.com/edx/jenkins-job-dsl/blob/master/platform/jobs/RetirementJobEdxTriggers.groovy>`_

--- a/en_us/user_retirement/source/implementation_overview.rst
+++ b/en_us/user_retirement/source/implementation_overview.rst
@@ -1,0 +1,110 @@
+
+***********************
+Implementation Overview
+***********************
+
+In the Open edX platform, the user experience is enabled by several
+services, such as LMS, Studio, ecommerce, credentials, discovery, and more.
+Personally Identifiable Identification (PII) about a user can exist in many of
+these services. As a consequence, to remove a user's PII, you must be able
+to request that each service containing PII to remove, delete, or unlink the
+data for that user in that service.
+
+A centralized process (the *driver* scripts) orchestrates all of these
+requests. For information about how to configure the driver scripts, see
+:ref:`driver-setup`.
+
+The User Retirement Workflow
+****************************
+
+The user retirement workflow is a configurable pipeline of building-block
+APIs. These APIs are used to:
+
+  * "forget" a retired user's PII
+  * Prevent a retired user from logging back in
+  * Prevent re-use of the username or email address of a retired user.
+
+Depending on which third parties a given Open edX instance integrates with,
+the user retirement process may need to call out to external services or to
+generate reports for later processing. Any such reports must subsequently be
+destroyed.
+
+Configurability and hackability was a design goal from the beginning, so this
+user retirement tooling should be able to accommodate a wide range of Open edX
+sites and custom use cases.
+
+The workflow is designed to be linear and re-runnable, allowing recovery and
+continuation in cases where a particular stage fails.  Each user who has
+requested retirement will be individually processed through this workflow, so
+multiple users could be in the same state simultaneously.  The LMS is the
+authoritative source of information about the state of each user in the
+retirement process, and the arbiter of state progressions, using the
+``UserRetirementStatus`` model and associated APIs.  The LMS also holds a
+table of the states themselves (the ``RetirementState`` model), rather than
+hard-coding the states.  This was done because we cannot predict all the
+possible states required by all members of the Open edX community.
+
+This example state diagram outlines the pathways users follow throughout the
+workflow:
+
+.. digraph:: retirement_states_example
+   :align: center
+
+      ranksep = "0.3";
+
+      node[fontname=Courier,fontsize=12,shape=box,group=main]
+      { rank = same INIT[style=invis] PENDING }
+      INIT -> PENDING;
+      "..."[shape=none]
+      PENDING -> RETIRING_ENROLLMENTS -> ENROLLMENTS_COMPLETE -> RETIRING_FORUMS -> FORUMS_COMPLETE -> "..." -> COMPLETE;
+
+      node[group=""];
+      RETIRING_ENROLLMENTS -> ERRORED;
+      RETIRING_FORUMS -> ERRORED;
+      PENDING -> ABORTED;
+
+      subgraph cluster_terminal_states {
+          label = "Terminal States";
+          labelloc = b  // put label at bottom
+          {rank = same ERRORED COMPLETE ABORTED}
+      }
+
+Unless an error occurs internal to the uer retirement tooling, a user's
+retirement state should always land in one of the terminal states.  At that
+point, either their entry should be cleaned up from the
+``UserRetirementStatus`` table, or if the state is ``ERRORED``, the
+administrator needs to examine the error and resolve it. For more information,
+see :ref:`recovering-from-errored`.
+
+The User Experience
+*******************
+
+From the learner's perspective, the vast majority of this process is obscured.
+The Account page contains a new section titled **Delete My Account**. In this
+section, a learner may click the **Delete My Account**** button and enter
+their password to confirm their request.  Subsequently, all of the learner's
+browser sessions are logged off, and they become locked out of their account.
+
+An informational email is immediately sent to the learner to confirm the
+deletion of their account. After this email is sent, the learner has a limited
+amount of time (defined by the ``--cool_off_days`` argument described in
+:ref:`driver-setup`) to contact the site administrators and rescind their
+request.
+
+At this point, the learner's account has been deactivated, but *not* retired.
+An entry in the ``UserRetirementStatus`` table is added, and their state set to
+``PENDING``.
+
+By default, the **Delete My Account** button is disabled, preventing account
+deletions.  For information about how to enable account deletion, see
+:ref:`waffle-switch-for-ux`.
+
+Third Party Auth
+----------------
+
+Learners who registered using social authentication must first unlink their
+LMS account from their third party account. For those learners, the **Delete
+My Account** button will be disabled until they do so; meanwhile, they will be
+instructed to follow the procedure in this help center article: `How do I link
+or unlink my edX account to a social media
+account?  <https://support.edx.org/hc/en-us/articles/207206067>`_.

--- a/en_us/user_retirement/source/index.rst
+++ b/en_us/user_retirement/source/index.rst
@@ -1,0 +1,35 @@
+.. _document index:
+
+#################################################
+User Retirement Guide for Open edX Administrators
+#################################################
+
+There have been many changes to privacy laws (for example, GDPR or the European
+Union General Data Protection Regulation) intended to change the way that
+businesses think about and handle Personally Identifiable Information (PII)
+data.
+
+As a step toward enabling Open edX to support some of the key updates in
+privacy laws, edX has implemented APIs and tooling that enables Open edX
+instances to retire registered users. When you implement this user retirement
+feature, your Open edX instance can automatically erase PII for a given user
+from systems that are internal to Open edX (for example, the LMS, forums,
+credentials, and other independently deployable applications (IDAs)), as well
+as external systems, such as third party marketing services.
+
+This guide is not only intended for instructing Open edX admins to perform
+the basic setup, but also to offer some insight into the implementation of the
+user retirement feature in order to help the Open edX community build
+additional APIs and states that meet their special needs. Custom code,
+plugins, packages, or XBlocks in your Open edX instance might store PII, but
+this tooling will not magically find and clean up that PII.
+
+.. toctree::
+    :numbered:
+    :maxdepth: 2
+
+    implementation_overview
+    service_setup
+    driver_setup
+    special_cases
+

--- a/en_us/user_retirement/source/service_setup.rst
+++ b/en_us/user_retirement/source/service_setup.rst
@@ -1,0 +1,164 @@
+
+*************************************
+Setting Up User Retirement in the LMS
+*************************************
+
+This section describes how to set up and configure the user retirement feature
+in the Open edX LMS.
+
+Django Settings
+***************
+
+The following Django settings control the behavior of the user retirement
+feature. Note that some of these settings values are lambda functions rather
+than standard string literals.  This is intentional; it is a pattern for
+defining *derived* settings specific to Open edX.  Read more about it in
+`openedx/core/lib/derived.py
+<https://github.com/edx/edx-platform/blob/fdc50c3/openedx/core/lib/derived.py>`_
+
+RETIRED_USERNAME_PREFIX
+    Default: ``'retired__user_'``
+
+    The prefix part of hashed usernames.  Used in ``RETIRED_USERNAME_FMT``.
+RETIRED_EMAIL_PREFIX
+    Default: ``'retired__user_'``
+
+    The prefix part of hashed emails.  Used in ``RETIRED_EMAIL_FMT``.
+RETIRED_EMAIL_DOMAIN
+    Default: ``'retired.invalid'``
+
+    The domain part of hashed emails.  Used in ``RETIRED_EMAIL_FMT``.
+RETIRED_USERNAME_FMT
+    Default: ``lambda settings: settings.RETIRED_USERNAME_PREFIX + '{}'``
+
+    The username field for a retired user gets transformed into this format,
+    where ``{}`` is replaced with the hash of their username.
+RETIRED_EMAIL_FMT
+    Default: ``lambda settings: settings.RETIRED_EMAIL_PREFIX + '{}@' + settings.RETIRED_EMAIL_DOMAIN``
+
+    The email field for a retired user gets transformed into this format, where
+    ``{}`` is replaced with the hash of their email.
+RETIRED_USER_SALTS
+    A list of salts used for hashing usernames and emails.  Only the last item
+    in this list is used as a salt for all new retirements, but historical
+    salts are preserved in order to guarantee that all hashed usernames and
+    emails can still be checked.
+
+    The default value MUST be overridden!
+RETIREMENT_SERVICE_WORKER_USERNAME
+    Default: ``'RETIREMENT_SERVICE_USER'``
+    The username of the retirement service worker.
+RETIREMENT_STATES
+    A list which defines the name and order of states for the retirement
+    workflow.  See `Retirement States`_ for details.
+
+Retirement States
+*****************
+
+The state of each user's retirement is stored in the LMS database, and the
+state list itself is also separately stored in the database.  We expect the
+list of states will be variable over time and across different Open edX
+installations, so it is the responsibility of the administrator to populate
+the state list.
+
+The default states are defined in `lms/envs/common.py
+<https://github.com/edx/edx-platform/blob/fe82954/lms/envs/common.py#L3421-L3449>`_
+in the ``RETIREMENT_STATES`` setting.  There must be, at minimum, a ``PENDING``
+state at the beginning, and ``COMPLETED``, ``ERRORED``, and ``ABORTED`` states
+at the end of the list.  Also, for every ``RETIRING_foo`` state, there must be
+a corresponding ``foo_COMPLETE`` state.
+
+Override these states if you need to add any states.  Typically, these settings are set in ``lms.envs.json``.
+
+After you have defined any custom states, populate the states table with the following management command:
+
+.. code-block:: bash
+
+   $ ./manage.py lms --settings=<your-settings> populate_retirement_states
+
+   All states removed and new states added. Differences:
+      Added: set([u'RETIRING_ENROLLMENTS', u'RETIRING_LMS', u'LMS_MISC_COMPLETE', u'RETIRING_LMS_MISC', u'ENROLLMENTS_COMPLETE', u'LMS_COMPLETE'])
+      Removed: set([])
+      Remaining: set([u'ERRORED', u'PENDING', u'ABORTED', u'COMPLETE'])
+   States updated successfully. Current states:
+   PENDING (step 1)
+   RETIRING_ENROLLMENTS (step 11)
+   ENROLLMENTS_COMPLETE (step 21)
+   RETIRING_LMS_MISC (step 31)
+   LMS_MISC_COMPLETE (step 41)
+   RETIRING_LMS (step 51)
+   LMS_COMPLETE (step 61)
+   ERRORED (step 71)
+   ABORTED (step 81)
+   COMPLETE (step 91)
+
+In this example, some states specified in settings were already present, so
+they were listed under "Remaining" and were not re-added. The command output
+also prints the "Current states"; this represents all the states in the
+states table. The ``populate_retirement_states`` command is idempotent, and
+always attempts to make the states table reflect the ``RETIREMENT_STATES``
+list in settings.
+
+.. _retirement-service-user:
+
+Retirement Service User
+***********************
+
+The user retirement driver scripts authenticate with the LMS and IDAs as the
+retirement service user with oauth client credentials.  Therefore, to use the
+driver scrpits, you must create a retirement service user, and generate a DOT application and client credentials, as in the following command.
+
+.. code-block:: bash
+
+   app_name=retirement
+   user_name=retirement_service_worker
+   ./manage.py lms --settings=<your-settings> manage_user $user_name $user_name@example.com --staff --superuser
+   ./manage.py lms --settings=<your-settings> create_dot_application $app_name $user_name
+
+The client credentials (client ID and client secret) will be printed to the
+terminal, so take this opportunity to copy them for future reference.  You
+will use these credentials to configure the driver scripts. For more
+information, see :ref:`driver-setup`.
+
+The retirement service user needs permission to perform retirement tasks, and
+that is done by specifying the ``RETIREMENT_SERVICE_WORKER_USERNAME`` variable
+in Dango settings:
+
+.. code-block:: python
+
+   RETIREMENT_SERVICE_WORKER_USERNAME = 'retirement_service_worker'
+
+.. _waffle-switch-for-ux:
+
+Waffle Switch to Display the Delete My Account Feature
+******************************************************
+
+A waffle switch named ``course_experience.gdpr`` controls whether the Account
+page displays the section named **Delete My Account****. If you do not
+activate this switch, learners will have no available mechanism to request
+account deletion.
+
+You can manage waffle switches from the Django Admin section "Waffle" ->
+"Switches".
+
+Django Admin
+************
+
+The Django admin interface contains the following models under ``USER_API``
+that relate to user retirement:
+
+Retirement states : ``/admin/user_api/retirementstate/``
+    Represents the table of states defined in ``RETIREMENT_STATES`` and
+    populated with ``populate_retirement_states``.
+User Retirement Requests : ``/admin/user_api/userretirementrequest/``
+    Represents the table which simply tracks the user ids of every learner who
+    has ever requested account deletion.  This table is primarily used for
+    internal bookkeeping, and normally isn't useful for administrators.
+User Retirement Statuses : ``/admin/user_api/userretirementstatus/``
+    Model where the retirement state for each individual learner can be
+    managed, if necessary.
+
+In special cases where you may need to manually intervene with the pipeline,
+you can use the User Retirement Statuses management page to change the
+state for an individual user.  For more info on handling these cases, see
+:ref:`handling-special-cases`.

--- a/en_us/user_retirement/source/special_cases.rst
+++ b/en_us/user_retirement/source/special_cases.rst
@@ -1,0 +1,65 @@
+.. _handling-special-cases:
+
+**********************
+Handling Special Cases
+**********************
+
+.. _recovering-from-errored:
+
+Recovering from ERRORED
+***********************
+
+If a retirement API indicates failure (4xx or 5xx status code), the driver
+immediately sets the user's state to ``ERRORED``.  To debug this error state,
+check the ``responses`` field in the user's row in
+``user_api_userretirementstatus`` (User Retirement Status) for any relevant
+logging.  Once the issue is resolved, you need to manually set
+the user's ``current_state`` to the state immediately prior to the state which
+should be retried.  You can do this using the Django admin.
+
+.. digraph:: retirement_states_example
+   :align: center
+
+      //rankdir=LR;  // Rank Direction Left to Right
+      ranksep = "0.3";
+
+      edge[color=grey]
+
+      node[fontname=Courier,fontsize=12,shape=box,group=main]
+      { rank = same INIT[style=invis] PENDING }
+      {
+          edge[style=bold,color=black]
+          INIT -> PENDING;
+          "..."[shape=none]
+          PENDING -> RETIRING_ENROLLMENTS -> ENROLLMENTS_COMPLETE -> RETIRING_FORUMS;
+      }
+      RETIRING_FORUMS -> FORUMS_COMPLETE -> "..." -> COMPLETE
+
+      node[group=""];
+      RETIRING_ENROLLMENTS -> ERRORED;
+      RETIRING_FORUMS -> ERRORED[style=bold,color=black];
+      PENDING -> ABORTED;
+
+      subgraph cluster_terminal_states {
+          label = "Terminal States";
+          labelloc = b  // put label at bottom
+          {rank = same ERRORED COMPLETE ABORTED}
+      }
+
+      ERRORED -> ENROLLMENTS_COMPLETE[style="bold,dashed",color=black,label=" via django\nadmin"]
+
+Now, the user retirement driver scripts will automatically resume this user's
+retirement the next time they are executed.
+
+Re-running some or all states
+*****************************
+
+If you decide you want to re-run all retirements from the beginning, set
+``current_state`` to ``PENDING`` for all retirements with ``current_state`` ==
+``COMPLETE``.  This would be useful in the case where a new stage is added
+after running all retirements (but before the retirement queue is cleaned up),
+and you want to run all the retirements through the new stage.  Or, perhaps you
+were developing a stage/API that didn't work correctly but still indicated
+success, so the pipeline progressed all users into ``COMPLETED``.  Retirement
+APIs are designed to be idempotent, so this should be a no-op for stages
+already run for a given user.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -45,6 +45,7 @@ then
         "en_us/open_edx_students"
         "en_us/ORA2"
         "en_us/students"
+        "en_us/user_retirement"
     )
 fi
 


### PR DESCRIPTION
RTD draft: https://draft-user-retirement-guide.readthedocs.io/en/latest/

The Makefile was just blindly copied from another documentation directory.

## [PLAT-2194](https://openedx.atlassian.net/browse/PLAT-2194)

This documentation covers setting up an Open edX instance and other tooling for user retirement, which is necessary for GDPR compliance.

### Date Needed (optional)

This week?  This week!

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @doctoryes 
- [x] Subject matter expert: @bmedx 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [x] Product review: @stroilova 
- [x] Legal review: nell
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

@macdiesel

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [x] Build an RTD draft for your branch and add a link here

https://draft-user-retirement-guide.readthedocs.io/en/latest/

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

