### PR TITLE
Update doc to reflect UI changes for timed exam settings

### DIFF
--- a/en_us/shared/course_features/timed_exams.rst
+++ b/en_us/shared/course_features/timed_exams.rst
@@ -208,15 +208,9 @@ affected, and their scores for the exam remain visible on the **Progress** page.
 
    The **Settings** dialog box opens to the **Basic** tab.
 
-#. Select the **Advanced** tab.
+#. Select the **Visibility** tab.
 
-#. In the **Set as a Special Exam** section, make sure **Timed** is selected.
-
-#. Select **Hide Exam After Due Date**.
-
-   .. image:: ../../../shared/images/timed_exam_hide_after_due_date.png
-    :alt: The Hide Exam After Due Date option in the Settings dialog box.
-    :width: 400
+#. In the **Subsection Visibility** section, select **Hide content after due date**.
 
 #. Select **Save**.
 


### PR DESCRIPTION
Updated the topic to reflect that hiding an exam after the due date has
passed is now accomplished by selecting Configure > Advanced > Hide content
after due date.

## [DOC-3658](https://openedx.atlassian.net/browse/DOC-3658)

### Date Needed: July 30, 2018

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time. N/A

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @sstack22 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: @JAAkana
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

