### PR TITLE
Updating Office Mix data description

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
@@ -5259,17 +5259,16 @@ exploration.
 Microsoft Office Mix Events
 ===========================
 
-Course teams can use Office Mix to turn Microsoft PowerPoint presentations in
-to interactive online lessons, called mixes. They can then use the Office Mix
-tool in Studio to include mixes in a course. When users interact with the
-Office Mix player in the LMS, the server emits the following events.
+Course teams could formerly use Office Mix to turn Microsoft PowerPoint 
+presentations in to interactive online lessons, called mixes. They can 
+then use the Office Mix tool in Studio to include mixes in a course. 
+Microsoft has discontinued Office Mix, so this tool is no longer available. 
+When users interacted with the Office Mix player in the LMS, the server would 
+emit the following events.
 
 .. contents::
   :local:
   :depth: 1
-
-For more information about adding mixes to a course, see
-:ref:`partnercoursestaff:Office Mix Tool`.
 
 ``microsoft.office.mix.loaded``
 ******************************************


### PR DESCRIPTION
## Research Guide: Data reference

The Research Guide includes reference information about student events that come from the Office Mix tool. We've removed the Office Mix tool, since Microsoft terminated the service it relied on. Data sets might still include Office Mix events, so I changed the description to make it clear that these events can no longer be generated and removed the cross-reference to the Office Mix section in the Course Authors guide.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

