### PR TITLE
Suggest smaller Python line-length limit

### DIFF
--- a/en_us/developers/source/style_guides/python-guidelines.rst
+++ b/en_us/developers/source/style_guides/python-guidelines.rst
@@ -46,7 +46,12 @@ Follow `PEP 8`_.
 * Names like this:  modules_and_packages, functions_and_methods, local_variables, GLOBALS, CONSTANTS, MultiWordClasses
 * Acronyms should count as one word:  RobustHtmlParser, not RobustHTMLParser
 * Trailing commas are good: they prevent having to edit the last line in a list when adding a new last line.  You can use them in lists, dicts, function calls, etc.
-* EXCEPT: we aren't (yet) limiting code lines to 79 characters.  Use 120 as a limit for code.  Please use 79 chars as a limit for docstring lines though, so that the text remains readable.
+* Many existing repositories currently limit code lines fairly liberally to 120 characters; however, for newer repositories, a lower limit may be justified:
+
+  * PEP-8 specifies **79 characters**, with the justification of ease of side-by-side code editing on smaller monitors.
+  * The Black code formatter, which is quickly gaining popularity, defaults to **88 characters**, with the reasoning that it retains many of the benefits of 79 while requiring significantly less line wrapping.
+
+* Please use 79 chars as a limit for docstring lines so that the text remains readable.
 
 .. contents::
  :local:


### PR DESCRIPTION
@nedbat 

I disagree that 120 characters is a good line-length limit.

I frequently code on my Thinkpad without an external monitor. Here's my screen when I edit a repo where we limit line length to 120. The vertical white line is 88 characters.

![linelength-120](https://user-images.githubusercontent.com/3628148/72559748-81e6c300-3873-11ea-97a9-e9fd9b9a7c84.png)

I can't see the end of every line without shrinking my terminals or zooming way out, both of which are annoying and not good for eye strain.

Furthermore, I don't have any serious vision impairments, so I can read fairly small text on a screen. Imagine if I did!

Here's the same bit of code, but Black-ed to wrap at column 88:
![linelength-88_2](https://user-images.githubusercontent.com/3628148/72560521-359c8280-3875-11ea-8b9a-2a87fb8a3927.png)


It really makes a difference!