### PR TITLE
replace course_experience.gdpr with ENABLE_ACCOUNT_DELETION

### DIFF
--- a/en_us/install_operations/source/configuration/user_retire/implementation_overview.rst
+++ b/en_us/install_operations/source/configuration/user_retire/implementation_overview.rst
@@ -98,9 +98,10 @@ At this point, the learner's account has been deactivated, but *not* retired.
 An entry in the ``UserRetirementStatus`` table is added, and their state set to
 ``PENDING``.
 
-By default, the **Delete My Account** button is disabled, preventing account
-deletions.  For information about how to enable account deletion, see
-:ref:`waffle-switch-for-ux`.
+By default, the **Delete My Account** section is visible and the button is
+enabled, allowing account deletions to queue up.  The
+``ENABLE_ACCOUNT_DELETION`` feature in django settings toggles the visibility
+of this section.  See :ref:`django-settings`.
 
 ================
 Third Party Auth

--- a/en_us/install_operations/source/configuration/user_retire/service_setup.rst
+++ b/en_us/install_operations/source/configuration/user_retire/service_setup.rst
@@ -7,6 +7,8 @@ Setting Up User Retirement in the LMS
 This section describes how to set up and configure the user retirement feature
 in the Open edX LMS.
 
+.. _django-settings:
+
 ***************
 Django Settings
 ***************
@@ -55,6 +57,9 @@ defining *derived* settings specific to Open edX. Read more about it in
        in the ``RETIREMENT_STATES`` setting
      - A list that defines the name and order of states for the retirement
        workflow.  See `Retirement States`_ for details.
+   * - FEATURES['ENABLE_ACCOUNT_DELETION']
+     - True
+     - Whether to display the "Delete My Account" section the account settings page.
 
 
 =================
@@ -137,20 +142,6 @@ in Django settings:
 .. code-block:: python
 
    RETIREMENT_SERVICE_WORKER_USERNAME = 'retirement_service_worker'
-
-.. _waffle-switch-for-ux:
-
-******************************************************
-Waffle Switch to Display the Delete My Account Feature
-******************************************************
-
-A waffle switch named ``course_experience.gdpr`` controls whether the Account
-page displays the section named **Delete My Account**. If you do not
-activate this switch, learners will have no available mechanism to request
-account deletion.
-
-You can manage waffle switches from the Django Admin section **Waffle ->
-Switches**.
 
 ************
 Django Admin


### PR DESCRIPTION
LEARNER-4422 removed the course_experience waffle flag many months ago.
Our docs should never have wrote about it because we treat waffle flags
as temporary aides during feature rollout rather than permanent toggles.
As such, this commit deletes anything in docs which suggest that the
course_experience.gdpr exists.

Coincidentally, there happens to be a
FEATURES['ENABLE_ACCOUNT_DELETION'] django setting which is essentially
the same thing, so I added some explanation around that.

## [PLAT-2313](https://openedx.atlassian.net/browse/PLAT-2313)

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @doctoryes 
- [x] Subject matter expert: @bmedx 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review: 
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [x] Build an RTD draft for your branch and add a link here
  - https://draft-edx-installing-configuring-and-running.readthedocs.io/en/pwnage101-no-more-course_experience.gdpr-waffle-flag-plat-2313/configuration/user_retire/implementation_overview.html#the-user-experience
  - https://draft-edx-installing-configuring-and-running.readthedocs.io/en/pwnage101-no-more-course_experience.gdpr-waffle-flag-plat-2313/configuration/user_retire/service_setup.html#django-settings

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

