### PR TITLE
Add documentation for enabling Badgr notifications

### DIFF
--- a/en_us/install_operations/source/configuration/enable_badging.rst
+++ b/en_us/install_operations/source/configuration/enable_badging.rst
@@ -240,6 +240,10 @@ which are located one level above the ``edx-platform`` directory.
      ``http://exampleserver.com/issuer/test-issuer``, the issuer slug is
      ``test-issuer``.
 
+   * ``BADGR_ENABLE_NOTIFICATIONS``: Optional boolean setting for enabling
+     email notifications. When set to "True", learners will be notified by email
+     when they earn a badge. Default is "False".
+
      .. code-block:: none
 
        ############## Badgr OpenBadges generation ##############
@@ -250,6 +254,7 @@ which are located one level above the ``edx-platform`` directory.
        # Do not add the trailing slash here.
        BADGR_BASE_URL = "http://localhost:8005"
        BADGR_ISSUER_SLUG = "test-issuer"
+       BADGR_ENABLE_NOTIFICATIONS = True
 
 #. Save the ``lms.yml`` and ``studio.yml`` files.
 


### PR DESCRIPTION
With Badgr v2 API, notification emails for earning badges are
no longer sent to learners by default.

An `edx-platform` patch adds a configuration option to enable/disable
these notifications: https://github.com/edx/edx-platform/pull/28313

This is the accompanying doc patch for the new setting.