### PR TITLE
fix mongodb database name in migrate instructions

### DIFF
--- a/en_us/install_operations/source/platform_releases/ginkgo.rst
+++ b/en_us/install_operations/source/platform_releases/ginkgo.rst
@@ -84,7 +84,7 @@ steps.
         # If there is table data you don't need, add --ignore-table=tablename
         mysqldump ${MYSQL_CONN} --no-create-info ${DBS} >> ${SQL_FILE}
 
-        for db in edxapp cs_comments_service_development; do
+        for db in edxapp cs_comments_service; do
             echo "Dumping Mongo db ${db}..."
             mongodump -u admin -p -h localhost --authenticationDatabase admin -d ${db} --out mongo-dump-${NOW}
         done

--- a/en_us/install_operations/source/platform_releases/hawthorn.rst
+++ b/en_us/install_operations/source/platform_releases/hawthorn.rst
@@ -90,7 +90,7 @@ steps.
         # If there is table data you don't need, add --ignore-table=tablename
         mysqldump ${MYSQL_CONN} --no-create-info ${DBS} >> ${SQL_FILE}
 
-        for db in edxapp cs_comments_service_development; do
+        for db in edxapp cs_comments_service; do
             echo "Dumping Mongo db ${db}..."
             mongodump -u admin -p -h localhost --authenticationDatabase admin -d ${db} --out mongo-dump-${NOW}
         done

--- a/en_us/install_operations/source/platform_releases/ironwood.rst
+++ b/en_us/install_operations/source/platform_releases/ironwood.rst
@@ -78,7 +78,7 @@ steps.
         # If there is table data you don't need, add --ignore-table=tablename
         mysqldump ${MYSQL_CONN} --no-create-info ${DBS} >> ${SQL_FILE}
 
-        for db in edxapp cs_comments_service_development; do
+        for db in edxapp cs_comments_service; do
             echo "Dumping Mongo db ${db}..."
             mongodump -u admin -p -h localhost --authenticationDatabase admin -d ${db} --out mongo-dump-${NOW}
         done


### PR DESCRIPTION
`cs_comments_service_development` does not exist in a typical deployment and should just be `cs_comments_service`.