### PR TITLE
Add note that overrides not allowed after grade freeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .project
 .pycharm_helpers/
 .pydevproject
+.vscode
 venv/
 
 ### NFS artifacts

--- a/en_us/shared/subsections/open_response_assessments/Manage_ORA_Assignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/Manage_ORA_Assignment.rst
@@ -161,6 +161,9 @@ Submitting an override assessment has the following results.
    final grade on the assessment is updated to reflect the most recent staff
    override assessment grade.
 
+   Once grades are frozen 30 days after the course end date, you will no longer
+   be able to perform override assessments for learners.
+
 Learners who receive override grades for their submissions see a **Staff
 Assessment** step in their assignments, where they can view the rubric and any
 comments provided in the staff assessments.


### PR DESCRIPTION
## [EDUCATOR-5394](https://openedx.atlassian.net/browse/EDUCATOR-5394)

Updates a note about grade overrides, specifying that grades cannot be overridden after course grades freeze.

### Date Needed (optional)

ASAP, clarifying existing behavior.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Product review: @sapanathomas523
- [ ] Doc team review (sanity check): @edx/doc

FYI: @edx/masters-devs-gta

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

