### PR TITLE
fix: Add new event to the event list

### DIFF
--- a/en_us/data/source/internal_data_formats/event_list.rst
+++ b/en_us/data/source/internal_data_formats/event_list.rst
@@ -74,6 +74,8 @@ D, E, F
      - :ref:`certificate_events`
    * - ``edx.certificate.evidence_visited``
      - :ref:`certificate_events`
+   * - ``edx.certificate.revoked``
+     - :ref:`certificate_events`
    * - ``edx.cohort.created``
      - :ref:`student_cohort_events`
    * - ``edx.cohort.creation_requested``


### PR DESCRIPTION
## [MICROBA-1298](https://openedx.atlassian.net/browse/MICROBA-1298)

Add `edx.certificate.revoked` to list of events in `event_list.rst`. This was missed when the event was originally introduced.

### Testing
- [X] Ran ./run_tests.sh without warnings or errors


