### PR TITLE
Change note about ORAs as prerequisites

### DIFF
--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -205,13 +205,7 @@ content until they have earned a minimum score in the prerequisite subsection.
 
 .. note::
    You must first :ref:`Enable Course Prerequisites` before 
-   prerequisite course subsections can be used.
-
-.. note::
-
-   You cannot use :ref:`open response assessments<Open Response Assessments 2>`
-   as the prerequisite for other course subsections.   
-
+   prerequisite course subsections can be used. 
 
 .. _enabling_subsection_gating:
 
@@ -243,6 +237,10 @@ subsection, follow these steps.
     prerequisite configuration controls do not prevent you from creating a
     circular chain of prerequisites that will permanently hide them from
     learners.
+
+.. note::
+    You cannot use :ref:`open response assessments<Open Response Assessments 2>`
+    that have a point value of 0 as the prerequisite for other course subsections. 
 
 #. Enable subsection prerequisites for your course. For more information, see
    :ref:`enabling_subsection_gating`.


### PR DESCRIPTION
## [DOC-3996](https://openedx.atlassian.net/browse/DOC-3996)

I removed the note about ORAs not being allowed as prerequisite sections and put a modified version in the Create a Prerequisite Subsection section.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert:
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [x] Build an RTD draft for your branch and add a link here

### Post-review

- [ ] Squash commits

