### PR TITLE
Update native installation link in Koa

### DIFF
--- a/en_us/install_operations/source/platform_releases/koa.rst
+++ b/en_us/install_operations/source/platform_releases/koa.rst
@@ -36,7 +36,7 @@ Installing the Koa Release
 **************************
 
 You can install the Open edX Koa release using either
-`devstack`_ or the `Open edX Native Installation`_ instructions.
+`devstack`_ or the `Open edX Native 20.04 Installation`_ instructions.
 
 Koa releases have git tag names like ``open-release/koa.1``.
 The available names are detailed on the `Open edX Named Releases page`_.

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -229,6 +229,8 @@
 
 .. _Open edX Native Installation: https://openedx.atlassian.net/wiki/x/g4G6C
 
+.. _Open edX Native 20.04 Installation: https://openedx.atlassian.net/l/c/L4sgQNbj
+
 .. _edX Feature Flags: https://openedx.atlassian.net/wiki/spaces/OpenDev/pages/34734726/edX+Feature+Flags
 
 .. THIRD PARTY LINKS


### PR DESCRIPTION
## [DOC-KOA-RELEASE](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/platform_releases/koa.html)

Native installation link in Koa release document is still pointing to outdated 16.04 installation. This PR will update the link to latest 20.04 installation.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

