### PR TITLE
Add ENABLE_PUBLISHER feature flag

### DIFF
--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -168,6 +168,9 @@ in the Open edX wiki.
    * - ENABLE_PSYCHOMETRICS
      - Deprecated
      - FALSE
+   * - ENABLE_PUBLISHER
+     - Supported
+     - FALSE
    * - ENABLE_RENDER_XBLOCK_API
      - Removed
      - FALSE


### PR DESCRIPTION
ENABLE_MKTG_SITE has been serving double duty to both indicate that
an Open edX installation is using a Drupal marketing site AND
is using the Publisher workflow tool for managing course metadata.

But now that publisher-frontend is available and the Publisher
feature is no longer tied to the marketing site, we want to tease
apart those two concerns. Hence ENABLE_PUBLISHER.

## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

Add a description of your changes with links to any relevant material.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

