### PR TITLE
[MST-612] Add new course team facing proctoring features

### DIFF
--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -593,6 +593,8 @@
 
 .. _Technical problems during a proctored exam: https://support.edx.org/hc/en-us/articles/360000205167
 
+.. _Checking Your Onboarding Status and Resetting Your Onboarding Exam: https://support.edx.org/hc/en-us/articles/1500002350902
+
 .. _XQueue: https://github.com/edx/xqueue
 
 .. _edX XQueue repository: https://github.com/edx/xqueue/blob/master/queue

--- a/en_us/shared/course_features/proctored_exams/proctored_managing.rst
+++ b/en_us/shared/course_features/proctored_exams/proctored_managing.rst
@@ -63,6 +63,21 @@ When the proctoring service reviews the learner’s proctored exam results, the
 reviewer takes the special allowance into account.
 
 
+.. _Resuming Proctored Exams in an Error State:
+
+******************************************
+Resuming Proctored Exams in an Error State
+******************************************
+
+If a learner encounters an error while taking a proctored exam and cannot
+continue, their exam attempt can be manually resumed with their answers and
+time remaining saved.
+
+The procedures for allowing learners to resume a proctored exam and a timed
+exam are the same. To allow learners to resume an exam, see :ref:`Resuming
+an Exam in an Error State`.
+
+
 .. _Requests for Retaking a Proctored Exam:
 
 ******************************************
@@ -86,6 +101,61 @@ Manage Technical Problems During a Proctored Exam
 For information about what learners should do if they experience technical
 problems during an exam, see `Technical problems during a proctored exam`_ in
 the edX Help Center.
+
+
+.. _View_Proctortrack_Onboarding_Status:
+
+***********************************
+View Proctortrack Onboarding Status
+***********************************
+
+Proctortrack requires all learners to complete an onboarding process before 
+they take a proctored exam. In the onboarding process, learners download and
+install the necessary client software and verify their identity with 
+Proctortrack. 
+
+.. note::  Onboarding includes a mandatory identity verification step which 
+   establishes an identity baseline with Verificient. This is required to gain
+   access to the first Proctored Exam, and can take 5+ business days for
+   learners to complete. See :ref:`Create a Proctored Exam with Proctortrack`
+   for more information.
+
+To view learners' onboarding status for your course, follow these steps.
+
+#. View the live version of your course.
+
+#. Select **Instructor**, and then select **Special Exams**.
+
+#. Expand **Student Onboarding Status**.
+
+#. Each entry can be filtered by username, email, or type of status. The following
+   statuses are available:
+
+   #. **Not Started**: Learner has not started the onboarding process.
+
+   #. **Setup Started**: Learner has started downloading the proctoring software.
+
+   #. **Proctoring Started**: Learner has started the onboarding exam.
+
+   #. **Submitted**: The onboarding exam attempt has been submitted for review.
+
+   #. **Verified**: The attempt has been verified, and the learner's onboarding status
+      is valid for two years from the last modified date.
+
+   #. **Approved in Another Course**: The learner has an approved onboarding profile in
+      another course, so they are effectively approved in any course for two years from
+      the last modified date. However, they can still complete the onboarding exam in
+      your course if desired.
+
+   #. **Rejected**: The attempt has been rejected, and the learner must retake the
+      onboarding exam.
+
+   #. **Error**: The learner encountered an error while taking the onboarding exam,
+      and their attempt must be reset.
+
+      .. note::  Learners can self-service reset their onboarding exam. See
+         `Checking Your Onboarding Status and Resetting Your Onboarding Exam`_ in
+         the edX Help Center.
 
 
 .. include:: ../../../links/links.rst

--- a/en_us/shared/course_features/timed_exams.rst
+++ b/en_us/shared/course_features/timed_exams.rst
@@ -148,6 +148,41 @@ For proctored exams, the reviewer takes the special allowance for extra time
 into account when the proctoring service reviews the learner’s proctored exam
 results.
 
+.. _Resuming an Exam in an Error State:
+
+**********************************
+Resuming an Exam in an Error State
+**********************************
+
+If a learner encounters an error while taking a timed or proctored exam, you
+can allow them to resume the exam with their answers and time remaining saved.
+
+.. note::
+   This option is only available if a learner's exam attempt is in an **Error**
+   state. This can be seen by following the directions below.
+
+.. note::
+   Onboarding and practice exams can be self-service reset by the learner. See
+   `Checking Your Onboarding Status and Resetting Your Onboarding Exam`_ in the
+   edX Help Center.
+
+To allow a learner to resume a timed or proctored exam attempt, follow these
+steps.
+
+#. View the live version of your course.
+#. Select **Instructor**, and then select **Special Exam**.
+#. Expand **Student Special Exam Attempts**. A list of timed and proctored exam
+   attempts appears.
+#. Search for the learner's username to locate their exam attempts.
+#. In the **Exam Name** column, locate the name of the specific exam for which
+   you are resuming the learner's exam attempt.
+#. In the **Actions** column, click the gear icon (⚙) and select **Resume**.
+   A message displays asking you to confirm that you want to resume the learner's
+   exam attempt.
+#. Select **OK**. The learner's exam attempt status will change from **Error**
+   to **Ready to Resume**, and they will be able to access the exam again.
+
+
 .. _Allow Learners to Retake a Timed Exam:
 
 **************************************************
@@ -171,8 +206,14 @@ To clear a timed or proctored exam attempt, follow these steps.
 #. Search for the learner's username to locate their exam attempts.
 #. In the **Exam Name** column, locate the name of the specific exam for which
    you are cleaning the learner's exam attempt.
-#. In the **Actions** column, select **X**. A message displays asking you
+#. In the **Actions** column, select **Reset**. A message displays asking you
    to confirm that you want to remove the learner's exam attempt.
+
+   .. note::
+      If the learner's exam attempt is in an error state, there will be a gear
+      icon (⚙) in place of the **Reset** button. Click this icon in order
+      to display the **Reset** and **Resume** options. For more information on
+      resuming an exam attempt, see :ref:`Resuming an Exam in an Error State`.
 #. Select **OK**. The learner's exam attempt is removed from the list.
 
 
@@ -203,4 +244,7 @@ affected, and their scores for the exam remain visible on the **Progress** page.
 #. In the **Subsection Visibility** section, select **Hide content after due date**.
 
 #. Select **Save**.
+
+
+.. include:: ../../../links/links.rst
 


### PR DESCRIPTION
## [MST-612](https://openedx.atlassian.net/browse/MST-612)

This update includes documentation for two new features to the instructor dashboard's special exams tab:

1. Resuming exams in an error state
2. Learner onboarding status view

---
![Screen Shot 2021-02-16 at 11 23 30 AM](https://user-images.githubusercontent.com/10442143/108092848-1ad5a800-704b-11eb-8471-72c13c35a8d4.png)
---
![Screen Shot 2021-02-16 at 11 24 00 AM](https://user-images.githubusercontent.com/10442143/108092867-2032f280-704b-11eb-9b48-4fb942c310f1.png)
---
![Screen Shot 2021-02-12 at 10 31 47 AM](https://user-images.githubusercontent.com/10442143/107790286-9cae9400-6d20-11eb-9082-c3a3b23d2575.png)
---
![Screen Shot 2021-03-08 at 11 30 25 AM](https://user-images.githubusercontent.com/10442143/110364697-1715bf80-8012-11eb-8d7e-9b79c2c29fa3.png)
![Screen Shot 2021-03-08 at 11 30 39 AM](https://user-images.githubusercontent.com/10442143/110364705-19781980-8012-11eb-83e3-3b9743a3d60d.png)
---

### Date Needed (optional)

03/10/2021

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @edx/masters-devs-cosmonauts 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

