### PR TITLE
Analyticstack does not include Insights, Data API

### DIFF
--- a/en_us/install_operations/source/installation/index.rst
+++ b/en_us/install_operations/source/installation/index.rst
@@ -52,7 +52,7 @@ convenient. For example, `nginx`_ and `gunicorn`_ are disabled in Devstack;
 Devstack uses Django's ``runserver`` instead.
 
 You can install the Open edX developer stack (just known as **Devstack**)
-or the Open edX analytics developer stack (**Analytics Devstack**).
+or the Open edX analytics developer stack (**Analytics Devstack** or just **Analyticstack**).
 
 =====================
 Devstack Installation
@@ -73,16 +73,14 @@ Analytics Devstack
 
 Some users might want to develop Analytics features on their instance of the
 Open edX platform. Because of the large number of dependencies needed to
-develop extensions to Analytics, edX has created a separate developer stack,
-known as Analytics Devstack. We strongly recommend that you install the
-Analytics Devstack instead of adding Analytics extensions to an instance of
-devstack.
+develop extensions to Analytics, edX has created a modified version of Devstack
+that provides the services and tools needed to modify the
+Open edX Analytics Pipeline.
 
-Analytics Devstack is a modified version of Devstack.
-This development environment provides all of the
-services and tools needed to modify the Open edX Analytics Pipeline, Data API,
-and Insights projects.
+For information on running Analytics Stack,
+see the `Getting Started on Analytics`_ document in the devstack repository.
 
-See the `devstack`_ repository for information on running Analytics Devstack.
+Insights and the Analytics Data API are currently not included in
+Analytics Devstack.
 
 .. include:: ../../../links/links.rst

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -157,6 +157,8 @@
 
 .. _Developing on Devstack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack
 
+.. _Getting Started on Analytics: https://github.com/edx/devstack/blob/master/docs/analytics.rst
+
 .. _forum migration described on the Open edX wiki: https://openedx.atlassian.net/wiki/display/TNL/Migrating+the+Discussion+Forums+to+Support+Teams+Discussion+Filtering
 
 .. _Google Drive XBlock: https://github.com/edx-solutions/xblock-google-drive


### PR DESCRIPTION
The Open edX docs claimed that Analytics Devstack includes Insights and the Data API, which is not the case. Those services must be run separately.

(I believe someone attempted to add those services to analyticstack, it wasn't successful).