### PR TITLE
[SE-2764] Address a few broken links and commands.

### DIFF
--- a/en_us/developers/source/architecture.rst
+++ b/en_us/developers/source/architecture.rst
@@ -72,7 +72,8 @@ open source.
 Course Structure
 ****************
 
-Open edX courses are composed of units called `XBlocks`_. Anyone can write new
+Open edX courses are composed of units called
+:ref:`XBlocks<xblocktutorial:Open edX XBlock Tutorial>`. Anyone can write new
 XBlocks, allowing educators and technologists to extend the set of components
 for their courses. The edX platform also still contains several XModules, the
 precursors to XBlocks. EdX is working to rewrite the existing XModules as
@@ -80,14 +81,16 @@ XBlocks and remove XModules from our code base.
 
 In addition to XBlocks, there are a few ways to extend course behavior:
 
-* The LMS is an `LTI`_ tool consumer. Course authors can embed LTI tools to
-  integrate other learning tools into an Open edX course.
+* The LMS is an :ref:`LTI<partnercoursestaff:LTI Component>` tool consumer.
+  Course authors can embed LTI tools to integrate other learning tools into an
+  Open edX course.
 
 * Problems can use embedded Python code to either present the problem or assess
   the learner’s response. Instructor-written Python code is executed in a
   secure environment called CodeJail.
 
-* JavaScript components can be integrated using `JS Input`_.
+* JavaScript components can be integrated using
+  :ref:`JS Input<Custom JavaScript Applications>`.
 
 * Courses can be exported and imported using OLX (open learning XML), an XML-
   based format for courses.
@@ -179,9 +182,6 @@ like order work flows and coupons.
 .. _Sass: http://sass-lang.com/
 .. _Bourbon framework: http://bourbon.io/
 .. _edx.org: http://edx.org/
-.. _XBlocks: https://open.edx.org/xblocks
-.. _LTI: https://open.edx.org/learning-tools-interoperability
-.. _JS Input: https://open.edx.org/js-input
 .. _Ruby: https://www.ruby-lang.org/en/
 .. _Sinatra: http://www.sinatrarb.com/
 .. _Celery: http://www.celeryproject.org/

--- a/en_us/xblock-tutorial/source/anatomy/javascript.rst
+++ b/en_us/xblock-tutorial/source/anatomy/javascript.rst
@@ -29,7 +29,7 @@ Note the following details about the JavaScript file.
 * The function ``ThumbsBlock`` initializes the XBlock. A JavaScript function to
   initialize the XBlock is required.
 
-  The ``ThumbsBlock`` function maps to the contstructor in the :ref:`XBlock
+* The ``ThumbsBlock`` function maps to the contstructor in the :ref:`XBlock
   Python file <The XBlock Python File>` and provides access to its methods and
   fields.
 

--- a/en_us/xblock-tutorial/source/reusable/create_db.rst
+++ b/en_us/xblock-tutorial/source/reusable/create_db.rst
@@ -21,8 +21,4 @@ database.
 
 #. Enter ``no``.
 
-   .. code-block:: none
-
-      (venv) $ python no
-
 .. confirm ^^


### PR DESCRIPTION
## [OSPR-5059](https://openedx.atlassian.net/browse/OSPR-5059)

This addresses three issues found by our team when running through the docs recently:

1. Fixes three links which no longer worked and were redirected to the marketplace.
2. Corrects a missing bullet point in an unordered list.
3. Corrects a broken command and rephrases how the command is presented to avoid ambiguity.

### Reviewers

- [X] OpenCraft Reviewer: @gabor-boros 
- [ ] edX reviewer TBD.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

