### PR TITLE
Correct lms/cms/studio config file names

### DIFF
--- a/en_us/developers/source/analytics.rst
+++ b/en_us/developers/source/analytics.rst
@@ -363,8 +363,8 @@ Segment
 A selection of events can be transmitted to `Segment`_ in order to take
 advantage of a wide variety of analytics-related third party services such as
 Mixpanel and Chartbeat. It is enabled in the LMS if the ``SEGMENT_KEY``
-key is set to a valid Segment API key in the ``lms.yaml`` file. Additionally,
-the setting ``EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST`` in the ``lms.yaml``
+key is set to a valid Segment API key in the ``lms.yml`` file. Additionally,
+the setting ``EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST`` in the ``lms.yml``
 file can be used to specify event names that should be emitted to Segment
 from normal ``tracker.emit()`` calls. Events specified in this whitelist will be
 sent to both the tracking logs and Segment.  Similarly, it is enabled in Studio

--- a/en_us/developers/source/analytics.rst
+++ b/en_us/developers/source/analytics.rst
@@ -369,7 +369,7 @@ file can be used to specify event names that should be emitted to Segment
 from normal ``tracker.emit()`` calls. Events specified in this whitelist will be
 sent to both the tracking logs and Segment.  Similarly, it is enabled in Studio
 if the ``SEGMENT_KEY`` key is set to a valid Segment API key in the
-``studio.yaml`` file.
+``studio.yml`` file.
 
 
 Google Analytics

--- a/en_us/edx_style_guide/source/ExampleRSTFile.rst
+++ b/en_us/edx_style_guide/source/ExampleRSTFile.rst
@@ -214,7 +214,7 @@ for ordered lists and two spaces for unordered lists.
 
 ::
 
-  #. In the ``lms.yaml`` and ``studio.yaml`` files, set the value of
+  #. In the ``lms.yml`` and ``studio.yaml`` files, set the value of
      ``CERTIFICATES_HTML_VIEW`` within the ``FEATURES`` object  to ``true``.
 
      .. code-block:: bash
@@ -225,7 +225,7 @@ for ordered lists and two spaces for unordered lists.
            ...
        }
 
-  #. Save the ``lms.yaml`` and ``studio.yaml`` files.
+  #. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 
 ***************************************

--- a/en_us/edx_style_guide/source/ExampleRSTFile.rst
+++ b/en_us/edx_style_guide/source/ExampleRSTFile.rst
@@ -214,7 +214,7 @@ for ordered lists and two spaces for unordered lists.
 
 ::
 
-  #. In the ``lms.yml`` and ``studio.yaml`` files, set the value of
+  #. In the ``lms.yml`` and ``studio.yml`` files, set the value of
      ``CERTIFICATES_HTML_VIEW`` within the ``FEATURES`` object  to ``true``.
 
      .. code-block:: bash
@@ -225,7 +225,7 @@ for ordered lists and two spaces for unordered lists.
            ...
        }
 
-  #. Save the ``lms.yml`` and ``studio.yaml`` files.
+  #. Save the ``lms.yml`` and ``studio.yml`` files.
 
 
 ***************************************

--- a/en_us/install_operations/source/configuration/changing_appearance/drag_and_drop_problem_styling.rst
+++ b/en_us/install_operations/source/configuration/changing_appearance/drag_and_drop_problem_styling.rst
@@ -61,7 +61,7 @@ Python module, follow these steps.
         pip install /path/to/my/module
 
 
-#. Edit the ``lms.yaml`` file for your LMS server. Add the ``drag-and-
+#. Edit the ``lms.yml`` file for your LMS server. Add the ``drag-and-
    drop-v2`` object to the ``XBLOCK_SETTINGS`` object. Include the content
    shown in the following example.
 

--- a/en_us/install_operations/source/configuration/changing_appearance/theming/enable_themes.rst
+++ b/en_us/install_operations/source/configuration/changing_appearance/theming/enable_themes.rst
@@ -51,7 +51,7 @@ To enable the use of themes for your Open edX installation, follow these steps.
    the type of environment you are using. For example, you can set the
    configuration property in the following files.
 
-   * For the LMS, you edit ``/edx/app/edxapp/lms.yaml`` to set
+   * For the LMS, you edit ``/edx/app/edxapp/lms.yml`` to set
      ``"ENABLE_COMPREHENSIVE_THEMING": true``.
 
    * For Studio, you edit ``/edx/app/edxapp/studio.yaml`` to set
@@ -82,7 +82,7 @@ To enable the use of themes for your Open edX installation, follow these steps.
         ],
 
    * For the LMS, add the path to ``COMPREHENSIVE_THEME_DIRS`` in
-     ``/edx/app/edxapp/lms.yaml``.
+     ``/edx/app/edxapp/lms.yml``.
 
      .. code-block:: none
 
@@ -129,7 +129,7 @@ For the following file structure:
                └── static
                └── templates
 
-set these in lms.yaml and studio.yaml:
+set these in lms.yml and studio.yaml:
 
 .. code:: json
 

--- a/en_us/install_operations/source/configuration/changing_appearance/theming/enable_themes.rst
+++ b/en_us/install_operations/source/configuration/changing_appearance/theming/enable_themes.rst
@@ -54,7 +54,7 @@ To enable the use of themes for your Open edX installation, follow these steps.
    * For the LMS, you edit ``/edx/app/edxapp/lms.yml`` to set
      ``"ENABLE_COMPREHENSIVE_THEMING": true``.
 
-   * For Studio, you edit ``/edx/app/edxapp/studio.yaml`` to set
+   * For Studio, you edit ``/edx/app/edxapp/studio.yml`` to set
      ``"ENABLE_COMPREHENSIVE_THEMING": true``.
 
    * For the E-commerce service, you edit ``/edx/etc/ecommerce.yml`` to set
@@ -72,7 +72,7 @@ To enable the use of themes for your Open edX installation, follow these steps.
    configuration property in the following files.
 
    * For Studio, add the path to ``COMPREHENSIVE_THEME_DIRS`` in
-     ``/edx/app/edxapp/studio.yaml``.
+     ``/edx/app/edxapp/studio.yml``.
 
      .. code-block:: none
 
@@ -129,7 +129,7 @@ For the following file structure:
                └── static
                └── templates
 
-set these in lms.yml and studio.yaml:
+set these in lms.yml and studio.yml:
 
 .. code:: json
 

--- a/en_us/install_operations/source/configuration/config_allowed_regis_emails.rst
+++ b/en_us/install_operations/source/configuration/config_allowed_regis_emails.rst
@@ -33,11 +33,11 @@ Configure Allowed Email Patterns
 
 To specify the email patterns that are allowed for registration, follow these steps.
 
-#. Locate the ``lms.yaml`` and ``studio.yaml`` files, which are located
+#. Locate the ``lms.yml`` and ``studio.yaml`` files, which are located
    one level above the ``edx-platform`` directory. You make the same changes
    to both files.
 
-#. In the ``lms.yaml`` and ``studio.yaml`` files add the
+#. In the ``lms.yml`` and ``studio.yaml`` files add the
    ``REGISTRATION_EMAIL_PATTERNS_ALLOWED`` setting.
 
    .. code-block:: none
@@ -64,6 +64,6 @@ To specify the email patterns that are allowed for registration, follow these st
         "(^\\w+\\.\\w+)@school\\.tld$"
      ]
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 #. Restart your ``edxapp`` instances.

--- a/en_us/install_operations/source/configuration/config_allowed_regis_emails.rst
+++ b/en_us/install_operations/source/configuration/config_allowed_regis_emails.rst
@@ -33,11 +33,11 @@ Configure Allowed Email Patterns
 
 To specify the email patterns that are allowed for registration, follow these steps.
 
-#. Locate the ``lms.yml`` and ``studio.yaml`` files, which are located
+#. Locate the ``lms.yml`` and ``studio.yml`` files, which are located
    one level above the ``edx-platform`` directory. You make the same changes
    to both files.
 
-#. In the ``lms.yml`` and ``studio.yaml`` files add the
+#. In the ``lms.yml`` and ``studio.yml`` files add the
    ``REGISTRATION_EMAIL_PATTERNS_ALLOWED`` setting.
 
    .. code-block:: none
@@ -64,6 +64,6 @@ To specify the email patterns that are allowed for registration, follow these st
         "(^\\w+\\.\\w+)@school\\.tld$"
      ]
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 #. Restart your ``edxapp`` instances.

--- a/en_us/install_operations/source/configuration/configure_milestone_app.rst
+++ b/en_us/install_operations/source/configuration/configure_milestone_app.rst
@@ -5,7 +5,7 @@
 Configure the Milestones Application
 ************************************
 
-#. Set the value of ``MILESTONES_APP`` in the ``lms.yaml`` and
+#. Set the value of ``MILESTONES_APP`` in the ``lms.yml`` and
    ``studio.yaml`` files to ``True``.
 
    .. code-block:: none
@@ -13,6 +13,6 @@ Configure the Milestones Application
        # Milestones application flag
        'MILESTONES_APP': True,
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 #. Run database migrations.

--- a/en_us/install_operations/source/configuration/configure_milestone_app.rst
+++ b/en_us/install_operations/source/configuration/configure_milestone_app.rst
@@ -6,13 +6,13 @@ Configure the Milestones Application
 ************************************
 
 #. Set the value of ``MILESTONES_APP`` in the ``lms.yml`` and
-   ``studio.yaml`` files to ``True``.
+   ``studio.yml`` files to ``True``.
 
    .. code-block:: none
 
        # Milestones application flag
        'MILESTONES_APP': True,
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 #. Run database migrations.

--- a/en_us/install_operations/source/configuration/customize_registration_page.rst
+++ b/en_us/install_operations/source/configuration/customize_registration_page.rst
@@ -27,7 +27,7 @@ Add Custom Fields to the Registration Page
 
 Before you add a custom field to the registration page, you must make sure that
 the combined sign-in and registration form is enabled for your Open edX
-instance. To do this, open the ``lms.yml`` and ``studio.yaml`` files, and
+instance. To do this, open the ``lms.yml`` and ``studio.yml`` files, and
 set the ``ENABLE_COMBINED_LOGIN_REGISTRATION`` feature flag to True. These
 files are located one level above the ``edx- platform`` directory.
 

--- a/en_us/install_operations/source/configuration/customize_registration_page.rst
+++ b/en_us/install_operations/source/configuration/customize_registration_page.rst
@@ -27,7 +27,7 @@ Add Custom Fields to the Registration Page
 
 Before you add a custom field to the registration page, you must make sure that
 the combined sign-in and registration form is enabled for your Open edX
-instance. To do this, open the ``lms.yaml`` and ``studio.yaml`` files, and
+instance. To do this, open the ``lms.yml`` and ``studio.yaml`` files, and
 set the ``ENABLE_COMBINED_LOGIN_REGISTRATION`` feature flag to True. These
 files are located one level above the ``edx- platform`` directory.
 
@@ -42,10 +42,10 @@ To add custom fields to the registration page, follow these steps.
    For more information about how to create Django forms, see `Django Forms`_
    on the `Django website`_.
 
-#. In the ``lms.yaml`` file, add the app for your model to the
+#. In the ``lms.yml`` file, add the app for your model to the
    ``ADDL_INSTALLED_APPS`` array.
 
-#. In the ``lms.yaml`` file, set the ``REGISTRATION_EXTENSION_FORM``
+#. In the ``lms.yml`` file, set the ``REGISTRATION_EXTENSION_FORM``
    setting to the path of the Django form that you just created, as a dot-
    separated Python string.
 

--- a/en_us/install_operations/source/configuration/enable_badging.rst
+++ b/en_us/install_operations/source/configuration/enable_badging.rst
@@ -192,7 +192,7 @@ To specify a different badge generator, follow these steps.
         image_url = models.URLField()
         assertion_url = models.URLField(
 
-#. In the ``lms.yml`` and ``studio.yaml`` files, set the value of
+#. In the ``lms.yml`` and ``studio.yml`` files, set the value of
    ``BADGING_BACKEND`` as a dot-separated python path specification to the
    object that you use to create and assign badges.
 
@@ -207,10 +207,10 @@ To specify a different badge generator, follow these steps.
 Enable Badges in Studio and the Learning Management System
 *****************************************************************
 
-To enable badges, you modify the ``lms.yml`` and ``studio.yaml`` files,
+To enable badges, you modify the ``lms.yml`` and ``studio.yml`` files,
 which are located one level above the ``edx-platform`` directory.
 
-#. In the ``lms.yml`` and ``studio.yaml`` files, in the FEATURES
+#. In the ``lms.yml`` and ``studio.yml`` files, in the FEATURES
    section, set the value of ``ENABLE_OPENBADGES``  to ``True``.
 
    .. code-block:: none
@@ -242,7 +242,7 @@ which are located one level above the ``edx-platform`` directory.
        BADGR_BASE_URL = "http://localhost:8005"
        BADGR_ISSUER_SLUG = "test-issuer"
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 #. Run database migrations.
 

--- a/en_us/install_operations/source/configuration/enable_badging.rst
+++ b/en_us/install_operations/source/configuration/enable_badging.rst
@@ -192,7 +192,7 @@ To specify a different badge generator, follow these steps.
         image_url = models.URLField()
         assertion_url = models.URLField(
 
-#. In the ``lms.yaml`` and ``studio.yaml`` files, set the value of
+#. In the ``lms.yml`` and ``studio.yaml`` files, set the value of
    ``BADGING_BACKEND`` as a dot-separated python path specification to the
    object that you use to create and assign badges.
 
@@ -207,10 +207,10 @@ To specify a different badge generator, follow these steps.
 Enable Badges in Studio and the Learning Management System
 *****************************************************************
 
-To enable badges, you modify the ``lms.yaml`` and ``studio.yaml`` files,
+To enable badges, you modify the ``lms.yml`` and ``studio.yaml`` files,
 which are located one level above the ``edx-platform`` directory.
 
-#. In the ``lms.yaml`` and ``studio.yaml`` files, in the FEATURES
+#. In the ``lms.yml`` and ``studio.yaml`` files, in the FEATURES
    section, set the value of ``ENABLE_OPENBADGES``  to ``True``.
 
    .. code-block:: none
@@ -218,7 +218,7 @@ which are located one level above the ``edx-platform`` directory.
      # Enable OpenBadge support.
      'ENABLE_OPENBADGES': True,
 
-#. In ``lms.yaml``, set the values for the following parameters.
+#. In ``lms.yml``, set the values for the following parameters.
 
    * ``BADGR_API_TOKEN``: A string containing the API token for the Badgr
      superuser account. Obtain the token from the /v1/user/auth-token page while
@@ -242,7 +242,7 @@ which are located one level above the ``edx-platform`` directory.
        BADGR_BASE_URL = "http://localhost:8005"
        BADGR_ISSUER_SLUG = "test-issuer"
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 #. Run database migrations.
 

--- a/en_us/install_operations/source/configuration/enable_certificates.rst
+++ b/en_us/install_operations/source/configuration/enable_certificates.rst
@@ -38,10 +38,10 @@ configuration tasks described in this topic.
 Enable Course Certificates in Studio and the LMS
 *************************************************
 
-To enable certificates, you modify the ``lms.yml`` and ``studio.yaml``
+To enable certificates, you modify the ``lms.yml`` and ``studio.yml``
 files, which are located one level above the ``edx-platform`` directory.
 
-#. In the ``lms.yml`` and ``studio.yaml`` files, set the value of
+#. In the ``lms.yml`` and ``studio.yml`` files, set the value of
    ``CERTIFICATES_HTML_VIEW`` within the ``FEATURES`` object  to ``true``.
 
    .. code-block:: none
@@ -52,7 +52,7 @@ files, which are located one level above the ``edx-platform`` directory.
          ...
      }
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 #. If it does not exist already, create the folder ``/tmp/certificates`` owned
    by the user and group ``www-data``. Depending on your configuration, this

--- a/en_us/install_operations/source/configuration/enable_certificates.rst
+++ b/en_us/install_operations/source/configuration/enable_certificates.rst
@@ -38,10 +38,10 @@ configuration tasks described in this topic.
 Enable Course Certificates in Studio and the LMS
 *************************************************
 
-To enable certificates, you modify the ``lms.yaml`` and ``studio.yaml``
+To enable certificates, you modify the ``lms.yml`` and ``studio.yaml``
 files, which are located one level above the ``edx-platform`` directory.
 
-#. In the ``lms.yaml`` and ``studio.yaml`` files, set the value of
+#. In the ``lms.yml`` and ``studio.yaml`` files, set the value of
    ``CERTIFICATES_HTML_VIEW`` within the ``FEATURES`` object  to ``true``.
 
    .. code-block:: none
@@ -52,7 +52,7 @@ files, which are located one level above the ``edx-platform`` directory.
          ...
      }
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 #. If it does not exist already, create the folder ``/tmp/certificates`` owned
    by the user and group ``www-data``. Depending on your configuration, this

--- a/en_us/install_operations/source/configuration/enable_custom_course_settings.rst
+++ b/en_us/install_operations/source/configuration/enable_custom_course_settings.rst
@@ -5,7 +5,7 @@ Enabling Custom Course Settings
 ####################################
 
 To enable course developers to add custom fields to a course on your instance 
-of Open edX, you must configure the ``studio.yaml`` file in the edX platform.
+of Open edX, you must configure the ``studio.yml`` file in the edX platform.
 
 .. Note::
   Before proceeding, review :ref:`Guidelines for Updating the Open edX
@@ -13,7 +13,7 @@ of Open edX, you must configure the ``studio.yaml`` file in the edX platform.
 
 #. Stop the LMS server.
 
-#. Create or update the file ``studio.yaml`` to include the custom course 
+#. Create or update the file ``studio.yml`` to include the custom course 
    settings feature flag.
 
    .. code-block:: yaml

--- a/en_us/install_operations/source/configuration/enable_entrance_exams.rst
+++ b/en_us/install_operations/source/configuration/enable_entrance_exams.rst
@@ -34,10 +34,10 @@ Open edX Course* and *Open edX Learner's* guides.
 Enable Entrance Exams in Studio and the Learning Management System
 *************************************************************************
 
-To enable entrance exams, you modify the ``lms.yaml`` and ``studio.yaml``
+To enable entrance exams, you modify the ``lms.yml`` and ``studio.yaml``
 files, which are located one level above the ``edx-platform`` directory.
 
-#. Set the value of ``ENTRANCE_EXAMS`` in the ``lms.yaml`` and
+#. Set the value of ``ENTRANCE_EXAMS`` in the ``lms.yml`` and
    ``studio.yaml`` files to ``True``.
 
    .. code-block:: none
@@ -45,6 +45,6 @@ files, which are located one level above the ``edx-platform`` directory.
      # Entrance exams feature flag
      'ENTRANCE_EXAMS': True,
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/enable_entrance_exams.rst
+++ b/en_us/install_operations/source/configuration/enable_entrance_exams.rst
@@ -34,17 +34,17 @@ Open edX Course* and *Open edX Learner's* guides.
 Enable Entrance Exams in Studio and the Learning Management System
 *************************************************************************
 
-To enable entrance exams, you modify the ``lms.yml`` and ``studio.yaml``
+To enable entrance exams, you modify the ``lms.yml`` and ``studio.yml``
 files, which are located one level above the ``edx-platform`` directory.
 
 #. Set the value of ``ENTRANCE_EXAMS`` in the ``lms.yml`` and
-   ``studio.yaml`` files to ``True``.
+   ``studio.yml`` files to ``True``.
 
    .. code-block:: none
 
      # Entrance exams feature flag
      'ENTRANCE_EXAMS': True,
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/enable_licensing.rst
+++ b/en_us/install_operations/source/configuration/enable_licensing.rst
@@ -36,10 +36,10 @@ in both Studio and the Learning Management System.
 Enable Licensing in Studio
 *****************************
 
-To enable licensing, you modify the ``lms.yaml`` and ``studio.yaml``
+To enable licensing, you modify the ``lms.yml`` and ``studio.yaml``
 files, which are located one level above the ``edx-platform`` directory.
 
-#. In the ``lms.yaml`` and ``studio.yaml`` files, in the ``FEATURES``
+#. In the ``lms.yml`` and ``studio.yaml`` files, in the ``FEATURES``
    dictionary, add ``'LICENSING':True``:
 
    .. code-block:: none
@@ -48,6 +48,6 @@ files, which are located one level above the ``edx-platform`` directory.
           'LICENSING': True,
           . . .
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/enable_licensing.rst
+++ b/en_us/install_operations/source/configuration/enable_licensing.rst
@@ -36,10 +36,10 @@ in both Studio and the Learning Management System.
 Enable Licensing in Studio
 *****************************
 
-To enable licensing, you modify the ``lms.yml`` and ``studio.yaml``
+To enable licensing, you modify the ``lms.yml`` and ``studio.yml``
 files, which are located one level above the ``edx-platform`` directory.
 
-#. In the ``lms.yml`` and ``studio.yaml`` files, in the ``FEATURES``
+#. In the ``lms.yml`` and ``studio.yml`` files, in the ``FEATURES``
    dictionary, add ``'LICENSING':True``:
 
    .. code-block:: none
@@ -48,6 +48,6 @@ files, which are located one level above the ``edx-platform`` directory.
           'LICENSING': True,
           . . .
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/enable_prerequisites.rst
+++ b/en_us/install_operations/source/configuration/enable_prerequisites.rst
@@ -36,17 +36,17 @@ Enable Prerequisite Courses in Studio and the Learning Management System
 *************************************************************************
 
 To enable prerequisite courses, you modify the ``lms.yml`` and
-``studio.yaml`` files, which are located one level above the ``edx-platform``
+``studio.yml`` files, which are located one level above the ``edx-platform``
 directory.
 
 #. Set the value of ``ENABLE_PREREQUISITE_COURSES`` in the
-   ``lms.yml`` and ``studio.yaml`` files to ``true``.
+   ``lms.yml`` and ``studio.yml`` files to ``true``.
 
    .. code-block:: none
 
        # Prerequisite courses feature flag
        'ENABLE_PREREQUISITE_COURSES': true,
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/enable_prerequisites.rst
+++ b/en_us/install_operations/source/configuration/enable_prerequisites.rst
@@ -35,18 +35,18 @@ Open edX Course* and *Open edX Learner's* guides.
 Enable Prerequisite Courses in Studio and the Learning Management System
 *************************************************************************
 
-To enable prerequisite courses, you modify the ``lms.yaml`` and
+To enable prerequisite courses, you modify the ``lms.yml`` and
 ``studio.yaml`` files, which are located one level above the ``edx-platform``
 directory.
 
 #. Set the value of ``ENABLE_PREREQUISITE_COURSES`` in the
-   ``lms.yaml`` and ``studio.yaml`` files to ``true``.
+   ``lms.yml`` and ``studio.yaml`` files to ``true``.
 
    .. code-block:: none
 
        # Prerequisite courses feature flag
        'ENABLE_PREREQUISITE_COURSES': true,
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/enable_socialsharing_icons.rst
+++ b/en_us/install_operations/source/configuration/enable_socialsharing_icons.rst
@@ -115,7 +115,7 @@ In addition to enabling the social sharing icons, you can allow course
 teams to provide a custom URL for social sharing sites to link back to.
 
 You must set the ``CUSTOM_COURSE_URLS`` parameter to ``True`` in both the
-``lms.yml`` and ``studio.yaml`` files. In the ``studio.yaml`` file, this
+``lms.yml`` and ``studio.yml`` files. In the ``studio.yml`` file, this
 parameter is the only social sharing setting.
 
 .. code-block:: none
@@ -124,7 +124,7 @@ parameter is the only social sharing setting.
         'CUSTOM_COURSE_URLS': True
     }
 
-When finished, save the ``lms.yml`` and ``studio.yaml`` files.
+When finished, save the ``lms.yml`` and ``studio.yml`` files.
 
 =================================
 Set a Custom URL for a Course

--- a/en_us/install_operations/source/configuration/enable_socialsharing_icons.rst
+++ b/en_us/install_operations/source/configuration/enable_socialsharing_icons.rst
@@ -35,10 +35,10 @@ URLS, a link to the course About page in the LMS is used.
 Configure Social Sharing
 *******************************
 
-To enable social sharing icons for courses, you modify the ``lms.yaml``
+To enable social sharing icons for courses, you modify the ``lms.yml``
 file, which is located one level above the ``edx-platform`` directory.
 
-#. In the ``lms.yaml`` file, modify the ``SOCIAL_SHARING_SETTINGS``
+#. In the ``lms.yml`` file, modify the ``SOCIAL_SHARING_SETTINGS``
    dictionary as needed.
 
    .. code-block:: none
@@ -67,7 +67,7 @@ file, which is located one level above the ``edx-platform`` directory.
    c. If you set ``CUSTOM_COURSE_URLS`` to ``True``, you must `Enable Custom
       Course URLs`_.
 
-#. Configure the ``SOCIAL_MEDIA_FOOTER_NAMES`` array in the ``lms.yaml``
+#. Configure the ``SOCIAL_MEDIA_FOOTER_NAMES`` array in the ``lms.yml``
    file to set the order of links you want learners to see in the footer.
 
    .. code-block:: none
@@ -82,7 +82,7 @@ file, which is located one level above the ``edx-platform`` directory.
         ]
 
 #. Configure the ``SOCIAL_MEDIA_FOOTER_DISPLAY`` dictionary in the
-   ``lms.yaml`` file  to define how you want social media icons to be
+   ``lms.yml`` file  to define how you want social media icons to be
    displayed. For each social media icon you enable, you define a ``title``,
    ``icon``, and ``action``.
 
@@ -105,7 +105,7 @@ file, which is located one level above the ``edx-platform`` directory.
         }
      }
 
-#. Save the ``lms.yaml`` file.
+#. Save the ``lms.yml`` file.
 
 *****************************************
 Enable Custom Course URLs
@@ -115,7 +115,7 @@ In addition to enabling the social sharing icons, you can allow course
 teams to provide a custom URL for social sharing sites to link back to.
 
 You must set the ``CUSTOM_COURSE_URLS`` parameter to ``True`` in both the
-``lms.yaml`` and ``studio.yaml`` files. In the ``studio.yaml`` file, this
+``lms.yml`` and ``studio.yaml`` files. In the ``studio.yaml`` file, this
 parameter is the only social sharing setting.
 
 .. code-block:: none
@@ -124,7 +124,7 @@ parameter is the only social sharing setting.
         'CUSTOM_COURSE_URLS': True
     }
 
-When finished, save the ``lms.yaml`` and ``studio.yaml`` files.
+When finished, save the ``lms.yml`` and ``studio.yaml`` files.
 
 =================================
 Set a Custom URL for a Course

--- a/en_us/install_operations/source/configuration/enable_timed_exams.rst
+++ b/en_us/install_operations/source/configuration/enable_timed_exams.rst
@@ -35,18 +35,18 @@ Enable Timed Exams in Studio and the Learning Management System
 *************************************************************************
 
 To enable timed exams, you modify the ``lms.yml`` and
-``studio.yaml`` files, which are located one level above the ``edx-platform``
+``studio.yml`` files, which are located one level above the ``edx-platform``
 directory.
 
 #. Set the value of ``ENABLE_SPECIAL_EXAMS`` in the
-   ``lms.yml`` and ``studio.yaml`` files to ``true``.
+   ``lms.yml`` and ``studio.yml`` files to ``true``.
 
    .. code-block:: none
 
        # Timed exams feature flag
        'ENABLE_SPECIAL_EXAMS': true,
 
-#. Save the  ``lms.yml`` and ``studio.yaml`` files.
+#. Save the  ``lms.yml`` and ``studio.yml`` files.
 
 #. Restart the Studio (CMS) and Learning Management System (LMS) processes so
    that your updates are loaded.

--- a/en_us/install_operations/source/configuration/enable_timed_exams.rst
+++ b/en_us/install_operations/source/configuration/enable_timed_exams.rst
@@ -34,19 +34,19 @@ Course*. For information about the learner experience, see
 Enable Timed Exams in Studio and the Learning Management System
 *************************************************************************
 
-To enable timed exams, you modify the ``lms.yaml`` and
+To enable timed exams, you modify the ``lms.yml`` and
 ``studio.yaml`` files, which are located one level above the ``edx-platform``
 directory.
 
 #. Set the value of ``ENABLE_SPECIAL_EXAMS`` in the
-   ``lms.yaml`` and ``studio.yaml`` files to ``true``.
+   ``lms.yml`` and ``studio.yaml`` files to ``true``.
 
    .. code-block:: none
 
        # Timed exams feature flag
        'ENABLE_SPECIAL_EXAMS': true,
 
-#. Save the  ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the  ``lms.yml`` and ``studio.yaml`` files.
 
 #. Restart the Studio (CMS) and Learning Management System (LMS) processes so
    that your updates are loaded.

--- a/en_us/install_operations/source/configuration/lti/enable_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/enable_lti.rst
@@ -10,7 +10,7 @@ LTI provider functionality is provided in the ``lti_provider`` app, located in
 By default, the ``lti_provider`` app is not used by edX installations. To
 enable this functionality throughout the platform, follow these steps.
 
-#. In the ``edx/app/edxapp/lms.yaml`` file, edit the file so that it
+#. In the ``edx/app/edxapp/lms.yml`` file, edit the file so that it
    includes the following line in the features section.
 
    .. code-block:: none
@@ -20,7 +20,7 @@ enable this functionality throughout the platform, follow these steps.
            "ENABLE_LTI_PROVIDER": true
        }
 
-#. Save the ``edx/app/edxapp/lms.yaml`` file.
+#. Save the ``edx/app/edxapp/lms.yml`` file.
 
 #. Run database migrations.
 

--- a/en_us/install_operations/source/configuration/lti/settings_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/settings_lti.rst
@@ -22,7 +22,7 @@ minutes.
 
 To change the interval for returning aggregated grades, follow these steps.
 
-#. In ``edx/app/edxapp/lms.yaml``, change the value for the following
+#. In ``edx/app/edxapp/lms.yml``, change the value for the following
    parameter.
 
    ``LTI_AGGREGATE_SCORE_PASSBACK_DELAY = 15 * 60``

--- a/en_us/install_operations/source/configuration/password.rst
+++ b/en_us/install_operations/source/configuration/password.rst
@@ -69,7 +69,7 @@ password policy, follow these steps.
    see :ref:`Creating a Password Validator`.
 
 #. Add your password validator to the list in the ``AUTH_PASSWORD_VALIDATORS`` 
-   configuration key in the ``lms.yaml`` configuration file. For details, 
+   configuration key in the ``lms.yml`` configuration file. For details, 
    see :ref:`Configuring a Password Validator`.
 
 .. _Creating a Password Validator:
@@ -96,7 +96,7 @@ Configuring a Password Validator
 
 To configure your Open edX instance to use a particular password validator, 
 add your password validator to the list in the ``AUTH_PASSWORD_VALIDATORS`` 
-configuration key in the ``lms.yaml`` configuration file. For example, to
+configuration key in the ``lms.yml`` configuration file. For example, to
 add a password validator named ``MyPasswordValidator``, add a line like this 
 to the ``lms.yml`` configuration file.
 ::

--- a/en_us/install_operations/source/configuration/sites/configure_site.rst
+++ b/en_us/install_operations/source/configuration/sites/configure_site.rst
@@ -6,7 +6,7 @@ Configuring Sites Independently
 
 You can set configuration properties independently for individual sites. The
 values that you define for individual sites override the default values that
-are present in the ``studio.yaml`` or ``lms.yml`` files. For example, you
+are present in the ``studio.yml`` or ``lms.yml`` files. For example, you
 can set the ``PLATFORM_NAME`` property to a different value for each of your
 sites to indicate that the sites present courses for different organizations or
 audiences.

--- a/en_us/install_operations/source/configuration/sites/configure_site.rst
+++ b/en_us/install_operations/source/configuration/sites/configure_site.rst
@@ -6,7 +6,7 @@ Configuring Sites Independently
 
 You can set configuration properties independently for individual sites. The
 values that you define for individual sites override the default values that
-are present in the ``studio.yaml`` or ``lms.yaml`` files. For example, you
+are present in the ``studio.yaml`` or ``lms.yml`` files. For example, you
 can set the ``PLATFORM_NAME`` property to a different value for each of your
 sites to indicate that the sites present courses for different organizations or
 audiences.

--- a/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
@@ -40,13 +40,13 @@ you ran the command.
 Add Keys to the LMS Configuration File
 **************************************************
 
-.. note:: Configuration settings added to the ``lms.yaml`` file are reset
+.. note:: Configuration settings added to the ``lms.yml`` file are reset
  to their default values when you use Ansible to update edx-platform.
 
 To configure an Open edX site with your public and private SAML keys, follow
 these steps.
 
-#. Open the ``edx/app/edxapp/lms.yaml`` file in your text editor.
+#. Open the ``edx/app/edxapp/lms.yml`` file in your text editor.
 
 #. In the root of the JSON, add the ``SOCIAL_AUTH_SAML_SP_PUBLIC_CERT`` key
    followed by a colon (:), a space, and an empty string where you'll paste the
@@ -81,7 +81,7 @@ these steps.
     "SOCIAL_AUTH_SAML_SP_PUBLIC_CERT": "-----BEGIN CERTIFICATE-----\nSWP6P/C1ypaYkmS...j9+hjvbBf3szk=\n-----END CERTIFICATE-----\n"
     "SOCIAL_AUTH_SAML_SP_PRIVATE_KEY": "-----BEGIN RSA PRIVATE KEY-----\nW1icmlkZN+FtM5h...s/psgLDn38Q==\n-----END RSA PRIVATE KEY-----\n"
 
-#. Save and close the ``lms.yaml`` file.
+#. Save and close the ``lms.yml`` file.
 
 
 **************************************************
@@ -143,7 +143,7 @@ these steps.
 
 #. Optionally, you can save your public and private keys in the Django
    administration console. Because this procedure saves your credentials in the
-   database, edX recommends that you use the ``lms.yaml`` file instead.
+   database, edX recommends that you use the ``lms.yml`` file instead.
    For more information, see :ref:`Add Keys to the LMS Configuration File`.
 
 #. Select **Save**. You can direct identity providers to
@@ -154,7 +154,7 @@ Ensure that the SAML Authentication Backend is Loaded
 *******************************************************
 
 By default, SAML is included as an approved data format for identity providers.
-The default configuration of the ``/edx/app/edxapp/lms.yaml`` file does not
+The default configuration of the ``/edx/app/edxapp/lms.yml`` file does not
 explicitly include the ``THIRD_PARTY_AUTH_BACKENDS`` setting.
 
 If you have customized this file and added the ``THIRD_PARTY_AUTH_BACKENDS``
@@ -163,6 +163,6 @@ setting to it, you might need to verify that the
 specified for it. That backend is required before you can add SAML IdPs.
 
 To verify that the SAML authentication backend is loaded on a devstack or
-fullstack installation, review the ``/edx/app/edxapp/lms.yaml`` file.
+fullstack installation, review the ``/edx/app/edxapp/lms.yml`` file.
 
 .. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/configuration/tpa/tpa_integrate_open/index.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_integrate_open/index.rst
@@ -19,7 +19,7 @@ Enable the Third Party Authentication Feature
 By default, third party authentication is not enabled on Open edX
 installations. To enable this feature, follow these steps.
 
-#. In the ``edx/app/edxapp/lms.yaml`` file, edit the file so that it
+#. In the ``edx/app/edxapp/lms.yml`` file, edit the file so that it
    includes the following line in the features section.
 
    .. code-block:: none
@@ -30,7 +30,7 @@ installations. To enable this feature, follow these steps.
            "ENABLE_THIRD_PARTY_AUTH": true
        }
 
-#. Save the ``edx/app/edxapp/lms.yaml`` file.
+#. Save the ``edx/app/edxapp/lms.yml`` file.
 
 ***********************************************
 Set Up a Third Party Authentication Provider

--- a/en_us/install_operations/source/configuration/tpa/tpa_integrate_open/tpa_oauth.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_integrate_open/tpa_oauth.rst
@@ -206,20 +206,20 @@ Configure Open edX
 
 Configuring Open edX is very similar for Google, Facebook, LinkedIn, and Azure.
 
-#. In the ``lms.yaml`` file, change the value of ``FEATURES`` >
+#. In the ``lms.yml`` file, change the value of ``FEATURES`` >
    ``ENABLE_THIRD_PARTY_AUTH`` to ``true`` (it is ``false`` by default).
 
 #. If necessary, make sure that the correct backend is specified.
 
    * If you are using Google, Facebook, LinkedIn, or Active Directory, open the
-     ``lms.yaml`` file and look for the ``THIRD_PARTY_AUTH_BACKENDS`` list.
+     ``lms.yml`` file and look for the ``THIRD_PARTY_AUTH_BACKENDS`` list.
      By default, the file does not contain this list.
 
-     If the ``lms.yaml`` file does not contain the
+     If the ``lms.yml`` file does not contain the
      ``THIRD_PARTY_AUTH_BACKENDS`` list, you do not have to complete any
      additional steps.
 
-     If the ``lms.yaml`` file contains the ``THIRD_PARTY_AUTH_BACKENDS``
+     If the ``lms.yml`` file contains the ``THIRD_PARTY_AUTH_BACKENDS``
      list, add the backend for the applicable IdP to the list.
 
        * For Google, add ``"social_core.backends.google.GoogleOAuth2"``.
@@ -232,13 +232,13 @@ Configuring Open edX is very similar for Google, Facebook, LinkedIn, and Azure.
           ``"social_core.backends.azuread.AzureADOAuth2"``.
 
    * If you are using a custom backend, add the applicable OAuth2 provider to
-     the ``THIRD_PARTY_AUTH_BACKENDS`` list in the ``lms.yaml`` file. If
+     the ``THIRD_PARTY_AUTH_BACKENDS`` list in the ``lms.yml`` file. If
      the file does not contain the ``THIRD_PARTY_AUTH_BACKENDS`` list, create
      the list, and then add the OAuth2 provider.
 
    For more information, see the `AWS template file`_ file in GitHub.
 
-#. In the ``lms.yaml`` file, add the client secret. To do this, create the
+#. In the ``lms.yml`` file, add the client secret. To do this, create the
    ``SOCIAL_AUTH_OAUTH_SECRETS`` key if the key does not already exist, and
    then add the appropriate value for your IdP.
 
@@ -330,7 +330,7 @@ Add the Provider Configuration
 #. For **Client ID**, enter the client ID that you noted earlier.
 
 #. Leave **Client Secret** blank. Open edX sets the secret through
-   ``lms.yaml``, which is more secure.
+   ``lms.yml``, which is more secure.
 
 #. (Optional) If you want Facebook or LinkedIn to provide the user's email
    address during registration, enter the following code into **Other
@@ -368,7 +368,7 @@ in.
    ``'unicode' object has no attribute 'get'``
 
   To resolve this problem, make sure that this setting does not appear multiple
-  times in the ``lms.yaml`` file.
+  times in the ``lms.yml`` file.
 
 .. _Additional Providers:
 
@@ -383,7 +383,7 @@ OAuth2 standard to the Open edX platform. To do this, follow these steps.
  OAuth1 providers are also supported and can be configured using these same
  steps. However, OAuth2 is preferred over OAuth1 wherever possible.
 
-#. In ``lms.yaml``, change the value of ``FEATURES`` >
+#. In ``lms.yml``, change the value of ``FEATURES`` >
    ``ENABLE_THIRD_PARTY_AUTH`` to ``true`` (it is ``false`` by default).
 
 #. Install the python-social-auth authentication backend specific to
@@ -411,7 +411,7 @@ OAuth2 standard to the Open edX platform. To do this, follow these steps.
 #. Enable the python-social-auth authentication backend specific to that
    provider:
 
-   #. In the ``THIRD_PARTY_AUTH_BACKENDS`` setting in ``lms.yaml``, add the
+   #. In the ``THIRD_PARTY_AUTH_BACKENDS`` setting in ``lms.yml``, add the
       full path of the module to the list.
 
    #. (optional) Set the value of ``THIRD_PARTY_AUTH_BACKENDS`` to match `the
@@ -420,7 +420,7 @@ OAuth2 standard to the Open edX platform. To do this, follow these steps.
 
 #. Obtain a client ID and client secret from the provider.
 
-#. Add the client secret to ``lms.yaml``. To do this, create a new key
+#. Add the client secret to ``lms.yml``. To do this, create a new key
    called ``SOCIAL_AUTH_OAUTH_SECRETS`` if it doesn't already exist, and then
    add the backend name to that key as follows.
 
@@ -460,7 +460,7 @@ OAuth2 standard to the Open edX platform. To do this, follow these steps.
 #. For **Client ID**, enter the client ID that you noted earlier.
 
 #. Leave **Client Secret** blank. Open edX sets the secret through
-   ``lms.yaml``, which is more secure.
+   ``lms.yml``, which is more secure.
 
 #. Select **Save**.
 

--- a/en_us/install_operations/source/configuration/transcripts.rst
+++ b/en_us/install_operations/source/configuration/transcripts.rst
@@ -28,13 +28,13 @@ Configuring the Transcript Feature Flag
   Platform`.
 
 To set the ``FALLBACK_TO_ENGLISH_TRANSCRIPTS`` feature flag, you modify the
-``lms.yml`` and ``studio.yaml`` files, which are located one level above 
+``lms.yml`` and ``studio.yml`` files, which are located one level above 
 the ``edx-platform`` directory.
 
-#. In the ``lms.yml`` and ``studio.yaml`` files, in the ``FEATURES``
+#. In the ``lms.yml`` and ``studio.yml`` files, in the ``FEATURES``
    dictionary, change the value of ``FALLBACK_TO_ENGLISH_TRANSCRIPTS`` to
    ``FALSE``.
 
-#. Save the ``lms.yml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/transcripts.rst
+++ b/en_us/install_operations/source/configuration/transcripts.rst
@@ -28,13 +28,13 @@ Configuring the Transcript Feature Flag
   Platform`.
 
 To set the ``FALLBACK_TO_ENGLISH_TRANSCRIPTS`` feature flag, you modify the
-``lms.yaml`` and ``studio.yaml`` files, which are located one level above 
+``lms.yml`` and ``studio.yaml`` files, which are located one level above 
 the ``edx-platform`` directory.
 
-#. In the ``lms.yaml`` and ``studio.yaml`` files, in the ``FEATURES``
+#. In the ``lms.yml`` and ``studio.yaml`` files, in the ``FEATURES``
    dictionary, change the value of ``FALLBACK_TO_ENGLISH_TRANSCRIPTS`` to
    ``FALSE``.
 
-#. Save the ``lms.yaml`` and ``studio.yaml`` files.
+#. Save the ``lms.yml`` and ``studio.yaml`` files.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/user_retire/service_setup.rst
+++ b/en_us/install_operations/source/configuration/user_retire/service_setup.rst
@@ -80,7 +80,7 @@ at the end of the list.  Also, for every ``RETIRING_foo`` state, there must be
 a corresponding ``foo_COMPLETE`` state.
 
 Override these states if you need to add any states.  Typically, these 
-settings are set in ``lms.envs.json``.
+settings are set in ``lms.yml``.
 
 After you have defined any custom states, populate the states table with the 
 following management command:

--- a/en_us/install_operations/source/configuration/youtube_api.rst
+++ b/en_us/install_operations/source/configuration/youtube_api.rst
@@ -103,7 +103,7 @@ steps.
    ``/edx/app/edxapp/edx-platform``.
 
 #. In the directory *above* your repository, there should be several JSON
-   files, including ``lms.yml`` and ``studio.yaml``. If you are running
+   files, including ``lms.yml`` and ``studio.yml``. If you are running
    devstack or fullstack, the directory is ``/edx/app/edxapp``.
 
 #. Open the ``lms.yml`` file in your text editor.
@@ -117,7 +117,7 @@ steps.
 
 #. Save and close the file.
 
-#. Open the ``studio.yaml`` file and make the same change. If that line does
+#. Open the ``studio.yml`` file and make the same change. If that line does
    not exist in this file, create it.
 
 #. Save and close the file.

--- a/en_us/install_operations/source/configuration/youtube_api.rst
+++ b/en_us/install_operations/source/configuration/youtube_api.rst
@@ -103,10 +103,10 @@ steps.
    ``/edx/app/edxapp/edx-platform``.
 
 #. In the directory *above* your repository, there should be several JSON
-   files, including ``lms.yaml`` and ``studio.yaml``. If you are running
+   files, including ``lms.yml`` and ``studio.yaml``. If you are running
    devstack or fullstack, the directory is ``/edx/app/edxapp``.
 
-#. Open the ``lms.yaml`` file in your text editor.
+#. Open the ``lms.yml`` file in your text editor.
 
 #. Find the line for the YouTube API key.
 

--- a/en_us/install_operations/source/ecommerce/create_products/create_products_overview.rst
+++ b/en_us/install_operations/source/ecommerce/create_products/create_products_overview.rst
@@ -36,7 +36,7 @@ Before you can create a product, you must start the E-Commerce service on your
 site. Follow these steps to start the E-Commerce service.
 
 #. In the ecommerce and LMS configuration files (``/edx/etc/ecommerce.yml`` and
-   ``/edx/app/edxapp/lms.yaml``, respectively), verify the following
+   ``/edx/app/edxapp/lms.yml``, respectively), verify the following
    settings.
 
    .. note::

--- a/en_us/install_operations/source/ecommerce/test_ecommerce.rst
+++ b/en_us/install_operations/source/ecommerce/test_ecommerce.rst
@@ -136,7 +136,7 @@ Configure the LMS
 
 To configure the LMS, follow these steps.
 
-#. Verify that the following settings in ``/edx/app/edxapp/lms.yaml`` are
+#. Verify that the following settings in ``/edx/app/edxapp/lms.yml`` are
    correct. ::
 
        "ECOMMERCE_API_URL": "http://localhost:8002/api/v2/"
@@ -145,7 +145,7 @@ To configure the LMS, follow these steps.
        "OAUTH_ENFORCE_SECURE": false
        "OAUTH_OIDC_ISSUER": "http://127.0.0.1:8000/oauth2"
 
-#. Verify that the following settings in ``/edx/app/edxapp/lms.yaml`` are
+#. Verify that the following settings in ``/edx/app/edxapp/lms.yml`` are
    correct. ::
 
        "ECOMMERCE_API_SIGNING_KEY": "insecure-secret-key" // Must match the E-Commerce JWT_SECRET_KEY setting
@@ -224,17 +224,17 @@ configuring the two courses in your LMS instance.
        sudo su ecommerce
 
 #. Verify that the following keys in ``/edx/etc/ecommerce.yml`` match your
-   settings in ``/edx/app/edxapp/lms.yaml`` and
-   ``/edx/app/edxapp/lms.yaml``.
+   settings in ``/edx/app/edxapp/lms.yml`` and
+   ``/edx/app/edxapp/lms.yml``.
 
    * One of the ``JWT_AUTH:JWT_ISSUERS`` entries should match
-     ``/edx/app/edxapp/lms.yaml:JWT_ISSUER``. The default value is
+     ``/edx/app/edxapp/lms.yml:JWT_ISSUER``. The default value is
      ``http://127.0.0.1:8000/oauth2``.
    * ``JWT_AUTH:JWT_SECRET_KEY`` should match
-     ``/edx/app/edxapp/lms.yaml:ECOMMERCE_API_SIGNING_KEY``. The default
+     ``/edx/app/edxapp/lms.yml:ECOMMERCE_API_SIGNING_KEY``. The default
      value is ``lms-secret``.
    * ``EDX_API_KEY`` should match
-     ``/edx/app/edxapp/lms.yaml:EDX_API_KEY``. The default value is
+     ``/edx/app/edxapp/lms.yml:EDX_API_KEY``. The default value is
      ``PUT_YOUR_API_KEY_HERE``.
 
 #. Set up the E-Commerce environment.

--- a/en_us/install_operations/source/mobile.rst
+++ b/en_us/install_operations/source/mobile.rst
@@ -211,7 +211,7 @@ Enable Push Notification on the Server
 
 To enable the push notification feature, follow these steps.
 
-#. In the ``edx/app/edxapp/studio.yaml`` file, add the following lines.
+#. In the ``edx/app/edxapp/studio.yml`` file, add the following lines.
 
    .. code-block:: none
 
@@ -220,7 +220,7 @@ To enable the push notification feature, follow these steps.
       "REST_API_KEY": "{API_key}" 
     }
 
-2. Save the ``edx/app/edxapp/studio.yaml`` file.
+2. Save the ``edx/app/edxapp/studio.yml`` file.
 
 #. Restart the server.
 

--- a/en_us/install_operations/source/mobile.rst
+++ b/en_us/install_operations/source/mobile.rst
@@ -28,7 +28,7 @@ Configuring Mobile Application Features
 *****************************************
 
 For the mobile API and authentication to work correctly with the edX mobile
-applications, you enable them in the ``edx/app/edxapp/lms.yaml`` file. You
+applications, you enable them in the ``edx/app/edxapp/lms.yml`` file. You
 then complete the setup for authentication by creating OAuth clients and
 adding their IDs to the custom configuration file of each mobile application.
 
@@ -36,12 +36,12 @@ adding their IDs to the custom configuration file of each mobile application.
 Enable Mobile Application Features
 ====================================
 
-.. note:: Configuration settings added to the ``lms.yaml`` file are reset
+.. note:: Configuration settings added to the ``lms.yml`` file are reset
  to their default values when you use Ansible to update edx-platform.
 
 To enable the mobile application features, follow these steps.
 
-#. In the ``edx/app/edxapp/lms.yaml`` file, add the following lines to the
+#. In the ``edx/app/edxapp/lms.yml`` file, add the following lines to the
    features section.
 
    .. code-block:: none
@@ -57,7 +57,7 @@ To enable the mobile application features, follow these steps.
   ``"OAUTH_ENFORCE_SECURE": false``. This configuration setting should never be
   set to ``false`` in anything other than a development environment.
 
-#. Save the ``edx/app/edxapp/lms.yaml`` file.
+#. Save the ``edx/app/edxapp/lms.yml`` file.
 
 #. Restart the server.
 
@@ -145,12 +145,12 @@ must log in again.
 The ``lms/envs/common.py`` file includes the default configuration settings for
 the number of days before OAuth tokens expire for confidential clients and
 public clients. Instead of modifying the defaults in ``lms/envs/common.py``, add
-the configuration settings to the ``lms.yaml`` file and set values that will
+the configuration settings to the ``lms.yml`` file and set values that will
 override the default settings.
 
 To configure the number of days before OAuth tokens expire, follow these steps.
 
-#. In the ``edx/app/edxapp/lms.yaml`` file, add the following lines to
+#. In the ``edx/app/edxapp/lms.yml`` file, add the following lines to
    specify the number of days that OAuth tokens remain valid for confidential
    or public clients.
 
@@ -163,9 +163,9 @@ To configure the number of days before OAuth tokens expire, follow these steps.
       "OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS" : 365
       "OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS" : 30
 
-#. Save the ``lms.yaml`` file, then restart the edxapp app.
+#. Save the ``lms.yml`` file, then restart the edxapp app.
 
-   The values that you defined in ``lms.yaml`` override the default
+   The values that you defined in ``lms.yml`` override the default
    values defined in ``lms/envs/common.py``.
 
 

--- a/en_us/open_edx_release_notes/source/CSMHE/migration_options.rst
+++ b/en_us/open_edx_release_notes/source/CSMHE/migration_options.rst
@@ -30,9 +30,9 @@ data. An outline of the steps you need to complete follows.
 
 #. Create the ``edxapp_csmh`` database.
 
-#. Update ``lms.yaml`` with a new entry in the DATABASES section.
+#. Update ``lms.yml`` with a new entry in the DATABASES section.
 
-#. Update ``lms.yaml`` to set ``"ENABLE_CSMH_EXTENDED": true``. Leave
+#. Update ``lms.yml`` to set ``"ENABLE_CSMH_EXTENDED": true``. Leave
    ``"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": true``.
 
 #. Run django migrations to generate the new table.
@@ -67,7 +67,7 @@ be running the release branch of edx-platform.
 
 Reprovisioning adds the ``edxapp_csmh`` database and its
 ``coursewarehistoryextended_studentmodulehistoryextended`` table. The
-``lms.yaml`` feature flags that control use of the
+``lms.yml`` feature flags that control use of the
 ``coursewarehistoryextended_studentmodulehistoryextended`` table have the
 following settings.
 
@@ -120,13 +120,13 @@ An outline of the steps you complete follows.
 
 #. Create the ``edxapp_csmh`` database.
 
-#. Update ``lms.yaml`` with a new entry in the DATABASES section.
+#. Update ``lms.yml`` with a new entry in the DATABASES section.
 
-   If you use the edxapp Ansible role to update ``lms.yaml``, the system
+   If you use the edxapp Ansible role to update ``lms.yml``, the system
    automatically merges an update to the ``edxapp_databases`` dictionary in
    `edxapp/defaults/main.yml`_.
 
-#. Update ``lms.yaml`` to set ``"ENABLE_CSMH_EXTENDED": true``.
+#. Update ``lms.yml`` to set ``"ENABLE_CSMH_EXTENDED": true``.
 
 #. Run migrations to create the new database table.
 
@@ -136,7 +136,7 @@ An outline of the steps you complete follows.
 #. Migrate all data from ``courseware_studentmodulehistory`` to
    ``coursewarehistoryextended_studentmodulehistoryextended``.
 
-#. Update ``lms.yaml`` to set
+#. Update ``lms.yml`` to set
    ``"ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES": false``.
 
 #. Truncate ``courseware_studentmodulehistory``.

--- a/en_us/open_edx_release_notes/source/CSMHE/migration_procedures.rst
+++ b/en_us/open_edx_release_notes/source/CSMHE/migration_procedures.rst
@@ -91,12 +91,12 @@ Options for Configuring the Database
 =====================================
 
 After you create the MySQL database and set users up, you update
-``lms.yaml`` to add configuration settings to the DATABASES section. To do
+``lms.yml`` to add configuration settings to the DATABASES section. To do
 so, you can use one of these options.
 
 * Use the `edxapp.yml playbook`_ to update your edxapp instances. If you
   choose to use this playbook, then master after 5 May 2016 will update
-  ``lms.yaml`` to set ``edxapp_databases`` in the DATABASES section for
+  ``lms.yml`` to set ``edxapp_databases`` in the DATABASES section for
   you.
 
   The playbook requires ``EDXAPP_MYSQL_CSMH_DB_NAME``,
@@ -105,7 +105,7 @@ so, you can use one of these options.
   same way that the ``EDXAPP_MYSQL_...`` variables are populated in your
   Ansible overrides.
 
-* Update the DATABASES section in ``lms.yaml`` manually. If you create the
+* Update the DATABASES section in ``lms.yml`` manually. If you create the
   MySQL database yourself, you must use this option. For more information, see
   :ref:`Update DATABASES Manually`.
 
@@ -115,9 +115,9 @@ Update DATABASES Manually
 **************************
 
 If you create the MySQL database yourself, you configure the database by adding
-a clause to the ``lms.yaml`` file.
+a clause to the ``lms.yml`` file.
 
-#. Open the ``edx/app/edxapp/lms.yaml`` file in your text editor.
+#. Open the ``edx/app/edxapp/lms.yml`` file in your text editor.
 
 #. In the DATABASES section, add configuration details for your new database.
    An example follows.
@@ -137,7 +137,7 @@ a clause to the ``lms.yaml`` file.
 Step 3: Enable Writes to the New Table
 *****************************************
 
-Edit the ``lms.yaml`` file to set the ``ENABLE_CSMH_EXTENDED`` feature
+Edit the ``lms.yml`` file to set the ``ENABLE_CSMH_EXTENDED`` feature
 flag.
 
    .. code-block:: bash
@@ -288,7 +288,7 @@ You can then rerun with MINID set to the result of this query.
 Disable Reads from the Old Table
 ====================================
 
-Edit the ``lms.yaml`` file to set the
+Edit the ``lms.yml`` file to set the
 ``ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES`` feature flag.
 
    .. code-block:: bash


### PR DESCRIPTION
Replace all remaining lms/cms json file related reference to lms/studio yml files (d96142d), and make sure the `yaml` files are called `yml` since all the configuration references them as `yml` files.

Some examples:

* https://github.com/edx/configuration/blob/master/playbooks/edxapp.yml#L39-L40
* https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/tasks/service_variant_config.yml#L80

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] @toxinu
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

### Testing

- [x] Ran ./run_tests.sh without warnings or errors *1

*1 Ran the tests and there are warnings/errors, but not related at all to my changes.

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

