### PR TITLE
Adds note section for multiple choice problem.

### DIFF
--- a/en_us/shared/exercises_tools/multiple_choice.rst
+++ b/en_us/shared/exercises_tools/multiple_choice.rst
@@ -201,6 +201,11 @@ elements of a multiple choice problem with OLX. For more information, see
 
 .. include:: ../../../shared/exercises_tools/Section_advanced_editor.rst
 
+.. note:: On editing and saving please make sure that a multiple choice problem
+    is encapsulated inside **<problem>** tag. The problem will render correctly
+    in **Studio** but will fail when exported and then imported to a course.
+    For a sample XML structure, see :ref:`Multiple Choice Problem XML`.
+
 .. _Use Feedback in a Multiple Choice Problem:
 
 ********************************************


### PR DESCRIPTION
Multiple choice problems could end up without
parent <problem> tag during course creation.
Problem does renders correctly in Studio but
fails to load when imported.This note is to
ensure course authors doesnot end up accidentally
removing parent <problem> tags.

PROD-1235

Snapshot 
<img width="1178" alt="Screen Shot 2020-03-25 at 12 09 19 AM" src="https://user-images.githubusercontent.com/373677/77475025-f7ee4400-6e39-11ea-967e-ac5237e5b36d.png">

