### PR TITLE
Fixing broken links in course authors guide

### DIFF
--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -389,7 +389,7 @@
 
 .. _How to add Closed Captions to an Office Mix: https://officemix.uservoice.com/knowledgebase/articles/505262-how-to-add-closed-captions-to-an-office-mix
 
-.. _W3C CSS color specification: https://www.w3.org/TR/css3-color/
+.. _W3C CSS color specification: https://www.w3.org/TR/css-color-3/
 
 .. _ESLint: https://openedx.atlassian.net/wiki/display/FEDX/ESLint
 
@@ -500,9 +500,7 @@
 
 .. Peer Instruction
 
-.. _Mazur Group: http://mazur.harvard.edu/research/detailspage.php?ed=1&rowid=8
-
-.. _Turn to Your Neighbor: https://blog.peerinstruction.net/
+.. _Turn to Your Neighbor: https://peerinstruction.wordpress.com/
 
 .. _OAuth 2.0 Standard: https://tools.ietf.org/html/draft-ietf-oauth-v2-31
 

--- a/en_us/shared/accessibility/best_practices_course_content_dev.rst
+++ b/en_us/shared/accessibility/best_practices_course_content_dev.rst
@@ -103,7 +103,7 @@ color corrected as effectively as HTML text. Whenever possible, use the default
 font and color defined in the edX platform, which was designed to be easy to
 read. If you choose to override default font colors, make sure that the
 foreground and background colors have `sufficient contrast
-<https://leaverou.github.io/contrast-ratio/>`_.
+<https://contrast-ratio.com/>`_.
 
 For audio elements, make sure that foreground sounds are sufficiently louder
 than background sounds.
@@ -358,12 +358,12 @@ Accessible Images Resources
 * `W3C WAI Images Tutorial <http://www.w3.org/WAI/tutorials/images/>`_
 
 * `HTML5 - Requirements for providing text to act as an alternative for images
-  <http://www.w3.org/TR/html5/embedded-content-0.html#alt>`_
+  <https://www.w3.org/TR/html5/semantics-embedded-content.html#alt-text>`_
 
-* `WebAim <http://webaim.org/techniques/alttext/>`_ provides general guidance
+* `WebAim <https://webaim.org/techniques/alttext/>`_ provides general guidance
   on the appropriate use of alternative text for images.
 
-* `The DIAGRAM Center <http://www.diagramcenter.org/webinars.html>`_,
+* `The DIAGRAM Center <http://diagramcenter.org/diagramwebinars.html>`_,
   established by the US Department of Education (Office of Special Education
   Programs), provides guidance on ways to make it easier, faster, and more
   cost effective to create and use accessible images.
@@ -386,7 +386,7 @@ Whenever possible, create course materials in HTML format, using the tools
 available to you in edX Studio. When you make digital textbooks (ebooks)
 available within your course, ask digital book publishers for books in either
 `DAISY <https://en.wikipedia.org/wiki/DAISY_Digital_Talking_Book>`_ or `EPUB 3
-<https://en.wikipedia.org/wiki/EPUB#Version_3.0.1_.28current_version.29>`_
+<https://en.wikipedia.org/wiki/EPUB#Version_3.0.1>`_
 format, or both. Both of these digital book formats include unparalleled
 support for accessibility. However, simply supporting accessibility does not
 always mean a document will be accessible. When you source ebooks from third
@@ -513,18 +513,18 @@ Accessible PDF Resources
 * Adobe provides documentation on how to `create and verify PDF accessibility
   <https://helpx.adobe.com/acrobat/using/create-verify-pdf-accessibility.html>`_.
 
-* `Adobe Accessibility <http://www.adobe.com/accessibility.html>`_ (Adobe) is a
+* `Adobe Accessibility <https://www.adobe.com/accessibility.html>`_ (Adobe) is a
   comprehensive collection of resources on PDF authoring and repair, using
   Adobe's products.
 
-* `PDF Accessibility <http://webaim.org/techniques/acrobat/>`_ (WebAIM)
+* `PDF Accessibility <https://webaim.org/techniques/acrobat/>`_ (WebAIM)
   provides a detailed and illustrated guide on creating accessible PDFs .
 
 * The National Center of Disability and Access to Education has a collection
   of one-page `"cheat sheets" on accessible document authoring <http://ncdae.org/resources/cheatsheets/>`_.
 
 * The Accessible Digital Office Document (ADOD) Project provides guidance on
-  `creating accessible Office documents <http://adod.idrc.ocad.ca/>`_.
+  `creating accessible Office documents <https://adod.idrc.ocad.ca/>`_.
 
 =====================================================
 Creating Accessible Word Documents
@@ -654,7 +654,7 @@ Accessible PowerPoint Resources
   presentations-6F7772B2-2F33-4BD2-8CA7-DAE3B2B3EF25>`_.
 
 * WebAIM's `PowerPoint Accessibility
-  <http://webaim.org/techniques/powerpoint/>`_.
+  <https://webaim.org/techniques/powerpoint/>`_.
 
 * Microsoft tool that allows you to `check Powerpoint documents for
   accessibility issues <https://support.office.com/en-us/article/Check-for-
@@ -703,16 +703,16 @@ directly in LaTeX using the `LaTeX Source Compiler
 Accessible Mathematical Content Resources
 ======================================================
 
-* `The MathJax website <http://www.mathjax.org>`_ provides guidance on creating
+* `The MathJax website <https://www.mathjax.org>`_ provides guidance on creating
   accessible pages using their display engine.
 
-* The `DO-IT project <http://www.washington.edu/doit/are-there-guidelines-creating-accessible-math?465=>`_ from the University of Washington provides guidance on creating accessible math content.
+* The `DO-IT project <https://www.washington.edu/doit/are-there-guidelines-creating-accessible-math?465=>`_ from the University of Washington provides guidance on creating accessible math content.
 
-* `The AccessSTEM website <http://www.washington.edu/doit/programs/accessstem/overview>`_
+* `The AccessSTEM website <https://www.washington.edu/doit/programs/accessstem/overview>`_
   provides guidance on creating accessible science, technology, engineering
   and math educational content.
 
-* The `Design Science News blog <http://news.dessci.com/accessible-math>`_
+* `Design Science <https://www.dessci.com/en/solutions/access/>`_
   shares information about making math accessible.
 
 .. _Best Practices for Custom Content Types:
@@ -835,13 +835,13 @@ creating accessible HTML.
 Accessible Custom Content Resources
 ======================================================
 
-* `Effective Practices for Description of Science Content within Digital Talking Books <http://ncam.wgbh.org/experience_learn/educational_media/stemdx>`_, from the National Center for Accessible Media, provides best practices for describing graphs, charts, diagrams, and illustrations.
+* `Provide access to digital publications <http://ncamftp.wgbh.org/ncam-old-site/invent_build/web_multimedia/accessible-digital-media-guide/guideline-d-digital-publicatio.html>`_, from the National Center for Accessible Media, provides best practices for describing graphs, charts, diagrams, and illustrations.
 
-* `AccessSTEM <http://www.washington.edu/doit/programs/accessstem/overview>`_
+* `AccessSTEM <https://www.washington.edu/doit/programs/accessstem/overview>`_
   provides guidance on creating accessible science, technology, engineering
   and math educational content.
 
-* The National Center on Educational Outcomes (NCEO) provides `Principles and Characteristics of Inclusive Assessment and Accountability Systems <http://www.cehd.umn.edu/nceo/onlinepubs/Synthesis40.html>`_.
+* The National Center on Educational Outcomes (NCEO) provides `Principles and Characteristics of Inclusive Assessment and Accountability Systems <https://www.cehd.umn.edu/nceo/onlinepubs/Synthesis40.html>`_.
 
 .. _Creating Accessible Media:
 
@@ -852,7 +852,7 @@ Create Accessible Media
 Media-based course materials help to convey concepts and can bring course
 information to life. We require all videos in edX courses to include timed text
 captions in `SubRip (SRT) format
-<https://en.wikipedia.org/wiki/SubRip#SubRip_text_file_format>`_. The edX media
+<https://en.wikipedia.org/wiki/SubRip>`_. The edX media
 player displays caption files in an interactive sidebar that benefits a variety
 of learners, including learners who are hard of hearing or whose native
 language differs from the primary language of the media. This built-in
@@ -884,7 +884,7 @@ Simply review the recorded video and update the script as needed. Proper
 editing should maintain both the original meaning, content, and essential
 vocabulary. Text captions can be uploaded to YouTube along with the video to
 create a timed text file in `SubRip (SRT) format
-<https://en.wikipedia.org/wiki/SubRip#SubRip_text_file_format>`_. Otherwise,
+<https://en.wikipedia.org/wiki/SubRip>`_. Otherwise,
 you will need to create the timed text caption file yourself or engage someone
 to do it. There are many companies that will create timed text captions
 (captions that synchronize the text with the video using time codes) for a fee.
@@ -937,8 +937,8 @@ Accessible Media Resources
 =====================================================
 
 * `Accessible Digital Media Guidelines <http://ncam.wgbh.org/invent_build/web_multimedia/accessible-digital-media-guide>`_ provides detailed advice on creating online video and audio with accessibility in mind.
-* `Captioning Key <https://dcmp.org/public_content/ai/captioningkey/index.html>`_ by the National Association for the Deaf provides excellent guidance on creating described and captioned media.
-* `Transcription, Captioning and Subtitling Standards <http://www.3playmedia.com/2014/05/06/transcription-captioning-subtitling-standards/>`_ by 3PlayMedia discusses best practices in this recorded webinar and white paper.
+* `Captioning Key <http://captioningkey.org/quality_captioning.html>`_ by the National Association for the Deaf provides excellent guidance on creating described and captioned media.
+* `Closed Captioning & Subtitling Standards in IP Video Programming <https://www.3playmedia.com/2016/06/16/closed-captioning-subtitling-standards-in-ip-video-programming/>`_ by 3PlayMedia discusses best practices in this recorded webinar and white paper.
 
 .. _Best Practices for HTML Markup:
 
@@ -1004,11 +1004,11 @@ Keep the following guidelines in mind when you create HTML content.
 HTML Markup Resources
 ====================================================
 
-* `Creating Semantic Structure <http://webaim.org/techniques/semanticstructure/>`_
+* `Creating Semantic Structure <https://webaim.org/techniques/semanticstructure/>`_
   provides guidance on reflecting the semantic structure of a web page in
   the underlying markup (WebAIM).
 
-* `Creating Accessible Tables <http://webaim.org/techniques/tables/data>`_
+* `Creating Accessible Tables <https://webaim.org/techniques/tables/data>`_
   provides specific guidance on creating data tables with the appropriate
   semantic structure so that screen readers can correctly present the
   information (WebAIM).
@@ -1059,8 +1059,6 @@ guidelines.
 =======================================
 Universal Design for Learning Resources
 =======================================
-
-* `Delivering Accessible Digital Learning (JISC Techdis) <http://www.jisctechdis.ac.uk/techdis/resources/accessiblecontent>`_ provides a useful overview of an inclusive approach to course design.
 
 * `The National Center on Universal Design for Learning <http://www.udlcenter.org/implementation/postsecondary>`_ provides a helpful overview on Universal Design for Learning.
 

--- a/en_us/shared/accessibility/supporting_learners_diverse_needs.rst
+++ b/en_us/shared/accessibility/supporting_learners_diverse_needs.rst
@@ -69,13 +69,13 @@ technology and accessibility specialists.
 The following resources might also assist you in producing accessible course
 content.
 
-* `User Agent Accessibility Guidelines (UAAG) 1.0 <http://www.w3.org/WAI/intro/uaag.php#whatis>`_
-* `Authoring Tool Accessibility Guidelines (ATAG) 2.0 <http://www.w3.org/WAI/intro/atag.php>`_
-* `WAI-ARIA (Accessible Rich Internet Applications) <http://www.w3.org/WAI/intro/aria.php>`_
-* `WCAT2ICT <http://www.w3.org/WAI/intro/wcag2ict>`_
+* `User Agent Accessibility Guidelines (UAAG) <https://www.w3.org/WAI/standards-guidelines/uaag/#user-agent-accessibility-guidelines-uaag>`_
+* `Authoring Tool Accessibility Guidelines (ATAG) <https://www.w3.org/WAI/standards-guidelines/atag/#atag>`_
+* `WAI-ARIA (Accessible Rich Internet Applications) <https://www.w3.org/WAI/standards-guidelines/aria/#introduction>`_
+* `WCAT2ICT <http://www.w3.org/WAI/standards-guidelines/wcag/non-web-ict/>`_
 * `EPUB 3.0 <http://idpf.org/epub/30>`_
 * `DAISY Consortium <http://www.daisy.org/>`_
-* `MathJax <http://www.mathjax.org>`_
+* `MathJax <https://www.mathjax.org>`_
 * `MathML <http://www.w3.org/Math/>`_
 
 While your ability to support students in the MOOC context might be different

--- a/en_us/shared/course_components/create_html_component.rst
+++ b/en_us/shared/course_components/create_html_component.rst
@@ -19,7 +19,7 @@ create web pages. Web browsers present HTML code in a more readable format.
 
 When students see text and images in your course, they are seeing HTML code
 that is formatted and presented by their browsers. For more information about
-HTML, see `Wikipedia <http://en.wikipedia.org/wiki/HTML>`_.
+HTML, see `Wikipedia <https://en.wikipedia.org/wiki/HTML>`_.
 
 ===================
 HTML Components

--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -53,7 +53,7 @@ Course team members can access content that has not been released by
    When you set release times in Studio, times are in Coordinated Universal
    Time (UTC). You might want to verify that you have specified the times that
    you intend by using a time zone converter such as `Time and Date Time Zone
-   Converter <http://www.timeanddate.com/worldclock/converter.html>`_.
+   Converter <https://www.timeanddate.com/worldclock/converter.html>`_.
 
    Learners who have specified a time zone in their account settings see course
    dates and times converted to their specified time zone. Learners who have

--- a/en_us/shared/developing_course/course_sections.rst
+++ b/en_us/shared/developing_course/course_sections.rst
@@ -175,7 +175,7 @@ To set the section release date, follow these steps.
    The time that you set is in Coordinated Universal Time (UTC). You might want
    to verify that you have specified the time that you intend by using a time
    zone converter such as `Time and Date Time Zone Converter
-   <http://www.timeanddate.com/worldclock/converter.html>`_.
+   <https://www.timeanddate.com/worldclock/converter.html>`_.
 
 #. Select **Save**.
 

--- a/en_us/shared/developing_course/course_subsections.rst
+++ b/en_us/shared/developing_course/course_subsections.rst
@@ -57,7 +57,7 @@ Subsection from Students`.
    Release dates and times that you set are in Coordinated Universal Time
    (UTC). You might want to verify that you have specified the time that you
    intend by using a time zone converter such as `Time and Date Time Zone
-   Converter <http://www.timeanddate.com/worldclock/converter.html>`_.
+   Converter <https://www.timeanddate.com/worldclock/converter.html>`_.
 
    Learners who have specified a time zone in their account settings see course
    dates and times converted to their specified time zone. Learners who have
@@ -230,7 +230,7 @@ To set the subsection release date, follow these steps.
    .. note:: The time that you set is in Coordinated Universal Time (UTC). You
       might want to verify that you have specified the time that you intend by
       using a time zone converter such as `Time and Date Time Zone Converter
-      <http://www.timeanddate.com/worldclock/converter.html>`_.
+      <https://www.timeanddate.com/worldclock/converter.html>`_.
 
       Learners who have specified a time zone in their account settings see
       course dates and times converted to their specified time zone. Learners
@@ -276,7 +276,7 @@ To set the assignment type and due date for a subsection, follow these steps.
    .. note:: The time that you set is in Coordinated Universal Time (UTC). You
       might want to verify that you have specified the time that you intend by
       using a time zone converter such as `Time and Date Time Zone Converter
-      <http://www.timeanddate.com/worldclock/converter.html>`_.
+      <https://www.timeanddate.com/worldclock/converter.html>`_.
 
       Learners who have specified a time zone in their account settings see
       course dates and times converted to their specified time zone. Learners

--- a/en_us/shared/developing_course/licensing_course.rst
+++ b/en_us/shared/developing_course/licensing_course.rst
@@ -78,7 +78,7 @@ Studio.
 
 For more information, see the `Creative Commons website`_.
 
-.. _Creative Commons website: http://creativecommons.org/licenses
+.. _Creative Commons website: https://creativecommons.org/licenses
 
 .. _Set Course Content Licensing:
 

--- a/en_us/shared/exercises_tools/custom_javascript.rst
+++ b/en_us/shared/exercises_tools/custom_javascript.rst
@@ -77,9 +77,8 @@ Create a Custom JavaScript Display and Grading Problem
    The example problem uses the file ``jschannel.js`` to bypass the SOP.
 
    For more information, see the same-origin policy page on the `Mozilla
-   Developer Network site <https://developer.mozilla.org/en-
-   US/docs/Web/JavaScript/Same_origin_policy_for_JavaScript>`_ or on
-   `Wikipedia <http://en.wikipedia.org/wiki/Same_origin_policy>`_.
+   Developer Network site <https://developer.mozilla.org/en-US/docs/Web/Security/>`_ 
+   or on `Wikipedia <https://en.wikipedia.org/wiki/Same_origin_policy>`_.
 
 
 ========================================

--- a/en_us/shared/exercises_tools/gene_explorer.rst
+++ b/en_us/shared/exercises_tools/gene_explorer.rst
@@ -7,7 +7,7 @@ Gene Explorer Tool
 .. note:: EdX does not support this tool.
 
 The gene explorer (GeneX), from the biology department at `UMB
-<http://www.umb.edu/>`_, simulates the transcription, splicing, processing, and
+<https://www.umb.edu/>`_, simulates the transcription, splicing, processing, and
 translation of a small hypothetical eukaryotic gene. GeneX allows learners to
 make specific mutations in a gene sequence, and it then calculates and displays
 the effects of the mutations on the mRNA and protein.

--- a/en_us/shared/exercises_tools/iframe.rst
+++ b/en_us/shared/exercises_tools/iframe.rst
@@ -28,8 +28,8 @@ graded or used to store student data. If you want to add a graded tool or
 exercise, add the tool as a :ref:`custom JavaScript problem<Custom JavaScript>`
 or an :ref:`LTI component<LTI Component>`.
 
-For more information about iframes, see the `HTML/Elements/iframe specification
-<http://www.w3.org/wiki/HTML/Elements/iframe>`_.
+For more information about iframes, see the `iframe: The Inline Frame element
+<https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe>`_.
 
 ****************************
 Create an IFrame Tool
@@ -146,5 +146,5 @@ elements below affect the iframe.
    :alt: Iframe with only the top half showing but no scroll bar available.
    :width: 500
 
-For more information about iframe attributes, see the `HTML/Elements/iframe
-specification <http://www.w3.org/wiki/HTML/Elements/iframe>`_.
+For more information about iframe attributes, see 
+`iframe: The Inline Frame element <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe>`_.

--- a/en_us/shared/exercises_tools/peer_instruction_tool.rst
+++ b/en_us/shared/exercises_tools/peer_instruction_tool.rst
@@ -18,7 +18,7 @@ learners in an online course.
   :depth: 2
 
 For more information about the Peer Instruction learning system, consult the
-resources of the `Mazur Group`_ or the `Turn to Your Neighbor`_ blog.
+`Turn to Your Neighbor`_ blog.
 
 *********************
 Assignment Overview

--- a/en_us/shared/exercises_tools/poll.rst
+++ b/en_us/shared/exercises_tools/poll.rst
@@ -68,8 +68,8 @@ Create a Poll
 
    - To do this on a Windows computer, you need to download a third-party
      program. For more information, see `How to Unpack a tar File in Windows
-     <http://www.haskell.org/haskellwiki/How_to_unpack_a_tar_file_in_Windows>`_,
-     `How to Extract a Gz File <http://www.wikihow.com/Extract-a-Gz-File>`_,
+     <https://www.haskell.org/haskellwiki/How_to_unpack_a_tar_file_in_Windows>`_,
+     `How to Extract a Gz File <https://www.wikihow.com/Extract-a-Gz-File>`_,
      `The gzip Home Page <http://www.gzip.org/>`_, or the `Windows
      <http://www.ofzenandcomputing.com/how-to-open-tar-gz-files/#windows>`_
      section of the `How to Open .tar.gz Files
@@ -128,10 +128,6 @@ Create a Poll
 #. After you add the poll code, save and close the .xml file.
 
 #. Re-package your course as a .tar.gz file.
-
-   * For information about how to do this on a Mac, see `How to Create a Tar GZip File from the Command Line <http://osxdaily.com/2012/04/05/create-tar-gzip/>`_.
-
-   * For information about how to do this on a Windows computer, see `How to Make a .tar.gz on Windows <http://stackoverflow.com/questions/12774707/how-to-make-a-tar-gz-on-windows>`_.
 
 #. In Studio, re-import your course. You can now review the poll question and
    answers that you added in Studio.

--- a/en_us/shared/students/completing_assignments/Section_proctoring_rules.rst
+++ b/en_us/shared/students/completing_assignments/Section_proctoring_rules.rst
@@ -116,5 +116,5 @@ your request and make any adjustments before you start your exam.
   status, you automatically receive a score of 0 for the exam. For most
   courses, you are no longer eligible for academic credit.
 
-  If you have questions about your proctoring exam status, go to http://edx.org
+  If you have questions about your proctoring exam status, go to https://edx.org
   to contact edX Support, or consult your course team.

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -203,7 +203,7 @@ assessment feature. For more information, see
 * The times that you set are in Coordinated Universal Time (UTC). To verify
   that you have specified the times that you intend, use a time zone converter
   such as `Time and Date Time Zone Converter
-  <http://www.timeanddate.com/worldclock/converter.html>`_.
+  <https://www.timeanddate.com/worldclock/converter.html>`_.
 
 To specify a name for the assignment as well as start and due dates for all
 learner responses, follow these steps.
@@ -409,7 +409,7 @@ To specify peer assessment settings, follow these steps.
      The times that you set are in Coordinated Universal Time (UTC). To verify
      that you have specified the times that you intend, use a time zone
      converter such as `Time and Date Time Zone Converter
-     <http://www.timeanddate.com/worldclock/converter.html>`_.
+     <https://www.timeanddate.com/worldclock/converter.html>`_.
 
      Additionally, the course grace period setting does not apply to open
      response assessments. For more information about the grace period setting,
@@ -438,7 +438,7 @@ the step starts and ends.
      The times that you set are in Coordinated Universal Time (UTC). To verify
      that you have specified the times that you intend, use a time zone
      converter such as `Time and Date Time Zone Converter
-     <http://www.timeanddate.com/worldclock/converter.html>`_.
+     <https://www.timeanddate.com/worldclock/converter.html>`_.
 
      Additionally, the course grace period setting does not apply to open
      response assessments. For more information about the grace period setting,


### PR DESCRIPTION
## [DOC-3591](https://openedx.atlassian.net/browse/DOC-3591)

Fixing a bunch of broken and redirecting links in the course authors guide, based on what I found by running make linkcheck. I didn't do all the instances where it's just http: redirecting to https:

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

