### PR TITLE
[DOC-4013] suggest to keep logical commits in PRs instead of squashing them

### DIFF
--- a/en_us/developers/source/process/contributor.rst
+++ b/en_us/developers/source/process/contributor.rst
@@ -51,9 +51,15 @@ list of requirements to be sure that your pull request is ready to be reviewed:
    multiple bugfixes) should not be bundled into one pull request. A handful of
    small pull requests is much better than one large pull request.
 
-#. Structure your pull request into logical commits. "Fixup" commits should be
-   squashed together. The best pull requests contain only a single, logical
-   change -- which means only a single, logical commit.
+#. Structure your pull request into logical commits. "Fixup" commits
+   should be squashed together. The best pull requests contain only a
+   single, logical change -- which means only a single, logical
+   commit. The person merging the pull request may choose to squash
+   all commits to reduce the number of commits in the master
+   branch. They will do so by using the `Squash and merge` button of
+   the GitHub interface to preserve the logical commits in the pull
+   request, for forensic purposes when trying to diagnose a regression
+   or understand a bug.
 
 #. All code in the pull request must be compatible with edX's AGPL license.
    This means that the author of the pull request must sign a `contributor's


### PR DESCRIPTION
## [DOC-4013](https://openedx.atlassian.net/browse/DOC-4013)

For non-trivial pull requests a single commit may be very difficult to
read. It can even be more difficult when coming back months later and
trying to understand how the pull request introduced a bug or a
regression.

The developer guide already suggests a pull request should be nicely
organized in logical commits. But it is not clear about squashing them
together, only suggesting it is a good practice but not explaining
why.

Clarify the benefits of keeping a well organized commit series in the
pull request. Add a hint for the person in charge of merging about how
to squash when merging without discarding the commit series.

Add a description of your changes with links to any relevant material.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [x] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

