### PR TITLE
update documentation: Python 3 as requirement instead of Python 2

### DIFF
--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -1,5 +1,3 @@
-
-
 .. Include this file in any file that includes a non-doc link.
 
 .. EdX Links
@@ -348,7 +346,7 @@
 
 .. _RabbitMQ: http://www.rabbitmq.com/
 
-.. _Download Python: https://www.python.org/download/releases/2.7/
+.. _Download Python: https://www.python.org/downloads/release/python-386/
 
 .. _YouTube Data API v3: https://developers.google.com/youtube/v3/
 

--- a/en_us/xblock-tutorial/source/getting_started/prereqs.rst
+++ b/en_us/xblock-tutorial/source/getting_started/prereqs.rst
@@ -12,11 +12,11 @@ To build an XBlock, you must have the following tools on your computer.
 
 
 ***********
-Python 2.7
+Python 3.8
 ***********
 
 To run the a virtual environment and the XBlock SDK, and to build an XBlock,
-you must have Python 2.7 installed on your computer.
+you must have Python 3.8 installed on your computer.
 
 `Download Python`_ for your operating system and follow the installation
 instructions.
@@ -25,7 +25,7 @@ instructions.
 Git
 ****
 
-EdX repositories, including XBlock and the XBlock SDK, are stored on GitHub. 
+EdX repositories, including XBlock and the XBlock SDK, are stored on GitHub.
 
 To build your own XBlock, and to deploy it later, you must use Git for source
 control.
@@ -39,7 +39,7 @@ A Virtual Environment
 
 It is recommended that you develop your XBlock using a Python virtual
 environment. A virtual environment is a tool to keep the dependencies required
-by different projects in separate places. 
+by different projects in separate places.
 
 With a virtual environment you can manage the requirements of your XBlock in a
 separate location so they do not conflict with requirements of other Python
@@ -48,7 +48,7 @@ applications you might need.
 The instructions and examples in this tutorial use `VirtualEnv`_ and
 `VirtualEnvWrapper`_ to build XBlocks. You can also use `PyEnv`_.
 
-After you have installed Python 2.7, follow the `VirtualEnv Installation`_
+After you have installed Python 3.8, follow the `VirtualEnv Installation`_
 instructions.
 
 For information on creating the virtual environment for your XBlock, see


### PR DESCRIPTION
The documentation about XBlock was outdated. The current version of XBlock uses Python 3.8. However, the documentation was still instructing users to use Python 2.7.