### PR TITLE
Clarify video start and stop time documentation.

### DIFF
--- a/en_us/shared/video/additional_video_options.rst
+++ b/en_us/shared/video/additional_video_options.rst
@@ -138,18 +138,18 @@ The following options appear on the **Advanced** page of the video component.
         video to play. Use HH:MM:SS format. The maximum value is 23:59:59.
 
         .. note::
-         Learners who download and play the video in the mobile
-         app see the entire video file. Only videos that play in a browser
-         start playing at the specified start time.
+           Learners who play video in the mobile app see the entire video file.
+           Only videos that play in a browser start playing at the specified
+           start time.
 
     * - **Video Stop Time**
       - The time you want the video to stop if you do not want the entire video
         to play. Use HH:MM:SS format. The maximum value is 23:59:59.
 
         .. note::
-         Learners who download and play the video in the mobile
-         app see the entire video file. Only videos that play in a browser
-         stop playing at the specified stop time.
+           Learners who play video in the mobile app see the entire video file.
+           Only videos that play in a browser stop playing at the specified
+           stop time.
 
     * - **YouTube IDs**
       - As of March 2018, edX no longer supports videos on YouTube.


### PR DESCRIPTION
Video start and stop times are not supported in the mobile app. Update
the documentation to reflect that, if learners view video in the mobile
app, they will see the entire video. If video is viewed in a browser,
start and stop times can be set.

## [DOC-3961](https://openedx.atlassian.net/browse/DOC-3961)

Add a description of your changes with links to any relevant material.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

