### PR TITLE
Correcting and improving the example Backuping script

### DIFF
--- a/en_us/install_operations/source/platform_releases/ginkgo.rst
+++ b/en_us/install_operations/source/platform_releases/ginkgo.rst
@@ -74,17 +74,17 @@ steps.
         #!/bin/bash
         MYSQL_CONN="-uroot -p"
         echo "Reading MySQL database names..."
-        mysql ${MYSQL_CONN} -ANe "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema')" > /tmp/db.txt
+        mysql ${MYSQL_CONN} -ANe "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema', 'sys')" > /tmp/db.txt
         DBS="--databases $(cat /tmp/db.txt)"
         NOW="$(date +%Y%m%dT%H%M%S)"
         SQL_FILE="mysql-data-${NOW}.sql"
         echo "Dumping MySQL structures..."
-        mysqldump ${MYSQL_CONN} --add-drop-database --no-data ${DBS} > ${SQL_FILE}
+        mysqldump ${MYSQL_CONN} --add-drop-database --skip-add-drop-table --no-data ${DBS} > ${SQL_FILE}
         echo "Dumping MySQL data..."
         # If there is table data you don't need, add --ignore-table=tablename
         mysqldump ${MYSQL_CONN} --no-create-info ${DBS} >> ${SQL_FILE}
 
-        for db in edxapp cs_comment_service_development; do
+        for db in edxapp cs_comments_service_development; do
             echo "Dumping Mongo db ${db}..."
             mongodump -u admin -p -h localhost --authenticationDatabase admin -d ${db} --out mongo-dump-${NOW}
         done

--- a/en_us/install_operations/source/platform_releases/hawthorn.rst
+++ b/en_us/install_operations/source/platform_releases/hawthorn.rst
@@ -80,17 +80,17 @@ steps.
         #!/bin/bash
         MYSQL_CONN="-uroot -p"
         echo "Reading MySQL database names..."
-        mysql ${MYSQL_CONN} -ANe "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema')" > /tmp/db.txt
+        mysql ${MYSQL_CONN} -ANe "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema', 'sys')" > /tmp/db.txt
         DBS="--databases $(cat /tmp/db.txt)"
         NOW="$(date +%Y%m%dT%H%M%S)"
         SQL_FILE="mysql-data-${NOW}.sql"
         echo "Dumping MySQL structures..."
-        mysqldump ${MYSQL_CONN} --add-drop-database --no-data ${DBS} > ${SQL_FILE}
+        mysqldump ${MYSQL_CONN} --add-drop-database --skip-add-drop-table --no-data ${DBS} > ${SQL_FILE}
         echo "Dumping MySQL data..."
         # If there is table data you don't need, add --ignore-table=tablename
         mysqldump ${MYSQL_CONN} --no-create-info ${DBS} >> ${SQL_FILE}
 
-        for db in edxapp cs_comment_service_development; do
+        for db in edxapp cs_comments_service_development; do
             echo "Dumping Mongo db ${db}..."
             mongodump -u admin -p -h localhost --authenticationDatabase admin -d ${db} --out mongo-dump-${NOW}
         done

--- a/en_us/install_operations/source/platform_releases/ironwood.rst
+++ b/en_us/install_operations/source/platform_releases/ironwood.rst
@@ -68,17 +68,17 @@ steps.
         #!/bin/bash
         MYSQL_CONN="-uroot -p"
         echo "Reading MySQL database names..."
-        mysql ${MYSQL_CONN} -ANe "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema')" > /tmp/db.txt
+        mysql ${MYSQL_CONN} -ANe "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema', 'sys')" > /tmp/db.txt
         DBS="--databases $(cat /tmp/db.txt)"
         NOW="$(date +%Y%m%dT%H%M%S)"
         SQL_FILE="mysql-data-${NOW}.sql"
         echo "Dumping MySQL structures..."
-        mysqldump ${MYSQL_CONN} --add-drop-database --no-data ${DBS} > ${SQL_FILE}
+        mysqldump ${MYSQL_CONN} --add-drop-database --skip-add-drop-table --no-data ${DBS} > ${SQL_FILE}
         echo "Dumping MySQL data..."
         # If there is table data you don't need, add --ignore-table=tablename
         mysqldump ${MYSQL_CONN} --no-create-info ${DBS} >> ${SQL_FILE}
 
-        for db in edxapp cs_comment_service_development; do
+        for db in edxapp cs_comments_service_development; do
             echo "Dumping Mongo db ${db}..."
             mongodump -u admin -p -h localhost --authenticationDatabase admin -d ${db} --out mongo-dump-${NOW}
         done


### PR DESCRIPTION
By this PR,
1) A typo has been fixed. There is no `cs_comment_service_development`. indeed its name is `cs_comments_service_development` ( with an extra 's' after 'comment' ).
2) A MySQL system database - `sys` - excluded from the list of databases being dumped.
3) Adding `DROP TABLE IF EXISTS...` before `CREATE TABLE` commands is skipped out. as we have a drop database, adding them are pointless.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
@nedbat 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

