### PR TITLE
Clean up references to deprecated edx-platform import paths

### DIFF
--- a/en_us/developers/source/analytics.rst
+++ b/en_us/developers/source/analytics.rst
@@ -193,7 +193,7 @@ Here is an example of a subclass.
 
 ::
 
-    from track.tests import EventTrackingTestCase
+    from common.djangoapps.track.tests import EventTrackingTestCase
     from openedx.core.lib.tests.assertions.events import assert_event_matches
 
     class MyTestClass(EventTrackingTestCase):

--- a/en_us/install_operations/source/configuration/password.rst
+++ b/en_us/install_operations/source/configuration/password.rst
@@ -33,10 +33,10 @@ under the ``AUTH_PASSWORD_VALIDATORS`` setting::
 
   AUTH_PASSWORD_VALIDATORS:
   -   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
-  -   NAME: util.password_policy_validators.MinimumLengthValidator
+  -   NAME: common.djangoapps.util.password_policy_validators.MinimumLengthValidator
         OPTIONS:
           min_length: 2
-  -   NAME: util.password_policy_validators.MaximumLengthValidator
+  -   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
         OPTIONS:
           max_length: 75
 
@@ -47,10 +47,10 @@ you would set::
 
   AUTH_PASSWORD_VALIDATORS:
   -   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
-  -   NAME: util.password_policy_validators.MinimumLengthValidator
+  -   NAME: common.djangoapps.util.password_policy_validators.MinimumLengthValidator
         OPTIONS:
           min_length: 16
-  -   NAME: util.password_policy_validators.MaximumLengthValidator
+  -   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
         OPTIONS:
           max_length: 256
 

--- a/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_SAML_SP.rst
@@ -159,7 +159,7 @@ explicitly include the ``THIRD_PARTY_AUTH_BACKENDS`` setting.
 
 If you have customized this file and added the ``THIRD_PARTY_AUTH_BACKENDS``
 setting to it, you might need to verify that the
-``third_party_auth.saml.SAMLAuthBackend`` python-social-auth backend class is
+``common.djangoapps.third_party_auth.saml.SAMLAuthBackend`` python-social-auth backend class is
 specified for it. That backend is required before you can add SAML IdPs.
 
 To verify that the SAML authentication backend is loaded on a devstack or


### PR DESCRIPTION
Code within edx-platform djangoapps should be referenced
via its full path. For example,

>    `track.tests`

should now be referenced as:

>    `common.djangoapps.track.tests`.

The old import paths are deprecated.

This is part of the import-shims cleanup, which resulted from the sys.path-hack removal effort. See the [forum post](https://discuss.openedx.org/t/koa-will-change-how-edx-platform-code-is-imported/3610) for details.

I'm keeping track of the list of these PRs on this edx-platform "parent PR": https://github.com/edx/edx-platform/pull/25684