### PR TITLE
Add password complexity requirements to edX Learner's Guide

### DIFF
--- a/en_us/shared/students/SFD_update_acct_settings.rst
+++ b/en_us/shared/students/SFD_update_acct_settings.rst
@@ -57,6 +57,14 @@ To change your password, follow these steps.
    Address** field.
 
 #. Select the confirmation link in the email message.
+   
+.. only:: Partners
+
+  Passwords must contain:
+
+  * At least 8 characters
+  * At least 1 numeric character
+  * At least 1 alphabetical character
 
 *************************
 Update Your Email Address


### PR DESCRIPTION
## [DOC-3944](https://openedx.atlassian.net/browse/DOC-3944)

I added the password complexity requirements to the edX Learner's Guide. This is also in the learner help center at https://support.edx.org/hc/en-us/articles/360001393334-How-do-I-change-or-reset-my-password-

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

