### PR TITLE
add minor info about interpolate_html

### DIFF
--- a/en_us/developers/source/preventing_xss/preventing_xss.rst
+++ b/en_us/developers/source/preventing_xss/preventing_xss.rst
@@ -1411,6 +1411,8 @@ The correct way is to use a variable to store the translation string and use the
     {% trans "Some text {start_link}link text to display{end_link}." as tmsg %}
     {% interpolate_html tmsg start_link='<a href='some-path'>'|safe end_link='</a>'|safe %}
 
+.. Important:: Add ``{% load django_markup %}`` to the top of the file to be able to use ``interpolate_html`` in the file.
+
 In the case of a ``blocktrans`` tag::
 
     ## DO NOT do this


### PR DESCRIPTION
Add minor info on how to use `interpolate_html` in [django-html-interpolation-missing ](https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss.html?#django-html-interpolation-missing) section.
Without this, people may end up facing the following error:

`django.template.exceptions.TemplateSyntaxError: Invalid block tag on line 13: 'interpolate_html', expected 'endblock'. Did you forget to register or load this tag?`