### PR TITLE
Replace DATE placeholder in Research Guide with more specific information

### DIFF
--- a/en_us/data/source/internal_data_formats/sql_schema.rst
+++ b/en_us/data/source/internal_data_formats/sql_schema.rst
@@ -2051,8 +2051,8 @@ learners' course grades.
 course_id
 ------------
   Course key of the containing course. In the format
-  ``course-v1:org+course+run`` for courses created after DATE and in the format
-  ``org/course/run`` for older courses.
+  ``course-v1:org+course+run`` for most courses created in or after Oct 2014 
+  and in the format ``org/course/run`` for older courses.
 
 ------------
 user_id


### PR DESCRIPTION
## [DOC-3979](https://openedx.atlassian.net/browse/DOC-3979)

The Research Guide had a placeholder, DATE, representing the date we switched the format for course IDs. This corrects that.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

