### PR TITLE
Update ORA feedback field length to 1000 characters

### DIFF
--- a/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
+++ b/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
@@ -319,7 +319,7 @@ Feedback Options
 By default, in peer assessment steps, learners can provide text feedback for
 the entire response, using a single comment field below the entire rubric. You
 can also add a comment field to an individual criterion or to several
-individual criteria. This comment field can contain up to 300 characters.
+individual criteria. This comment field can contain up to 1000 characters.
 
 Comment fields for individual criterion appear below the options for the
 criterion.


### PR DESCRIPTION
## [EDUCATOR-5479](https://openedx.atlassian.net/browse/EDUCATOR-5479)

Update ORA feedback field length to 1000 characters from an old value of 300.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review: @sapanathomas523 
- [ ] Partner support: Vicki Hall

FYI: @edx/masters-devs-gta 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Screenshot (with highlight)

<img width="705" alt="Screen Shot 2021-01-06 at 13 00 01" src="https://user-images.githubusercontent.com/12944465/103803858-2df26280-501f-11eb-9c0a-e51e84fcba3d.png">

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [x] Squash commits

