### PR TITLE
Pin packages for compatibility with python 2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ release-note:
 requirements: ## install development environment requirements
 	pip install -r requirements/dev.txt
 
-upgrade: requirements ## update the pip requirements files to use the latest releases satisfying our constraints
+upgrade: ## update the pip requirements files to use the latest releases satisfying our constraints
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,5 @@
 # Core dependencies for documentation builds
+-c constraints.txt
 
 edx-sphinx-theme                    # edX theme for the generated documentation
 sphinx==1.6.5                       # Documentation builder

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,13 +14,14 @@ idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
-pygments==2.6.1           # via sphinx
+pygments==2.5.2           # via -c requirements/constraints.txt, sphinx
 pytz==2019.3              # via babel
 requests==2.23.0          # via sphinx
 six==1.14.0               # via edx-sphinx-theme, sphinx
 snowballstemmer==2.0.0    # via sphinx
 sphinx==1.6.5             # via -r requirements/base.in, edx-sphinx-theme
-sphinxcontrib-websupport==1.2.0  # via sphinx
+sphinxcontrib-websupport==1.1.2  # via -c requirements/constraints.txt, sphinx
+typing==3.7.4.1           # via sphinx
 urllib3==1.25.8           # via requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,2 @@
+pygments==2.5.2			    # pinned until we upgrade to Python 3
+sphinxcontrib-websupport==1.1.2     # pinned until we upgrade to Python 3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,13 +16,14 @@ imagesize==1.2.0          # via -r requirements/base.txt, sphinx
 jinja2==2.11.1            # via -r requirements/base.txt, sphinx
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 pip-tools==4.5.1          # via -r requirements/dev.in
-pygments==2.6.1           # via -r requirements/base.txt, sphinx
+pygments==2.5.2           # via -r requirements/base.txt, sphinx
 pytz==2019.3              # via -r requirements/base.txt, babel
 requests==2.23.0          # via -r requirements/base.txt, sphinx
 six==1.14.0               # via -r requirements/base.txt, edx-sphinx-theme, pip-tools, sphinx
 snowballstemmer==2.0.0    # via -r requirements/base.txt, sphinx
 sphinx==1.6.5             # via -r requirements/base.txt, edx-sphinx-theme
-sphinxcontrib-websupport==1.2.0  # via -r requirements/base.txt, sphinx
+sphinxcontrib-websupport==1.1.2  # via -r requirements/base.txt, sphinx
+typing==3.7.4.1           # via -r requirements/base.txt, sphinx
 urllib3==1.25.8           # via -r requirements/base.txt, requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION

Pinning pygments and sphinxcontrib-websupport to versions that are compatible with Python 2, until this repo is upgraded to python3.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

