### PR TITLE
Add YouTube info to Open edX video docs

### DIFF
--- a/en_us/shared/video/prepare_video/set_up_host.rst
+++ b/en_us/shared/video/prepare_video/set_up_host.rst
@@ -13,14 +13,25 @@ Set Up a Hosting Service
     For Edge courses, you must work with a third party hosting site to make
     your videos available for streaming or download.
 
+    To host your videos, you can use any video hosting site that you want. Many
+    courses use `Amazon S3`_. When you select a video hosting site, we strongly
+    recommend that you keep the following information in mind.
+
 .. only:: Open_edX
 
    You must work with a third party hosting site to make your videos available
    for streaming or download.
 
-To host your videos, you can use any video hosting site that you want. Many
-courses use `Amazon S3`_. When you select a video hosting site, we strongly
-recommend that you keep the following information in mind.
+   To host your videos, you can use any video hosting site that you want, such
+   as `Amazon S3`_ or `YouTube`_.
+
+   When you select a video hosting site, we strongly recommend that you keep
+   the following information in mind.
+
+.. only:: Open_edX
+
+ * If you host your videos on `YouTube`_, you must follow all rules and
+   restrictions that are associated with YouTube.
 
 * The hosting site might have to handle high traffic volume.
 * Not all hosting sites are available in all countries or regions. We recommend
@@ -28,7 +39,8 @@ recommend that you keep the following information in mind.
 * Learners' internet connections vary widely. We recommend that you make your
   videos available for both download and streaming.
 * The URL for your videos must end in .mp4, .mpeg, .webm, or .ogg. The video
-  player cannot support videos that you upload on sites such as Vimeo.
+  player cannot support videos that you upload on sites such as Vimeo,
+  Dailymotion, or other sites that use their own player.
 
   .. note::
     To help make sure all standard browsers can play your video, we strongly

--- a/en_us/shared/video/upload_video.rst
+++ b/en_us/shared/video/upload_video.rst
@@ -1,9 +1,15 @@
 To upload a video to a third party hosting site, follow the instructions for
 that site. Keep the following guidelines in mind.
 
+.. only:: Open_edX
+
+ * If you host your videos on `YouTube`_, you must follow all rules and
+   restrictions that are associated with YouTube.
+
 * The URL for the video that you upload on a third party hosting site must end
   in .mp4, .mpeg, .webm, or .ogg. The video player cannot support videos that
-  you upload on sites such as YouTube and Vimeo.
+  you upload on sites such as Vimeo, Dailymotion, or other sites that use their
+  own player.
 
   To help make sure all standard browsers can play your video, edX strongly
   recommends that you use .mp4 format.


### PR DESCRIPTION
## [DOC-3904](https://openedx.atlassian.net/browse/DOC-3904)

Open edX supports video hosting on YouTube. Make this explicit in the Open edX video documentation.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (copy edit): @edx/doc
