### PR TITLE
Drop RUN_AS_ANALYTICS_SERVER_ENABLED

### DIFF
--- a/en_us/install_operations/source/feature_flags/feature_flag_index.rst
+++ b/en_us/install_operations/source/feature_flags/feature_flag_index.rst
@@ -246,9 +246,6 @@ in the Open edX wiki.
    * - REQUIRE_COURSE_EMAIL_AUTH
      - Supported
      - TRUE
-   * - RUN_AS_ANALYTICS_SERVER_ENABLED
-     - Deprecated
-     - FALSE
    * - SEGMENT_IO_LMS
      - Deprecated
      - FALSE


### PR DESCRIPTION
This is an old deprecated toggle that we are removing.

https://openedx.atlassian.net/browse/DEPR-44