### PR TITLE
Note about mobile bug for content experiments

### DIFF
--- a/en_us/shared/course_features/content_experiments/content_experiments_overview.rst
+++ b/en_us/shared/course_features/content_experiments/content_experiments_overview.rst
@@ -31,6 +31,12 @@ group that each learner has been assigned to. For more information, see
 For information about analyzing events from content experiments, see
 :ref:`data:AB_Event_Types` in the *EdX Research Guide*.
 
+.. important::
+
+  Due to an issue in the edX mobile apps, content experiments do not display 
+  correctly in the mobile apps. Blocks created with Content Experiment 
+  components display in the mobile app with a "Group ID" label. 
+
 
 .. _Courses with Multiple Content Experiments:
 


### PR DESCRIPTION
## [DOC-3993](https://openedx.atlassian.net/browse/DOC-3993)

I added a note to the start of the Content Experiments section, explaining the MA-2951 bug, with a workaround.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @staubina 
- [ ] Subject matter expert: @MirzaMubasharBaig 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [x] Partner support: 
- [ ] PM review: @marcotuts 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [x] Squash commits

