### PR TITLE
Remove references to "Enable Student-Generated Certificates" option in LMS instructor dashboard

### DIFF
--- a/en_us/shared/student_progress/checking_student_progress.rst
+++ b/en_us/shared/student_progress/checking_student_progress.rst
@@ -99,27 +99,16 @@ For more information about how to specify a day to issue certificates, see
 Allow Learners to Receive Early Certificates
 ============================================
 
-To allow learners to receive certificates before the course end date or before
-they have completed the course, you use the **Enable Student-Generated
-Certificates** setting on the instructor dashboard.
+If the administrator has configured the site correctly (see
+:ref:`installation:Enable Automatic Certificate Generation` in
+*Installing, Configuring, and Running the Open edX Platform*),
+self-paced courses issue certificates to learners as soon as learners
+have completed enough of the course, with a high enough grade, to earn
+a certificate. You do not have to change any settings.
 
-.. note::
-  If the administrator has configured the site correctly (see
-  :ref:`installation:Enable Automatic Certificate Generation` in
-  *Installing, Configuring, and Running the Open edX Platform*),
-  self-paced courses issue certificates to learners as soon as
-  learners have completed enough of the course, with a high enough
-  grade, to earn a certificate. You do not have to change any
-  settings.
-
-#. View the live version of your course.
-
-#. In the LMS, select **Instructor**, and then select **Certificates**.
-
-#. Select **Enable Student-Generated Certificates**.
-
-   To prevent learners from receiving early certificates, select **Disable
-   Student-Generated Certificates**.
+Earlier Open edX versions had an **Enable Student-Generated
+Certificates** option in the LMS instructor dashboard; this option has
+been removed.
 
 .. _Allow Learners to Download Certificates:
 


### PR DESCRIPTION
The "Enable Student-Generated Certificates" option no longer exists in the Certificates tab of the Instructor dashboard in the LMS. Remove the reference to it.

https://github.com/edx/edx-platform/pull/23735 clarified that this option no longer exists. The fact that it is still mentioned in the documentation is a risk to make potential contributors spend time and effort trying to bring it back.