### PR TITLE
Show Answer: Number of Attempts configuration and learner's view

### DIFF
--- a/en_us/shared/course_components/Section_learner_problem_view.rst
+++ b/en_us/shared/course_components/Section_learner_problem_view.rst
@@ -77,7 +77,11 @@ an option is available in problems.
    problem. If a learner selects **Show Answer**, the learner sees both the
    correct answer and the explanation, if any.
 
-9. **Feedback.** After a learner selects **Submit**, an icon appears beside
+   If you specify a number in **Show Answer: Number of Attempts**, the learner
+   must submit at least that number of attempted answers before the **Show 
+   Answer** option is available for the problem.
+
+#. **Feedback.** After a learner selects **Submit**, an icon appears beside
    each response field or selection within a problem. A green check mark
    indicates that the response was correct, a green asterisk (*) indicates that
    the response was partially correct, and a red X indicates that the response

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -553,6 +553,16 @@ options define when the answer is shown to learners.
        does not include a correct answer to show to learners, make sure you
        select **Never**.
 
+.. _Show Answer Number of Attempts:
+
+===============================
+Show Answer: Number of Attempts
+===============================
+
+This setting limits when learners can select the **Show Answer** option for a 
+problem. Learners must submit at least the specified number of attempted
+answers for the problem before the **Show Answer** option is available to them.
+
 .. _Show Reset Button:
 
 =================


### PR DESCRIPTION
## [DOC-4009](https://openedx.atlassian.net/browse/DOC-4009)

This is documentation to go along with https://github.com/edx/edx-platform/pull/19380 / OSPR-2884

### Date Needed (optional)

This feature is likely to be released Feb 6 - 8.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @stvstnfrd
- [x] Subject matter expert: @ormsbee 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

