### PR TITLE
A11y doc update re: learner accommodations

### DIFF
--- a/en_us/shared/course_features/proctored_exams/proctored_managing.rst
+++ b/en_us/shared/course_features/proctored_exams/proctored_managing.rst
@@ -19,8 +19,9 @@ case by case basis.
 Accommodate Learners with Disabilities
 **************************************
 
-You can make a special policy accommodation to the exam policy for a particular
-learner, such as allowing an additional person to help a blind learner.
+A learner may request and qualify for a disability accommodation to a
+proctored exam, such as an additional time allowance or an exam policy
+exception allowing a personal care assistant in the room.
 
 .. note::
   Make sure the learner who has requested special accommodations, including
@@ -49,8 +50,7 @@ To make a special policy accommodation for a learner, follow these steps.
 
 #. Add a description of the allowance, such as the following example.
 
-   ``Learner cannot see. Allow an additional person in the room to act as a
-   scribe.``
+   ``Learner has a disability. Allow one additional person in the room.``
 
 #. For **Username** or **Email**, enter the learner's information.
 


### PR DESCRIPTION
Per MIT request, updated text to clarity that granting accommodations is
initiated by learners and not by edX/an institution/course team.  Text
approved by Jeff W.

## [DOC-3971](https://openedx.atlassian.net/browse/DOC-3971)

### Date Needed 20 Aug 2018

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [X] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

