### PR TITLE
switch to native.sh instead of sandbox.sh

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Brandon DeRosier <x@bdero.me>
 Deb Chatigny <dchatigny@edx.org>
 Grant Goodman <ggoodman@edx.org>
 Mikkel Madsen <mikkel3@gmail.com>
+Mostafa Hussein <mostafa.hussein91@gmail.com>

--- a/en_us/install_operations/source/platform_releases/ginkgo.rst
+++ b/en_us/install_operations/source/platform_releases/ginkgo.rst
@@ -122,7 +122,7 @@ steps.
 
     .. code-block:: bash
 
-        $ /edx/app/edx_ansible/edx_ansible/util/install/sandbox.sh --tags migrate
+        $ /edx/app/edx_ansible/edx_ansible/util/install/native.sh --tags migrate
 
 #. Copy your configuration files from the Ficus machine to the Ginkgo machine.
 

--- a/en_us/install_operations/source/platform_releases/hawthorn.rst
+++ b/en_us/install_operations/source/platform_releases/hawthorn.rst
@@ -128,7 +128,7 @@ steps.
 
     .. code-block:: bash
 
-        $ /edx/app/edx_ansible/edx_ansible/util/install/sandbox.sh --tags migrate
+        $ /edx/app/edx_ansible/edx_ansible/util/install/native.sh --tags migrate
 
 #. Copy your configuration files from the Ginkgo machine to the Hawthorn
     machine.

--- a/en_us/install_operations/source/platform_releases/ironwood.rst
+++ b/en_us/install_operations/source/platform_releases/ironwood.rst
@@ -116,7 +116,7 @@ steps.
 
     .. code-block:: bash
 
-        $ /edx/app/edx_ansible/edx_ansible/util/install/sandbox.sh --tags migrate
+        $ /edx/app/edx_ansible/edx_ansible/util/install/native.sh --tags migrate
 
 #. Copy your configuration files from the Hawthorn machine to the Ironwood
     machine.


### PR DESCRIPTION
Starting from Ginkgo sandbox.sh was deprecated in favour of native.sh.

I was unable to scan and sign the license agreement at the moment, and if the next sentence helps then here you go:

I grant edX a non-exclusive, worldwide, royalty-free patent license to any patents in which I hold the rights which cover my contributions or portions of my contributions to the edX codebase, to make, use, sell, offer for sale, import and otherwise run, modify, and propagate the contents of my contribution.