### PR TITLE
Remove old allowance documentation

### DIFF
--- a/en_us/shared/course_features/proctored_exams/proctored_managing.rst
+++ b/en_us/shared/course_features/proctored_exams/proctored_managing.rst
@@ -31,32 +31,7 @@ exception allowing a personal care assistant in the room.
   If you need to allow more time for the learner, see :ref:`Grant
   Learners More Time for a Timed Exam`.
 
-To make a special policy accommodation for a learner, follow these steps.
-
-#. View the live version of your course.
-
-#. Select **Instructor**, and then select **Special Exams**.
-
-#. Expand **Allowance Section**.
-
-#. Select **Add Allowance**.
-
-   The **Add a New Allowance** dialog box opens.
-
-#. For **Special Exam**, select the subsection that contains the proctored
-   exam.
-
-#. For **Allowance Type**, select **Review Policy Exception**.
-
-#. Add a description of the allowance, such as the following example.
-
-   ``Learner has a disability. Allow one additional person in the room.``
-
-#. For **Username** or **Email**, enter the learner's information.
-
-#. Select **Save**.
-
-Under the new bulk allowance modal, follow these steps to add exceptions in bulk.
+To make a special policy accommodation for learners, follow these steps.
 
 #. View the live version of your course.
 

--- a/en_us/shared/course_features/timed_exams.rst
+++ b/en_us/shared/course_features/timed_exams.rst
@@ -117,34 +117,8 @@ Grant Learners More Time for a Timed or Proctored Exam
   For more information about the grace period setting, see :ref:`Set the Grace
   Period`.
 
-From the instructor dashboard, a course team member can grant a learner
+From the instructor dashboard, a course team member can grant learners
 extra time to complete a timed or proctored exam.
-
-#. View the live version of your course.
-
-#. Select **Instructor**, and then select **Special Exams**.
-
-#. Expand **Allowance Section**.
-
-#. Select **Add Allowance**.
-
-   The **Add a New Allowance** dialog box opens.
-
-#. For **Special Exam**, select the subsection that contains the timed or
-   proctored exam.
-
-#. For **Allowance Type**, select **Additional Time (minutes)**.
-
-#. In the **Additional Time** field, enter the number of extra minutes that you
-   want to grant to the learner.
-
-   .. note:: You must enter a whole number greater than 0.
-
-#. For **Username** or **Email**, enter the learner's information.
-
-#. Select **Save**.
-
-Under the new bulk allowance modal, follow these steps to add exta time in bulk.
 
 #. View the live version of your course.
 


### PR DESCRIPTION
Delete documentation from the old allowance modal as it is not used anymore.

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

