### PR TITLE
docs: Remove reference to repo

### DIFF
--- a/utilities/repo-manifest.xml
+++ b/utilities/repo-manifest.xml
@@ -2,7 +2,7 @@
 <manifest>
   <remote  name="github"
            fetch="https://github.com" />
-           
+
   <default revision="master"
            remote="github" />
 
@@ -10,15 +10,14 @@
   <project name="edx/edx-platform" remote="github" path="edx-platform"/>
   <project name="edx/ecommerce" remote="github" path="ecommerce"/>
   <project name="edx/course-discovery" remote="github" path="course-discovery"/>
-  <project name="edx/edx-certificates" remote="github" path="edx-certificates"/>
   <project name="edx/api-manager" remote="github" path="api-manager"/>
 </manifest>
 
 <!-- Instructions
 
-This is a manifest file for the Google Android repo tool. It will clone 
-local copies of multiple git repositories, placing them in at fixed 
-relative file paths. For more information about the repo tool, see 
+This is a manifest file for the Google Android repo tool. It will clone
+local copies of multiple git repositories, placing them in at fixed
+relative file paths. For more information about the repo tool, see
 http://source.android.com/source/developing.html.
 
 To use repo for edX repositories, change to an empty directory and invoke


### PR DESCRIPTION
Remove reference to _edx-certificates_ repo as it has been deprecated and archived

MICROBA-1362 DEPR-160