### PR TITLE
LTI Tool Provider feature is not supported

### DIFF
--- a/en_us/course_authors/source/course_features/lti/index.rst
+++ b/en_us/course_authors/source/course_features/lti/index.rst
@@ -1,22 +1,19 @@
 .. _Using edX as an LTI Tool Provider:
 
-######################################
+#####################################
 Using edX as an LTI Tool Provider
-######################################
+#####################################
 
-The edX Edge site can be configured to be a learning tool interoperability
-(LTI) provider to other systems and applications that partner institutions use.
-After initial configuration and testing between Edge and your system or
-application is complete, course teams can use this feature to reuse Edge course
-content, including advanced problem types and videos, in an on campus or in
-house learning management system. Examples currently include courses running on
-Canvas and Blackboard.
+.. note:: This feature was a closed pilot experiment. This feature is not
+ supported for new users.
 
-.. note:: Support for this feature is provisional. EdX is currently working
- with a set of early adopter partners in a closed pilot to test this
- feature.
-
-.. This note ^ can be removed after we get a better sense of how we'll do testing with new consumers, and regression testing for code changes. We'll also need to provide some direction on how they would line up this work (probably though partner manager) - Alison 16 Sept 15
+An experimental feature enabled the edX Edge site to be configured  to be a
+learning tool interoperability (LTI) provider to other systems and  applications
+that partner institutions use. After initial configuration and testing between
+Edge and your system or application is complete, course teams could use this
+feature to reuse Edge course content, including advanced problem types and
+videos, in an on campus or in house learning management system. Examples
+currently include courses running on Canvas and Blackboard.
 
 You use the topics in this section to prepare a course for reuse in another
 context.

--- a/en_us/shared/course_features/lti/lti_address_content.rst
+++ b/en_us/shared/course_features/lti/lti_address_content.rst
@@ -6,8 +6,8 @@ Determining Content Addresses
 
 .. only:: Partners
 
-  .. note:: Support for this feature is provisional. EdX is currently working
-   with a limited number of partners to test this feature on edX Edge.
+.. note:: This feature was a closed pilot experiment. This feature is not
+ supported for new users.
 
 To include the content of an existing course in another system, you use the edX
 LMS to find the location identifiers for the content you want to include. You

--- a/en_us/shared/course_features/lti/lti_blackboard_example.rst
+++ b/en_us/shared/course_features/lti/lti_blackboard_example.rst
@@ -6,8 +6,8 @@ Example: edX as an LTI Provider to Blackboard
 
 .. only:: Partners
 
-  .. note:: Support for this feature is provisional. EdX is currently working
-   with a limited number of partners to test this feature on edX Edge.
+.. note:: This feature was a closed pilot experiment. This feature is not
+ supported for new users.
 
 To use edX course content in the Blackboard LMS, you add a new app to the course and then add external tool module items.
 

--- a/en_us/shared/course_features/lti/lti_canvas_example.rst
+++ b/en_us/shared/course_features/lti/lti_canvas_example.rst
@@ -6,8 +6,8 @@ Example: edX as an LTI Provider to Canvas
 
 .. only:: Partners
 
-  .. note:: Support for this feature is provisional. EdX is currently working
-   with a limited number of partners to test this feature on edX Edge.
+.. note:: This feature was a closed pilot experiment. This feature is not
+ supported for new users.
 
 To use edX course content in the Canvas LMS, you add a new app to the course and then add external tool module items.
 

--- a/en_us/shared/course_features/lti/lti_grade_content.rst
+++ b/en_us/shared/course_features/lti/lti_grade_content.rst
@@ -6,8 +6,8 @@ Grading Remote Content
 
 .. only:: Partners
 
-  .. note:: Support for this feature is provisional. EdX is currently working
-   with a limited number of partners to test this feature on edX Edge.
+.. note:: This feature was a closed pilot experiment. This feature is not
+ supported for new users.
 
 When you include the problem components in a graded edX subsection in an
 external LMS, the edX system grades the learner responses to those problems.

--- a/en_us/shared/course_features/lti/lti_prepare_content.rst
+++ b/en_us/shared/course_features/lti/lti_prepare_content.rst
@@ -6,8 +6,8 @@ Preparing to Reuse Course Content
 
 .. only:: Partners
 
-  .. note:: Support for this feature is provisional. EdX is currently working
-   with a limited number of partners to test this feature on edX Edge.
+.. note:: This feature was a closed pilot experiment. This feature is not
+ supported for new users.
 
   To make the content of an existing edX course reusable in an external LMS,
   you create a duplicate version of the course. You use the duplicate course

--- a/en_us/shared/course_features/lti/lti_reuse_content.rst
+++ b/en_us/shared/course_features/lti/lti_reuse_content.rst
@@ -6,8 +6,8 @@ Reusing Course Content with LTI
 
 .. only:: Partners
 
-  .. note:: Support for this feature is provisional. EdX is currently working
-   with a limited number of partners to test this feature on edX Edge.
+.. note:: This feature was a closed pilot experiment. This feature is not
+ supported for new users.
 
 When you use LTI to reuse edX course content, learners who are already familiar
 with an external learning management system or other consumer application


### PR DESCRIPTION
## [DOC-4006](https://openedx.atlassian.net/browse/DOC-4006)

Using edX Edge as an LTI Tool Provider was a closed pilot feature. We don't plan to allow anyone else to use it. Therefore, I've modified the course author doc to label the feature as unsupported.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @scottrish 
- [ ] Subject matter expert: @jaakana
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] PM review: @marcotuts 
### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

