### PR TITLE
Added Information on how to enable course metadata

### DIFF
--- a/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
@@ -189,6 +189,10 @@ change.
      **Settings** menu.
   #. In the **Other Course Settings** field, paste your JSON dictionary.
 
+  In case you can't find the **Other Course Settings** field in 
+  the **Advanced Settings**, set ``ENABLE_OTHER_COURSE_SETTINGS`` to ``true`` 
+  under ``FEATURES`` in ``cms.env.json`` and restart Studio.
+
 
 
 .. include:: ../../../../links/links.rst

--- a/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/creating_new_course.rst
@@ -191,7 +191,7 @@ change.
 
   In case you can't find the **Other Course Settings** field in 
   the **Advanced Settings**, set ``ENABLE_OTHER_COURSE_SETTINGS`` to ``true`` 
-  under ``FEATURES`` in ``cms.env.json`` and restart Studio.
+  under ``FEATURES`` in ``/edx/etc/studio.yml`` and restart Studio.
 
 
 


### PR DESCRIPTION
Adds information on how to enable course metadata. This is helpful for those who are trying to add course metadata but can't figure out where the `Other Course Settings` field is in _Advanced Settings_. 

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] @bradenmacdonald 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

> There were warnings; however, the changes done did not increase the number of warnings. The warnings present are already present in the `master` branch.

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

