### PR TITLE
Catalog API: Add Awin information

### DIFF
--- a/en_us/course_catalog_api_user_guide/source/intro_edx_apis.rst
+++ b/en_us/course_catalog_api_user_guide/source/intro_edx_apis.rst
@@ -8,6 +8,12 @@ Welcome to the Course Catalog API user guide. This guide will help you get set
 up to use the edX Course Catalog API and give you the information you need to
 return the results you want.
 
+PLEASE NOTE: The edX Course Catalog API is purely informational in purpose,
+and should not be utilized for affiliate marketing efforts.  For those specifically
+interested in commission-based affiliate marketing opportunties, please refer to
+edX's `Global Affiliate Program <https://ui.awin.com/merchant-profile/6798>`_,
+which is managed through Awin.
+
 .. _EdX APIs:
 
 ******************************************


### PR DESCRIPTION
Adding information about edX's Global Affiliate Program, managed by Awin, in order to redirect potential affiliate marketing partners away from integrating with the Course Catalog API and to that channel instead.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

