### PR TITLE
Lilac support for re-enabling Chrome 92+ iFrame JS dialog/modal creation

### DIFF
--- a/en_us/open_edx_release_notes/source/lilac.rst
+++ b/en_us/open_edx_release_notes/source/lilac.rst
@@ -13,6 +13,15 @@ These are the release notes for the Lilac release, the 12th community release of
  :depth: 1
  :local:
 
+=====================
+Changes since Lilac.1
+=====================
+
+- Chrome 92 suppressed different origin subframe dialog/modal creation via JS, which broke the "Open in New Window" mode of the LTI Component unit as well as ORA unit modals for the Learning MFE. But Google provided an `origin trial`_ which can disable this suppression. A change was added to allow a Lilac Open edx installation using the Learning MFE to specify a token which enables the Chrome origin trial which disables the suppression. To do so, generate a token on this `registration page`_ and provide it as a custom Django setting named: ``CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN``.
+
+.. _origin trial: https://github.com/GoogleChrome/OriginTrials/blob/gh-pages/developer-guide.md
+.. _registration page: https://developer.chrome.com/origintrials/#/registration/-710583578706051071
+
 ===================
 Learner Experiences
 ===================


### PR DESCRIPTION
Added in this PR: https://github.com/edx/edx-platform/pull/28321

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: @nedbat 
- [ ] Subject matter expert: @jnlapierre 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

