### PR TITLE
Modify caveat about teams and discussions

### DIFF
--- a/en_us/developers/source/style_guides/sass-guidelines.rst
+++ b/en_us/developers/source/style_guides/sass-guidelines.rst
@@ -57,9 +57,6 @@ This should instead be written as::
       color: $my-custom-color;
     }
 
-See :ref:`ui_bootstrap_custom_designs` for more details about writing custom
-Sass for Bootstrap.
-
 .. _CSS Rules: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md#possible-errors
 .. _default flag: http://sass-lang.com/documentation/file.SASS_REFERENCE.html#Variable_Defaults___default
 .. _edX Stylelint Config: https://github.com/edx/stylelint-config-edx

--- a/en_us/shared/course_features/teams/teams_setup.rst
+++ b/en_us/shared/course_features/teams/teams_setup.rst
@@ -40,12 +40,9 @@ and a clear outcome to achieve with fellow team members. For example, you
 might create an assignment that consists of a group project or activity, with
 a choice of topics, and ask learners to join teams within the topic of their
 choice to complete the assignment. Team members can use discussions within the
-team to communicate and collaborate on the assignment.
-
-Teams are not as effective when members have no specific team tasks or goals.
-EdX does not recommend using teams in your course if you want only to provide
-a way for learners to connect socially. You can encourage learners to connect
-socially by using discussions within the course. For more information about
+team to communicate and collaborate on the assignment. If you want only to 
+provide a way for learners to connect socially, consider using discussions 
+within the course rather than teams. For more information about
 using discussions, see :ref:`Running_discussions`.
 
 


### PR DESCRIPTION
## [DOC-4000](https://openedx.atlassian.net/browse/DOC-4000)

Ben Piscopo reports that the Teams documentation dissuaded a partner from trying to use teams, so we softened the language that contrasted Teams and Discussions.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

