### PR TITLE
Document the columns in the Bulk Grade Download CSV

### DIFF
--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -428,9 +428,23 @@ To override grades in bulk, follow these steps.
 
 #. Click the **Download Bulk Management** button to download a CSV of subsection assignment grades for this segment of learners.
 
-#. Open the CSV in a data editor like Excel.
+   The CSV contains one row per learner, and the following columns:
 
-#. Fill in the new grade column for the assignment(s) you want to override grades for and save the file.
+   * **username**: The user's username
+   * **student_key**: The user's external university id, if configured
+   * **course_id**: The course id
+   * **track**: The user's enrollment track (i.e. audit, verified, etc.)
+   * **cohort**: The user's assigned cohort, if any
+   
+   In addition, there are five columns per graded subsection. **<id>** is a unique internal identifier for each graded subsection.
+   
+   * **name-<id>**: The name of the subsection
+   * **grade-<id>**: The “effective” grade for the subsection. This is equal to the override grade if there is an override, otherwise it is equal to the “original grade”
+   * **original_grade-<id>**: The grade that the user earned through answering problems and being scored through the LMS
+   * **previous_override-<id>**: The overridden grade (if any) that the learner has received through gradebook grade overrides.
+   * **new_override-<id>**: This column will always be blank. This is where you will enter the user's new grade for the subsection.
+
+#. Fill in the new_override column for the assignment(s) you want to override grades for and save the file.
 
 #. Return to the Gradebook and click on the **Bulk Management** tab.
 

--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -431,8 +431,8 @@ To override grades in bulk, follow these steps.
    The CSV contains one row per learner, and the following columns:
 
    * **username**: The user's username
-   * **student_key**: The user's external university id, if configured
-   * **course_id**: The course id
+   * **student_key**: The user's external university ID, if configured
+   * **course_id**: The course ID
    * **track**: The user's enrollment track (e.g. audit, verified, etc.)
    * **cohort**: The user's assigned cohort, if any
    

--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -433,7 +433,7 @@ To override grades in bulk, follow these steps.
    * **username**: The user's username
    * **student_key**: The user's external university id, if configured
    * **course_id**: The course id
-   * **track**: The user's enrollment track (i.e. audit, verified, etc.)
+   * **track**: The user's enrollment track (e.g. audit, verified, etc.)
    * **cohort**: The user's assigned cohort, if any
    
    In addition, there are five columns per graded subsection. **<id>** is a unique internal identifier for each graded subsection.

--- a/en_us/shared/student_progress/course_grades.rst
+++ b/en_us/shared/student_progress/course_grades.rst
@@ -430,7 +430,7 @@ To override grades in bulk, follow these steps.
 
    The CSV contains one row per learner, and the following columns:
 
-   * **username**: The user's username
+   * **username**: The user's edX username
    * **student_key**: The user's external university ID, if configured
    * **course_id**: The course ID
    * **track**: The user's enrollment track (e.g. audit, verified, etc.)
@@ -441,8 +441,8 @@ To override grades in bulk, follow these steps.
    * **name-<id>**: The name of the subsection
    * **grade-<id>**: The “effective” grade for the subsection. This is equal to the override grade if there is an override, otherwise it is equal to the “original grade”
    * **original_grade-<id>**: The grade that the user earned through answering problems and being scored through the LMS
-   * **previous_override-<id>**: The overridden grade (if any) that the learner has received through gradebook grade overrides.
-   * **new_override-<id>**: This column will always be blank. This is where you will enter the user's new grade for the subsection.
+   * **previous_override-<id>**: The overridden grade (if any) that the learner has received through gradebook grade overrides
+   * **new_override-<id>**: This column will always be blank. This is where you will enter the user's new grade for the subsection
 
 #. Fill in the new_override column for the assignment(s) you want to override grades for and save the file.
 


### PR DESCRIPTION
## [EDUCATOR-5544](https://openedx.atlassian.net/browse/EDUCATOR-5544)

Add  documentation for the contents of the Gradebook Bulk Grade CSV

### Reviewers

- [x] @sapanathomas523 
- [x] @nsprenkle 
- [ ] @muselesscreator 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- https://github.com/edx/edx-documentation/blob/jkantor/bulk-grades/en_us/shared/student_progress/course_grades.rst#override-learner-subsection-scores-in-bulk

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

