### PR TITLE
changes Hawthorn to Ironwood in upgrade section

### DIFF
--- a/en_us/install_operations/source/platform_releases/ironwood.rst
+++ b/en_us/install_operations/source/platform_releases/ironwood.rst
@@ -47,7 +47,7 @@ Upgrading from the Hawthorn Release
 
 The recommended approach to upgrading an existing installation of the Open edX
 Hawthorn release to the Ironwood release is to make a fresh installation of the
-Hawthorn release on a new machine, and move your data and settings to it.
+Ironwood release on a new machine, and move your data and settings to it.
 
 To move and upgrade your Hawthorn data onto an Ironwood installation, follow these
 steps.


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

In Upgrade section docs said to make a fresh installation of Hawthorn release instead of Ironwood.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

