### PR TITLE
Adds Details about Adding Course Mode to Enable Certificates for a Course

### DIFF
--- a/en_us/shared/set_up_course/studio_add_course_information/studio_creating_certificates.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/studio_creating_certificates.rst
@@ -90,6 +90,29 @@ Certificates`.
 
     #. At the bottom of the page, select **Save Changes**.
 
+    .. note:: The **Certificate Web/HTML View Enabled** settings is set to
+       ``true`` by default.
+       
+       You can still find it among the **Deprecated Settings** in
+       **Advanced Settings**
+
+    In addition to enabling certificates for your course, you have to add
+    a course mode for the course you wish to create a certificate for.
+
+    #. Access the LMS Django Administration website for your instance of
+       Open edX. To do this, go to 
+       ``https://<host name of your Open edX instance>/admin``. For example,
+       this might be ``https://courses.YourOrganization.com/admin``.
+
+    #. Under **Course Modes** > **Course modes**, add a new course mode for
+       course you want to create a certificate for.
+
+    .. note:: Different certificate types are available with the different
+       course modes. 
+
+       See :ref:`enrollment track<enrollment_track_g>` for more information
+       about different course modes or certificate types.
+
 .. Confirmed March 9, 2017: On edx.org, the Certificate Web/HTML View Enabled
 .. setting is true by default, so the "Enable" procedure isn't necessary for
 .. partners.


### PR DESCRIPTION
When trying to add a Course Certificate, I was having trouble. Apparently, the documentation is missing the necessary information about adding a "Course Mode" in order to enable Certificates for a course.

This PR adds the following information to the documentation:
- **Certificate Web/HTML View Enabled** is a deprecated settings
- **Certificate Web/HTML View Enabled** is now enabled by default
- **Course Mode** is necessary to enable Course Certificates
- **Course Mode** has different certificate types, mentioned in **enrollment_track**

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] @toxinu
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [x] Ran `./run_tests.sh en_us/open_edx_course_authors`
- [x] Built the changes locally using `./develop.sh en_us/open_edx_course_authors` and navigated to the following page:
```
http://127.0.0.1:9090/set_up_course/studio_add_course_information/studio_creating_certificates.html
```

> `./run_tests.sh` resulted in warnings but not related to the changes that I made

### Screenshot of Changes

![image](https://user-images.githubusercontent.com/5631091/90645676-ed947280-e23e-11ea-95ff-e6f898b15f3f.png)

[Here is a link to that section, prior to the changes.](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/set_up_course/studio_add_course_information/studio_creating_certificates.html#enable-certificates)

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

