### PR TITLE
Add note about bandwidth requirement for RP Now v4

### DIFF
--- a/en_us/shared/course_features/proctored_exams/proctored_learners.rst
+++ b/en_us/shared/course_features/proctored_exams/proctored_learners.rst
@@ -9,7 +9,9 @@ To prepare learners for a proctored exam, follow these guidelines.
 .. only:: Partners
 
   * Emphasize that learners must be aware of the requirements before taking the
-    exam, and that some of the requirements might take some preparation.
+    exam, and that some of the requirements might take some preparation. The 
+    proctoring software has minimum bandwidth requirements and learners must
+    have a consistent connection of 500 kbps or more.
   * Well before the exam, provide learners with information about the grading
     policy in your course and the requirements for earning academic credit.
   * Explain what proctored exams are, and provide learners with links to


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

Adding a sentence that tells course teams that they should warn learners about RPNow v4 bandwidth requirements

### Date Needed (optional)

This should be merged and published when we upgrade to RP Now v4. 

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [x] Product review: @stroilova 
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Squash commits

