### PR TITLE
DEPR-48 Remove all references to deprecated CourseTalk widget

### DIFF
--- a/en_us/install_operations/source/configuration/deprecated_add_course_talk_widget.rst
+++ b/en_us/install_operations/source/configuration/deprecated_add_course_talk_widget.rst
@@ -1,4 +1,8 @@
-.. _Add CourseTalk:
+.. _Add CourseTalk (Deprecated):
+
+################################################
+DEPRECATED: This Is Unavailable in Lilac onwards
+################################################
 
 #############################################
 Adding the CourseTalk Widget

--- a/en_us/install_operations/source/configuration/index.rst
+++ b/en_us/install_operations/source/configuration/index.rst
@@ -15,7 +15,7 @@ configuration options.
    changing_appearance/index
    customize_registration_page
    config_allowed_regis_emails
-   add_coursetalk_widget
+   deprecated_add_course_talk_widget
    edx_search
    enable_badging
    enable_certificates

--- a/en_us/open_edx_release_notes/source/eucalyptus.rst
+++ b/en_us/open_edx_release_notes/source/eucalyptus.rst
@@ -110,7 +110,7 @@ CourseTalk for Course Reviews
 The CourseTalk widget allows learners to post course ratings and reviews that
 then appear on the course's **About** page. When you add the CourseTalk widget
 to an Open edX instance, the widget is enabled for every course on that
-instance. For more information, see :ref:`installation:Add CourseTalk`.
+instance. For more information, see :ref:`installation:Add CourseTalk (Deprecated)`.
 
 ==================================
 Configurable Data Storage Services

--- a/en_us/release_notes/source/2016/documentation/doc_0411_2016.rst
+++ b/en_us/release_notes/source/2016/documentation/doc_0411_2016.rst
@@ -5,7 +5,10 @@ Configuring the CourseTalk Widget
 
 The *Installing, Configuring, and Running the Open edX Platform* guide now
 includes information about the CourseTalk widget. For more information, see
-:ref:`installation:Add CourseTalk`.
+:ref:`installation:Add CourseTalk (Deprecated)`.
+
+     .. note::
+        The CourseTalk widget is deprecated as of the Open edX Lilac release.
 
 ===============
 Enabling Badges

--- a/en_us/shared/set_up_course/studio_add_course_information/creating_about_page.rst
+++ b/en_us/shared/set_up_course/studio_add_course_information/creating_about_page.rst
@@ -19,17 +19,6 @@ before they enroll in the course.
      additional information.
  :width: 600
 
-.. only:: Open_edX
-
-   .. note::
-      If the CourseTalk widget is enabled for your instance of the Open edX
-      platform, the About page for every course also includes the CourseTalk
-      widget. Learners who have enrolled in your course use this widget to
-      write reviews of your course on the **Course** page in the LMS. These
-      reviews are then visible on the course About page. For more information,
-      see :ref:`installation:Add CourseTalk`.
-
-
 You add the contents of your course About page in Studio. For more information,
 see one of the following topics.
 


### PR DESCRIPTION
See https://github.com/edx/edx-platform/pull/25571

## No doc ticket

Remove references to CourseTalk widget which was deleted as part of DEPR-48. See the above PR for more detail.


### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert:  @marcotuts 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

