### PR TITLE
Update dropdown.rst

### DIFF
--- a/en_us/shared/exercises_tools/dropdown.rst
+++ b/en_us/shared/exercises_tools/dropdown.rst
@@ -67,7 +67,7 @@ field empty.
 .. note:: You separate :ref:`multiple questions<Multiple Problems in
   One Component>` in a problem component with three hyphen (``---``)
   characters. You can separate the answer options with either comma (``,``)
-  characters or new lines. Each question can have a single correct answer.
+  characters or new lines. Each question can ONLY have a single correct answer.
 
 The OLX markup for this example problem follows.
 

--- a/en_us/shared/exercises_tools/dropdown.rst
+++ b/en_us/shared/exercises_tools/dropdown.rst
@@ -7,8 +7,8 @@ Dropdown Problem
 .. note:: EdX offers full support for this problem type.
 
 The dropdown problem type is a core problem type that can be added to any
-course. At a minimum, dropdown problems include a question or prompt and
-several answer options. By adding hints, feedback, or both, you can give
+course. Dropdown problems include a question or prompt and
+several answer options with a single correct answer. By adding hints, feedback, or both, you can give
 learners guidance and help when they work on a problem.
 
 .. contents::
@@ -26,6 +26,8 @@ In dropdown problems, learners select one option from a list of answer options.
 Unlike :ref:`multiple choice<Multiple Choice>` problems, where the answer
 choices are always visible directly below the question, the answer options for
 dropdown problems do not appear until the learner selects the dropdown arrow.
+
+Dropdown problems can only have one correct answer per question, we reccomend adding a "Both B & C" option where multiple multiple selections could be correct.
 
 ================================
 Example Dropdown Problem
@@ -65,7 +67,7 @@ field empty.
 .. note:: You separate :ref:`multiple questions<Multiple Problems in
   One Component>` in a problem component with three hyphen (``---``)
   characters. You can separate the answer options with either comma (``,``)
-  characters or new lines.
+  characters or new lines. Each question can have a single correct answer.
 
 The OLX markup for this example problem follows.
 


### PR DESCRIPTION
Adding explicit verbiage to indicate that only one correct answer is possible for course teams building dropdown problems.

## [PROD-347](https://openedx.atlassian.net/browse/PROD-347)

Updating docs [10.13. Dropdowns](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/dropdown.html#dropdown-problem) to explicitly state that dropdown problems only accept 1 correct answer.  

This should clarify the intended behavior and PROD-347 will prevent a course team from programming drop down problem types with more than one correct answer designated (which doesn't work).

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: Ben Piscopo
- [ ] Partner support: Jenn Akana

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

