### PR TITLE
[BB-2107] Fix the "PAL" acronym spelling error in glossary.rst

### DIFF
--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -802,7 +802,7 @@ P
 
 **PAL**
 
-  Phrase alternating line. The PAL standard is a color encoding system for
+  Phase alternating line. The PAL standard is a color encoding system for
   analog videos. It is used in locations such as Brazil, Australia, south Asia,
   most of Africa, and western Europe.
 


### PR DESCRIPTION
Fixed a minor spelling error encountered in `en_us/shared/glossary/glossary.rst`.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

@Agrendalath

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
