### PR TITLE
Draft release note, based on Matt Dubose portal post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .project
 .pycharm_helpers/
 .pydevproject
+venv/
 
 ### NFS artifacts
 .nfs*

--- a/en_us/install_operations/source/configuration/customize_registration_page.rst
+++ b/en_us/install_operations/source/configuration/customize_registration_page.rst
@@ -33,7 +33,7 @@ files are located one level above the ``edx- platform`` directory.
 
 To add custom fields to the registration page, follow these steps.
 
-#. :ref:`Start the LMS<Start the LMS>` and sign in to your instance of Open edX.
+#. Start and sign in to your instance of Open edX.
 
 #. Use Python to create a Django form that contains the fields that you want to
    add to the page, and then create a Django model to store the information

--- a/en_us/install_operations/source/installation/install_analytics.rst
+++ b/en_us/install_operations/source/installation/install_analytics.rst
@@ -81,11 +81,10 @@ namenode, run this command.
    
    make namenode-logs
 
-For additional information, see :ref:`Starting the Open edX Developer
-Stack`.
+For additional information, see :ref:`Starting Devstack`.
 
-For help with the Analytics Devstack installation, see
-:ref:`troubleshooting_devstack_installation`.
+For help with running the Analytics Devstack, see
+:ref:`Troubleshooting Devstack`.
 
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/installation/install_devstack.rst
+++ b/en_us/install_operations/source/installation/install_devstack.rst
@@ -79,7 +79,7 @@ The default username and password for the superusers are both ``edx``. You can
 access the services directly using Django admin at the ``/admin/`` path, or
 log in using single sign-on at ``/login/``.
 
-When you have completed these steps, see :ref:`Starting the Open edX Developer
+When you have completed these steps, see :ref:`Starting Devstack`.
 Stack` to begin using Devstack.
 
 For help with running Devstack, see :ref:`Troubleshooting Devstack`.

--- a/en_us/install_operations/source/installation/install_devstack.rst
+++ b/en_us/install_operations/source/installation/install_devstack.rst
@@ -33,7 +33,7 @@ To install Devstack, follow these steps.
    ``https://github.com/edx/devstack``, selecting the branch that you want to
    work with.
 
-#. Navigate to the ``devstack`` directory
+#. Navigate to the ``devstack`` directory.
 
 #. Create a Python virtual environment. For information about how to do this,
    see `Virtual Environments`_.
@@ -80,7 +80,6 @@ access the services directly using Django admin at the ``/admin/`` path, or
 log in using single sign-on at ``/login/``.
 
 When you have completed these steps, see :ref:`Starting Devstack`.
-Stack` to begin using Devstack.
 
 For help with running Devstack, see :ref:`Troubleshooting Devstack`.
 

--- a/en_us/install_operations/source/platform_releases/birch.rst
+++ b/en_us/install_operations/source/platform_releases/birch.rst
@@ -11,8 +11,7 @@ This section describes how to install the Open edX Birch release.
  :depth: 1
 
 .. note::
-  Now that the Open edX Cypress release is available, edX no longer
-  supports the Birch release.
+  EdX no longer supports the Birch release.
 
 ******************************
 What's Included in Birch
@@ -46,102 +45,6 @@ The following Open edX Git repositories have the Git tag **named-release/birch.2
 * edx-documentation
 * edx-ora2
 * XBlock
-
-.. confirm
-
-******************************
-Installing the Birch Release
-******************************
-
-You can install the Open edX Birch release using :ref:`Devstack <Installing the
-Open edX Developer stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
-
-Review the prerequisites and instructions for each option, then choose the
-option that best meets your needs. Ensure you install the required software to
-run the edX Platform.
-
-If you are upgrading from the Aspen release, see `Upgrading from Aspen to
-Birch`_.
-
-For new installations, follow the steps below.
-
-#. `Download the Vagrant Box`_ or `Download the BitTorrent File`_.
-
-   .. caution::
-     The Vagrant boxes have a large file size (about 2.5GB). If you have a slow
-     or unreliable Internet connection, use BitTorrent to download the
-     Vagrant box you need.
-
-#. `Set the OPENEDX_RELEASE Environment Variable`_.
-#. `Install the Vagrant Box`_.
-
-=========================
-Download the Vagrant Box
-=========================
-
-If you have a fast and reliable Internet connection, you can download the
-Vagrant box directly or by running ``vagrant up`` when installing
-:ref:`Devstack <Installing the Open edX Developer Stack>` or
-:ref:`Fullstack <Installing Open edX Fullstack>`.
-
-See the `Open edX Releases Wiki page`_ to access the latest Vagrant
-boxes.
-
-See `Vagrant's documentation on boxes`_ for more information.
-
-
-=============================
-Download the BitTorrent File
-=============================
-
-You can also download the BitTorrent file for the option you selected.
-BitTorrent is recommended if you have a slow or unreliable data connection.
-You then use the BitTorrent file to download the Vagrant box. If the Internet
-connection is temporarily lost while you are downloading the Vagrant box
-through BitTorrent, you can later continue the download without data loss or
-corruption.
-
-See the `Open edX Releases Wiki page`_ to access the latest Vagrant
-boxes.
-
-See `BitTorrent`_ for more information.
-
-If you download the Vagrant box through BitTorrent, you must add the box to
-Vagrant before continuing with the installation process.
-
-* For devstack installations, run the following command.
-
-   .. code-block:: bash
-
-     $ vagrant box add /path-to-downloaded-box/vagrant-images-birch-2-devstack.box --name birch-devstack-2
-
-* For fullstack installations, run the following command.
-
-   .. code-block:: bash
-
-     $ vagrant box add /path-to-downloaded-box/vagrant-images-birch-2-fullstack.box --name birch-fullstack-2
-
-============================================
-Set the OPENEDX_RELEASE Environment Variable
-============================================
-
-Before installing the Vagrant box, you must set the value of the
-`OPENEDX_RELEASE` environment variable to the Git tag for the Birch release:
-
-.. code-block:: bash
-
-  export OPENEDX_RELEASE="named-release/birch.2"
-
-
-=========================
-Install the Vagrant Box
-=========================
-
-When you have completed the previous steps, install the Birch release by
-following the installation instructions for :ref:`Devstack <Installing the Open
-edX Developer Stack>` or
-:ref:`Fullstack <Installing Open edX Fullstack>`.
-
 
 ******************************
 Upgrading from Aspen to Birch

--- a/en_us/install_operations/source/platform_releases/cypress.rst
+++ b/en_us/install_operations/source/platform_releases/cypress.rst
@@ -4,7 +4,8 @@
 Open edX Cypress Release
 ########################################
 
-This section describes how to install the Open edX Cypress release.
+This section describes the Open edX Cypress release. Note that edX no longer
+supports the Cypress release.
 
 .. contents::
  :local:
@@ -46,102 +47,6 @@ The following Open edX Git repositories have the Git tag
 * edx-documentation
 * edx-ora2
 * XBlock
-
-******************************
-Installing the Cypress Release
-******************************
-
-You can install the Open edX Cypress release using
-:ref:`Devstack <Installing the Open edX Developer stack>` or
-:ref:`Fullstack <Installing Open edX Fullstack>`.
-
-Review the prerequisites and instructions for each option, and then choose the
-option that best meets your needs. Ensure that you install the
-required software to run the edX Platform.
-
-If you are upgrading from the Birch release, see `Upgrading from Birch to
-Cypress`_.
-
-For new installations, follow these steps.
-
-#. `Download the Vagrant Box`_ or `Download the BitTorrent File`_.
-
-   .. caution::
-     The Vagrant boxes have a large file size (about 2.5GB). If you have a slow
-     or unreliable Internet connection, use BitTorrent to download the
-     Vagrant box you need.
-
-#. `Set the OPENEDX_RELEASE Environment Variable`_.
-
-#. `Install the Vagrant Box`_.
-
-=========================
-Download the Vagrant Box
-=========================
-
-If you have a fast and reliable Internet connection, you can download the
-Vagrant box directly or by running ``vagrant up`` when installing
-:ref:`Devstack <Installing the Open edX Developer Stack>` or
-:ref:`Fullstack <Installing Open edX Fullstack>`.
-
-See the `Open edX Releases Wiki page`_ to access the latest Vagrant
-boxes.
-
-See `Vagrant's documentation on boxes`_ for more information.
-
-=============================
-Download the BitTorrent File
-=============================
-
-You can also download the BitTorrent file for the option you selected.
-BitTorrent is recommended if you have a slow or unreliable data connection.
-You then use the BitTorrent file to download the Vagrant box. If the Internet
-connection is temporarily lost while you are downloading the Vagrant box
-through BitTorrent, you can later continue the download without data loss or
-corruption.
-
-See the `Open edX Releases Wiki page`_ to access the latest Vagrant
-boxes.
-
-See `BitTorrent`_ for more information.
-
-If you download the Vagrant box through BitTorrent, you must add the box to
-Vagrant before continuing with the installation process.
-
-* For devstack installations, run the following command.
-
-   .. code-block:: bash
-
-     $ vagrant box add /path-to-downloaded-box/name-of-vagrant-box --name
-       cypress-devstack
-
-
-* For fullstack installations, run the following command.
-
-   .. code-block:: bash
-
-     $ vagrant box add /path-to-downloaded-box/name-of-vagrant-box --name
-       cypress-fullstack
-
-============================================
-Set the OPENEDX_RELEASE Environment Variable
-============================================
-
-Before installing the Vagrant box, you must set the value of the
-``OPENEDX_RELEASE`` environment variable to the Git tag for the Cypress
-release. Use the Linux ``export`` command.
-
-.. code-block:: bash
-
-  export OPENEDX_RELEASE="named-release/cypress"
-
-=========================
-Install the Vagrant Box
-=========================
-
-When you have completed the previous steps, install the Cypress release by
-following the installation instructions for :ref:`Devstack <Installing the Open
-edX Developer Stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
 
 ********************************
 Upgrading from Birch to Cypress

--- a/en_us/install_operations/source/platform_releases/dogwood.rst
+++ b/en_us/install_operations/source/platform_releases/dogwood.rst
@@ -4,7 +4,8 @@
 Open edX Dogwood Release
 ########################################
 
-This section describes how to install the Open edX Dogwood release.
+This section describes the Open edX Dogwood release. Note that edX no longer 
+supports the Dogwood relesae. 
 
 .. contents::
  :local:
@@ -46,102 +47,6 @@ The following Open edX Git repositories have the Dogwood Git tag.
 * edx-analytics-dashboard
 * edx-analytics-data-api
 * edx-analytics-pipeline
-
-******************************
-Installing the Dogwood Release
-******************************
-
-You can install the Open edX Dogwood release using :ref:`Devstack <Installing
-the Open edX Developer stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
-
-Review the prerequisites and instructions for each option, and then choose the
-option that best meets your needs. Ensure that you install the
-required software to run the edX platform.
-
-If you are upgrading from the Cypress release, see `Upgrading from Cypress to
-Dogwood`_.
-
-For new installations, follow these steps.
-
-#. `Download the Vagrant Box`_ or `Download the BitTorrent File`_.
-
-   .. caution::
-     The Vagrant boxes have a large file size (between 4 and 5 GB). If you have
-     a slow or unreliable Internet connection, use BitTorrent to download the
-     Vagrant box you need.
-
-#. `Set the OPENEDX_RELEASE Environment Variable`_.
-
-#. `Install the Vagrant Box`_.
-
-=========================
-Download the Vagrant Box
-=========================
-
-If you have a fast and reliable Internet connection, you can download the
-Vagrant box directly or by running ``vagrant up`` when you install
-:ref:`Devstack <Installing the Open edX Developer Stack>` or
-:ref:`Fullstack <Installing Open edX Fullstack>`.
-
-To access the latest Vagrant boxes, see the `Open edX Releases Wiki
-page`_.
-
-For more information about working with vagrant boxes, see `Vagrant's
-documentation on boxes`_.
-
-=============================
-Download the BitTorrent File
-=============================
-
-You can also download the BitTorrent file for the option you selected.
-BitTorrent is recommended if you have a slow or unreliable data connection.
-You then use the BitTorrent file to download the Vagrant box. If the Internet
-connection is temporarily lost while you are downloading the Vagrant box
-through BitTorrent, you can later continue the download without data loss or
-corruption.
-
-To access the latest Vagrant box torrents, see the `Open edX Releases Wiki
-page`_.
-
-For more information about downloading BitTorrent files, see `BitTorrent`_.
-
-If you download the Vagrant box through BitTorrent, you must add the box to
-Vagrant before continuing with the installation process.
-
-Be sure to verify that you have the most up-to-date Git tag for the Open edX
-releases on the `Open edX Releases Wiki page`_.
-
-* For devstack installations, run the following command.
-
-   .. code-block:: bash
-
-     $ vagrant box add /{path-to-downloaded-box}/{vagrant-box-name} --name {Git-tag}
-
-* For fullstack installations, run the following command.
-
-   .. code-block:: bash
-
-     $ vagrant box add /{path-to-downloaded-box}/{vagrant-box-name} --name {Git-tag}
-
-============================================
-Set the OPENEDX_RELEASE Environment Variable
-============================================
-
-Before installing the Vagrant box, you must set the value of the
-``OPENEDX_RELEASE`` environment variable to the Git tag for the Dogwood
-release. To do so, use the Linux ``export`` command.
-
-.. code-block:: bash
-
-  export OPENEDX_RELEASE="{Git tag}"
-
-=========================
-Install the Vagrant Box
-=========================
-
-When you have completed the previous steps, install the Dogwood release by
-following the installation instructions for :ref:`Devstack <Installing the Open
-edX Developer Stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
 
 *********************************
 Upgrading from Cypress to Dogwood

--- a/en_us/install_operations/source/platform_releases/eucalyptus.rst
+++ b/en_us/install_operations/source/platform_releases/eucalyptus.rst
@@ -4,7 +4,8 @@
 Open edX Eucalyptus Release
 ########################################
 
-This section describes how to install the Open edX Eucalyptus release.
+This section describes the Open edX Eucalyptus release. Note that edX no longer 
+supports the Eucalyptus relesae. 
 
 .. contents::
  :local:
@@ -42,23 +43,6 @@ The following Open edX Git repositories have the Eucalyptus Git tag.
 * edx-analytics-dashboard
 * edx-analytics-data-api
 * edx-analytics-pipeline
-
-*********************************
-Installing the Eucalyptus Release
-*********************************
-
-You can install the Open edX Eucalyptus release using :ref:`Devstack <Installing
-the Open edX Developer stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
-
-Review the prerequisites and instructions for each option, and then choose the
-option that best meets your needs. Ensure that you install the
-required software to run the Open edX platform.
-
-If you are upgrading from the Dogwood release, see `Upgrading from Dogwood to
-Eucalyptus`_.
-
-Eucalyptus releases have Git tag names like ``open-release/eucalyptus.1``.
-The available names are detailed on the `Open edX Releases Wiki page`_.
 
 
 ************************************
@@ -124,8 +108,8 @@ The steps to upgrade differ based on your original installation method.
 Upgrading a Vagrant Installation
 ================================
 
-Devstack and Fullstack are installed using Vagrant.  To upgrade to a Eucalyptus
-point release, follow these steps in the host operating system.
+Devstack and Fullstack for Eucalyptus are installed using Vagrant.  To upgrade 
+to a Eucalyptus point release, follow these steps in the host operating system.
 
 .. code-block:: bash
 

--- a/en_us/install_operations/source/platform_releases/ficus.rst
+++ b/en_us/install_operations/source/platform_releases/ficus.rst
@@ -4,7 +4,8 @@
 Open edX Ficus Release
 ######################
 
-This section describes how to install the Open edX Ficus release.
+This section describes the Open edX Ficus release. Note that edX no longer 
+supports the Ficus relesae. 
 
 .. contents::
  :local:
@@ -47,25 +48,6 @@ The following Open edX git repositories have the Ficus git tag:
 * notifier
 * programs
 * ux-pattern-library
-
-****************************
-Installing the Ficus Release
-****************************
-
-You can install the Open edX Ficus release using :ref:`Devstack <Installing
-the Open edX Developer stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
-
-Review the prerequisites and instructions for each option, and then choose the
-option that best meets your needs. Ensure that you install the
-required software to run the Open edX platform.
-
-Ficus releases have git tag names like ``open-release/ficus.1``.
-The available names are detailed on the `Open edX Releases Wiki page`_.
-
-Previous releases ran on Ubuntu 12.04, but Ficus runs on 16.04.  Because of the
-change in operating system, edX is not providing an upgrade path.  If you have
-an existing Eucalyptus installation, you must install Ficus on a new
-machine, and move your data and settings to it.
 
 
 ***************************************

--- a/en_us/install_operations/source/platform_releases/ginkgo.rst
+++ b/en_us/install_operations/source/platform_releases/ginkgo.rst
@@ -4,7 +4,7 @@
 Open edX Ginkgo Release
 ########################
 
-This section describes how to install the Open edX Ginkgo release.
+This section describes the Open edX Ginkgo release.
 
 .. contents::
  :local:
@@ -47,22 +47,6 @@ The following Open edX git repositories have the Ginkgo git tag:
 * edx-ui-toolkit
 * notifier
 * ux-pattern-library
-
-******************************
-Installing the Ginkgo Release
-******************************
-
-You can install the Open edX Ginkgo release using :ref:`Devstack <Installing
-the Open edX Developer stack>` or :ref:`Fullstack <Installing Open edX Fullstack>`.
-
-Review the prerequisites and instructions for each option, and then choose the
-option that best meets your needs. Ensure that you install the
-required software to run the Open edX platform.
-
-Ginkgo releases have git tag names like ``open-release/ginkgo.1``.
-The available names are detailed on the `Open edX Releases Wiki page`_.
-
-.. _upgrade_ficus:
 
 **********************************
 Upgrading from the Ficus Release

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -531,7 +531,7 @@
 
 .. _AWS template file: https://github.com/edx/edx-platform/blob/b3462e5b1c3cc45ad8673f3f12e84fa17ffa6b64/lms/envs/aws.py#L586-L596
 
-.. _random and highly secure password: https://github.com/edx/edx- platform/blob/46d69eba/common/djangoapps/third_party_auth/pipeline.py#L392-L410
+.. _random and highly secure password: https://github.com/edx/edx-platform/blob/46d69eba/common/djangoapps/third_party_auth/pipeline.py#L392-L410
 
 .. _OAuth backends supported by python-social-auth v0.2.12: http://python-social-auth.readthedocs.io/en/latest/backends/index.html#social-backends
 
@@ -576,6 +576,8 @@
 .. _User Retirement: https://user-retirement-guide.readthedocs.io/en/latest/index.html
 
 .. _Open edX Release Notes: http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/hawthorn.html
+
+.. _Password Policy: https://github.com/edx/edx-platform/wiki/Optional-Password-Policy-Enforcement
 
 .. _Taking Timed and Proctored Exams: https://support.edx.org/hc/en-us/sections/115004169247
 

--- a/en_us/open_edx_release_notes/source/dogwood.rst
+++ b/en_us/open_edx_release_notes/source/dogwood.rst
@@ -83,9 +83,8 @@ support analytics development. This environment, known as the Analytics
 Devstack, includes the edX Analytics Data API and Open edX Insights, as well
 as all of the components needed to run the Open edX Analytics Pipeline.
 
-For more information, see :ref:`installation:Installing the Open edX Analytics
-Developer Stack` in the *Installing, Configuring, and Running the Open edX
-Platform* guide.
+For more information, see the *Installing, Configuring, and Running the Open 
+edX Platform* guide.
 
 .. note:: EdX does not currently provide installation or support of Insights
  for Open edX installations.

--- a/en_us/open_edx_release_notes/source/hawthorn.rst
+++ b/en_us/open_edx_release_notes/source/hawthorn.rst
@@ -35,8 +35,8 @@ LMS and Learner Features
 
 * We’ve enhanced the learner profiles so that they now include the date a
   learner joined the platform and any course credentials they have received.
-  This links to social media accounts and helps learners share information with
-  one another. 
+  Learner profiles link to social media accounts and help learners share 
+  information with one another. 
 * Learners now have the ability to purchase all the courses in a
   program in just one transaction. This avoids the hassle of having to enter
   payment information multiple times.
@@ -55,8 +55,8 @@ Studio and Course Author Tools
   problems. This can be done through a setting on both the instructor dashboard 
   and the Staff Debug viewer.
 * Course Reviews can now be viewed and added by learners from within the course 
-  experience. Open edX system administrators can configure a reviews provider 
-  such as CourseTalk to allows learners to leave reviews for a particular course.
+  experience. Open edX system administrators can configure a reviews provider, 
+  such as CourseTalk, to allows learners to leave reviews for a particular course.
 * Proctored exams have been improved, enabling course teams to add specific exam 
   instructions in the Studio proctored exam settings.
 * The Files & Uploads page has been updated to significantly simplify the 
@@ -73,7 +73,7 @@ Studio and Course Author Tools
   higher verification rates than ones without.
 * The HTML components have been updated to give you even more easy formatting 
   options such as aligning your text the way you want: aligned to the left or 
-  right, centered, or fully justified. Images to HTML components can be added 
+  right, centered, or fully justified. Images in HTML components can be added 
   right inside the HTML component itself, without having to upload files 
   beforehand.
 * The Video Uploads page is enabled by default. For course teams who partner 

--- a/en_us/open_edx_release_notes/source/hawthorn.rst
+++ b/en_us/open_edx_release_notes/source/hawthorn.rst
@@ -86,8 +86,6 @@ System Upgrades and Updates
 *******************************
 
 The Hawthorn release makes version updates to a number of system components.
->> THIS IS A CUT AND PASTE FROM GINKGO
-
 
 .. list-table::
    :widths: 60 40
@@ -95,20 +93,18 @@ The Hawthorn release makes version updates to a number of system components.
 
    * - System
      - Upgraded Version
-   * - Catalog Service
+   * - edxapp
      - Django 1.11.x
-   * - Credentials Service
-     - Django 1.11.x
-   * - Django Waffle
-     - 0.12.0
-   * - E-Commerce Service
-     - Django 1.10.x
+   * - Mongo
+     - Mongo 3.2
    * - Search
      - ElasticSearch 1.5
    * - Node
-     - Node 6.9
+     - Node 8
    * - xblock-lti-consumer
      - 1.1.5
+   * - Queueing
+     - Redis replaces Rabbit
 
 
 ***********************
@@ -117,7 +113,15 @@ Deprecated Features
 
 Several features are deprecated or deleted in the Open edX Hawthorn release.
 
-* TK
+* The waffle flag ``unified_course_view``, which can be used for the new view
+  of the course outline on a separate page, was deprecated in Ginkgo.  The old
+  sidebar navigation and this waffle flag will be fully removed in the next
+  release. We recommend switching this flag to ``True``, so that you will not
+  experience any change with the next release.
+* ``django-simple-history`` has been deprecated and removed.
+* The ``LogoutViewConfiguration`` model has been removed. Single logout is now 
+  permanently enabled. This meants that logging out of the LMS or an IDA logs 
+  you out of all systems.
 
 
 .. include:: links.rst

--- a/en_us/open_edx_release_notes/source/hawthorn.rst
+++ b/en_us/open_edx_release_notes/source/hawthorn.rst
@@ -77,8 +77,10 @@ Studio and Course Author Tools
   right inside the HTML component itself, without having to upload files 
   beforehand.
 * The Video Uploads page is enabled by default. For course teams who partner 
-  with 3Play Media and cielo24, transcripts-—including translations of 
-  transcripts-—are added to Studio automatically.​
+  with 3Play Media and cielo24, transcripts (including translations of 
+  transcripts) are added to Studio automatically.​
+* You can establish a password policy to require a minimum strength and 
+  complexity for passwords. For more information, see `Password Policy`_
 
 
 *******************************

--- a/en_us/open_edx_release_notes/source/hawthorn.rst
+++ b/en_us/open_edx_release_notes/source/hawthorn.rst
@@ -4,7 +4,7 @@
 Open edX Hawthorn Release
 #########################
 
-This page lists the highlights of the Hawthorn release.
+This page lists the highlights of the Hawthorn release of the Open edX platform.
 
 The `edX Release Notes`_ contain a summary of changes that are deployed to
 edx.org. Those changes are part of the master branch of the edX Platform in
@@ -18,9 +18,9 @@ of Open edX. Changes after that point will be in future Open edX releases.
  :depth: 1
  :local:
 
-************
-New Features
-************
+*************************
+New and Improved Features
+*************************
 
 The Open edX Hawthorn release includes the following updates.
 
@@ -29,36 +29,64 @@ The Open edX Hawthorn release includes the following updates.
  :local:
 
 
-===
-LMS
-===
+========================
+LMS and Learner Features
+========================
 
-*  TK
+* We’ve enhanced the learner profiles so that they now include the date a
+  learner joined the platform and any course credentials they have received.
+  This links to social media accounts and helps learners share information with
+  one another. 
+* Learners now have the ability to purchase all the courses in a
+  program in just one transaction. This avoids the hassle of having to enter
+  payment information multiple times.
+* New discussion notifications now send an email message the first time a 
+  learner's post receives a comment. The message contains the comment and a 
+  link back to the course discussions for easy access. Inline discussions are 
+  expanded by default. This change has led to a threefold increase in 
+  discussion participation on edx.org.​
 
 
 ===============================
 Studio and Course Author Tools
 ===============================
 
-*  TK
+* Course teams now have the ability to override learner scores for individual 
+  problems. This can be done through a setting on both the instructor dashboard 
+  and the Staff Debug viewer.
+* Course Reviews can now be viewed and added by learners from within the course 
+  experience. Open edX system administrators can configure a reviews provider 
+  such as CourseTalk to allows learners to leave reviews for a particular course.
+* Proctored exams have been improved, enabling course teams to add specific exam 
+  instructions in the Studio proctored exam settings.
+* The Files & Uploads page has been updated to significantly simplify the 
+  experience of adding all types of files to a course. This includes the 
+  ability to search and a Hide File Preview option.
+* The ORA problem editor has been improved. A new interface offers the same 
+  formatting options for the prompt that are available for HTML components. 
+  You no longer have to create a separate HTML component above the ORA 
+  assignment.
+* Weekly course highlight messages can now be sent to encourage learners to 
+  remain engaged with self-paced courses. Specify a few highlights for each 
+  course section, and the platform sends out a weekly email message that lists 
+  these highlights. Courses on edx.org that enabled weekly highlights had 
+  higher verification rates than ones without.
+* The HTML components have been updated to give you even more easy formatting 
+  options such as aligning your text the way you want: aligned to the left or 
+  right, centered, or fully justified. Images to HTML components can be added 
+  right inside the HTML component itself, without having to upload files 
+  beforehand.
+* The Video Uploads page is enabled by default. For course teams who partner 
+  with 3Play Media and cielo24, transcripts-—including translations of 
+  transcripts-—are added to Studio automatically.​
 
-=======================
-Insights and Analytics
-=======================
-
-*  TK
-
-*****************
-Service Upgrades
-*****************
-
-TK
 
 *******************************
 System Upgrades and Updates
 *******************************
 
 The Hawthorn release makes version updates to a number of system components.
+>> THIS IS A CUT AND PASTE FROM GINKGO
 
 
 .. list-table::


### PR DESCRIPTION
Draft of release notes for Hawthorn, starting from @mduboseedx 's post at https://open.edx.org/blog/all-about-hawthorn

Need to verify that all these feature changes are in Open edX and not just edx.org
Also need to update System Upgrades and Updates section, which is currently just a cut and paste from Ginkgo and therefore 100% wrong.

### Date Needed (optional)

8/2

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @mduboseedx 
- [x] Subject matter expert: @nedbat 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

