### PR TITLE
Remove references to datadog.

### DIFF
--- a/en_us/developers/source/analytics.rst
+++ b/en_us/developers/source/analytics.rst
@@ -357,21 +357,6 @@ for a single API to be used while still transmitting data to each of these
 service providers. This would reduce discrepancies between the measurements
 made by the various systems and significantly clarify the instrumentation.
 
-Data Dog
-*****************
-
-Data dog is used primarily for real-time operational monitoring of a running
-edX platform server. It supports rapid display and monitoring of various
-metrics within the platform such as enrollments, user creation and answers to
-problems.
-
-The edX platform is instrumented to send data to `data dog`_ using the
-standard `dogapi`_ python package. If ``lms.auth.json`` contains a
-``DATADOG_API`` key whose value is a valid data dog API key, then the edX
-platform will transmit a variety of metrics to data dog. Running ``git grep
-dog_stats_api`` will give a pretty good overview of the usage of data dog to
-track operational metrics.
-
 Segment
 *****************
 
@@ -385,6 +370,7 @@ from normal ``tracker.emit()`` calls. Events specified in this whitelist will be
 sent to both the tracking logs and Segment.  Similarly, it is enabled in Studio
 if the ``SEGMENT_KEY`` key is set to a valid Segment API key in the
 ``cms.auth.json`` file.
+
 
 Google Analytics
 *****************
@@ -407,6 +393,4 @@ continue to be supported.
 
 .. _event-tracking: https://github.com/edx/event-tracking
 .. _event-tracking documentation: http://event-tracking.readthedocs.io/en/latest/overview.html#event-tracking
-.. _data dog: http://www.datadoghq.com/
-.. _dogapi: http://pydoc.datadoghq.com/en/latest/
 .. _Segment: https://segment.com/

--- a/en_us/developers/source/deploy-new-service.rst
+++ b/en_us/developers/source/deploy-new-service.rst
@@ -79,9 +79,7 @@ below.
 Metrics
 -------
 What are the key metrics for your application? Concurrent users? Transactions
-per second? Ideally you should create a DataDog view that captures the key
-metrics for your service and provided an instant gauge of overall service
-health.
+per second?
 
 Messaging
 ---------

--- a/en_us/developers/source/process/code-considerations.rst
+++ b/en_us/developers/source/process/code-considerations.rst
@@ -21,8 +21,6 @@ Operational Impact
       available?
     * A new queue that needs to be monitored for dequeueing
     * Bulk Email --> Amazon SES, Inbound queues, etc...
-    * Are important feature metrics sent to datadog and is there a
-      dashboard to monitor them?
 
 * Am I building a feature that will have impact on the performance of the
   system? Keep in mind that Open edX needs to support hundreds of thousands if


### PR DESCRIPTION
## [DEPR-9](https://openedx.atlassian.net/browse/DEPR-9)

Remove references to DataDog in developer documentation because it's a service that is not use and not supported any longer.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @nasthagiri  
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

