### PR TITLE
Explain in more detail how to set a minimum password length

### DIFF
--- a/en_us/install_operations/source/configuration/password.rst
+++ b/en_us/install_operations/source/configuration/password.rst
@@ -20,9 +20,49 @@ users who log  in to the LMS or Studio. Under the default password complexity
 policy, passwords must contain 2 to 75 characters and cannot be similar to the
 user's username or email address.
 
-You can substitute your own password policy for the default policy. To configure 
-a password policy in replacement of the default password policy, follow these 
-steps.
+.. note:: Open edX does not store plain-text passwords, only
+   hashes. Since the length of a hash is independent of the length of
+   the original password, passwords can effectively be of unlimited
+   length. The 75-character default limit is rather arbitrary. Open
+   edX does impose an upper limit of 5,000 characters on a password,
+   but this should be well beyond the practical limit of password
+   length.
+
+This password policy is defined in the ``lms.yml`` configuration file,
+under the ``AUTH_PASSWORD_VALIDATORS`` setting::
+
+  AUTH_PASSWORD_VALIDATORS:
+  -   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
+  -   NAME: util.password_policy_validators.MinimumLengthValidator
+        OPTIONS:
+          min_length: 2
+  -   NAME: util.password_policy_validators.MaximumLengthValidator
+        OPTIONS:
+          max_length: 75
+
+You can override these settings by modifying one of the existing
+``OPTIONS``. For example, if you want to enforce a minimum password
+length of 16 characters, and a maximum length of 256,
+you would set::
+
+  AUTH_PASSWORD_VALIDATORS:
+  -   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
+  -   NAME: util.password_policy_validators.MinimumLengthValidator
+        OPTIONS:
+          min_length: 16
+  -   NAME: util.password_policy_validators.MaximumLengthValidator
+        OPTIONS:
+          max_length: 256
+
+
+.. warning:: If your Open edX configuration :ref:`enables third-party
+   authentication <Enabling Third Party Authentication>`, the *maximum*
+   value you can specify for the ``MinimumLengthValidator``'s
+   ``min_length`` option is 25.
+
+You can also substitute your own password policy for the default
+policy. To configure a password policy in replacement of the default
+password policy, follow these steps.
 
 #. Create or import a new password validator. This is a Python class that defines how a 
    password is validated. For details about writing a password validator class, 
@@ -58,14 +98,10 @@ To configure your Open edX instance to use a particular password validator,
 add your password validator to the list in the ``AUTH_PASSWORD_VALIDATORS`` 
 configuration key in the ``lms.env.json`` configuration file. For example, to
 add a password validator named ``MyPasswordValidator``, add a line like this 
-to the ``lms.env.json`` configuration file.
+to the ``lms.yml`` configuration file.
 ::
  
-  "AUTH_PASSWORD_VALIDATORS": [
-      {
-           "NAME": "path.to.file.MyPasswordValidatorClass",
-
-      },
-  ]
+  AUTH_PASSWORD_VALIDATORS:
+  -   NAME: path.to.module.MyPasswordValidatorClass
 
 .. include:: ../../../links/links.rst


### PR DESCRIPTION
* Improve the information that explains how to configure `AUTH_PASSWORD_VALIDATORS`: it's more likely that an Open edX operator wants to just modify the minimum and maximum allowed password length, rather than use custom validators or write their own.

* Document a snag that exists in TPA configurations: the password that is generated for users that register via third-party authentication, as opposed to first registering with a password and then adding TPA, is hardcoded to 25 characters in length. In an environment where the minimum password length is longer than that, registration via TPA always fails with a particularly puzzling user-facing password validation error.

* Update references to `lms.auth.json` with ones to `lms.yml`.

Reference on generated password length:
https://github.com/edx/edx-platform/blob/open-release/juniper.2/openedx/core/djangoapps/user_authn/utils.py#L49
this actually sets a default length of 12, but it is only ever called, outside of test code, with `length=25`).

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

