### PR TITLE
Unenrollment and cohort in Enterprise API

### DIFF
--- a/en_us/enterprise_api/source/api_reference/reference.rst
+++ b/en_us/enterprise_api/source/api_reference/reference.rst
@@ -762,12 +762,22 @@ field and the ``course_mode``, as well as one or more of the ``user_email``,
      - boolean
      - Whether the learner has consented to be contacted by email. Default is
        ``false``.
+   * - ``is_active``
+     - boolean
+     - Whether the enrollment is active. Setting to ``false`` unenrolls the learner.
+       If set, the user must already exist. Default is ``true``
+       (Optional field)
+   * - ``cohort``
+     - string
+     - Assign the learner to this cohort name. Cohort must already be created.
+       (Optional field)
 
 POST Payload Example
 *********************
 
 Here is an example of the payload of a ``course-enrollments`` call. In this
-example, we enroll two learners in two different course runs.
+example, we enroll two learners in two different course runs and unenroll one
+learner from a third course.
 
 ::
 
@@ -776,12 +786,19 @@ example, we enroll two learners in two different course runs.
       "course_run_id":"course-v1:edX+DemoX+Demo_Course",
       "course_mode":"verified",
       "user_email":"ephraim_symbolist@example.com",
-      "email_students": true
+      "email_students":true
     },
     {
       "course_run_id":"course-v1:UMy+Intro_to_Education`",
       "course_mode":"audit",
-      "tpa_user_id":"abcdefg"
+      "tpa_user_id":"abcdefg",
+      "cohort":"Department XYZ"
+    },
+    {
+      "course_run_id":"course-v1:UU+Advanced_Unenrollment",
+      "course_mode":"audit",
+      "tpa_user_id":"hijklmn",
+      "is_active":false
     }
   ]
 


### PR DESCRIPTION
Added documentation for cohort and unenrollment support in the Enterprise Enrollment API

Contingent upon [#365](https://github.com/edx/edx-enterprise/pull/365) and [#363](https://github.com/edx/edx-enterprise/pull/363)


## [DOC-3981](https://openedx.atlassian.net/browse/DOC-3981)

Add a description of your changes with links to any relevant material.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

