### PR TITLE
updating Open edX Releases Wiki link

### DIFF
--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -212,7 +212,7 @@
 
 .. EDX WIKI LINKS
 
-.. _Open edX Releases Wiki page: https://openedx.atlassian.net/wiki/display/DOC/Open+edX+Releases
+.. _Open edX Releases Wiki page: https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/11108700/Open+edX+Releases
 
 .. _Release Pages: https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=12550314
 


### PR DESCRIPTION
The Open edX Releases Wiki was moved from the DOC space in Confluence to the Open edX Operations space. This PR updates the link for readthedocs

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

@grantgoodmanedX 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

