### PR TITLE
Fix JSON format text-wrapping issue.

### DIFF
--- a/en_us/shared/student_progress/course_answers.rst
+++ b/en_us/shared/student_progress/course_answers.rst
@@ -256,7 +256,12 @@ When you open the report, the value in the **State** column appears on a single
 line. This value is a record in JSON format. An example record for a text input
 CAPA problem follows.
 
-``{"correct_map": {"e58b639b86db44ca89652b30ea566830_2_1": {"hint": "", "hintmode": null, "correctness": "correct", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}}, "input_state": {"e58b639b86db44ca89652b30ea566830_2_1": {}}, "last_submission_time": "2015-10-26T17:32:20Z", "attempts": 3, "seed": 1, "done": true, "student_answers": {"e58b639b86db44ca89652b30ea566830_2_1": "choice_2"}}``
+``{"correct_map": {"e58b639b86db44ca89652b30ea566830_2_1": {"hint": "",``
+``"hintmode": null, "correctness": "correct", "msg": "", "answervariable":``
+``null, "npoints": null, "queuestate": null}}, "input_state":``
+``{"e58b639b86db44ca89652b30ea566830_2_1": {}}, "last_submission_time":``
+``"2015-10-26T17:32:20Z", "attempts": 3, "seed": 1, "done": true,``
+``"student_answers": {"e58b639b86db44ca89652b30ea566830_2_1": "choice_2"}}``
 
 You can use a JSON "pretty print" tool or script to make the value in the
 **State** column more readable, as in the following example.


### PR DESCRIPTION
In file 17.2.1.4, fix JSON text formatting that is running off the page.

I fixed two issues:
 - Added line breaks to the end of all lines in the code block.
 - Added grave double accents (``) at the beginning and the end of the
lines.

https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/s
tudent_progress/course_answers.html?highlight=answer%20data#interpret-th
e-student-state-report

## [DOC-3975](https://openedx.atlassian.net/browse/DOC-3975)

### Date Needed: 21-Aug-2018

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

