### PR TITLE
docs: added Edx Discovery API docs

### DIFF
--- a/en_us/discovery_api/Makefile
+++ b/en_us/discovery_api/Makefile
@@ -1,0 +1,183 @@
+# Makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+PAPER         ?=
+BUILDDIR      ?= build
+
+# User-friendly check for sphinx-build
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+Q_FLAG        =
+
+ifeq ($(quiet), true)
+Q_FLAG = -Q
+endif
+
+# Internal variables.
+PAPEROPT_a4     = -D latex_paper_size=a4
+PAPEROPT_letter = -D latex_paper_size=letter
+ALLSPHINXOPTS   = $(Q_FLAG) -d $(BUILDDIR)/doctrees -c source $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+# the i18n builder cannot share the environment and doctrees with the others
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  html       to make standalone HTML files"
+	@echo "  dirhtml    to make HTML files named index.html in directories"
+	@echo "  singlehtml to make a single large HTML file"
+	@echo "  pickle     to make pickle files"
+	@echo "  json       to make JSON files"
+	@echo "  htmlhelp   to make HTML files and a HTML help project"
+	@echo "  qthelp     to make HTML files and a qthelp project"
+	@echo "  devhelp    to make HTML files and a Devhelp project"
+	@echo "  epub       to make an epub"
+	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
+	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
+	@echo "  text       to make text files"
+	@echo "  man        to make manual pages"
+	@echo "  texinfo    to make Texinfo files"
+	@echo "  info       to make Texinfo files and run them through makeinfo"
+	@echo "  gettext    to make PO message catalogs"
+	@echo "  changes    to make an overview of all changed/added/deprecated items"
+	@echo "  xml        to make Docutils-native XML files"
+	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
+	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+
+clean:
+	rm -rf $(BUILDDIR)/*
+
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+dirhtml:
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+singlehtml:
+	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
+	@echo
+	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+
+pickle:
+	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
+	@echo
+	@echo "Build finished; now you can process the pickle files."
+
+json:
+	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
+	@echo
+	@echo "Build finished; now you can process the JSON files."
+
+htmlhelp:
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
+	@echo
+	@echo "Build finished; now you can run HTML Help Workshop with the" \
+	      ".hhp project file in $(BUILDDIR)/htmlhelp."
+
+qthelp:
+	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
+	@echo
+	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
+	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/getting_started.qhcp"
+	@echo "To view the help file:"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/getting_started.qhc"
+
+devhelp:
+	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
+	@echo
+	@echo "Build finished."
+	@echo "To view the help file:"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/getting_started"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/getting_started"
+	@echo "# devhelp"
+
+epub:
+	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	@echo
+	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+
+latex:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo
+	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
+	@echo "Run \`make' in that directory to run these through (pdf)latex" \
+	      "(use \`make latexpdf' here to do that automatically)."
+
+latexpdf:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through pdflatex..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+latexpdfja:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through platex and dvipdfmx..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+text:
+	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
+	@echo
+	@echo "Build finished. The text files are in $(BUILDDIR)/text."
+
+man:
+	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	@echo
+	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+
+texinfo:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo
+	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
+	@echo "Run \`make' in that directory to run these through makeinfo" \
+	      "(use \`make info' here to do that automatically)."
+
+info:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo "Running Texinfo files through makeinfo..."
+	make -C $(BUILDDIR)/texinfo info
+	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+
+gettext:
+	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	@echo
+	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+
+changes:
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
+	@echo
+	@echo "The overview file is in $(BUILDDIR)/changes."
+
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	@echo
+	@echo "Link check complete; look for any errors in the above output " \
+	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+doctest:
+	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	@echo "Testing of doctests in the sources finished, look at the " \
+	      "results in $(BUILDDIR)/doctest/output.txt."
+
+xml:
+	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
+	@echo
+	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
+
+pseudoxml:
+	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
+	@echo
+	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/en_us/discovery_api/source/api_reference/reference.rst
+++ b/en_us/discovery_api/source/api_reference/reference.rst
@@ -1,58 +1,66 @@
 .. _Discovery API Reference:
 
-################################
+###########################
 EdX Discovery API Reference
-################################
+###########################
 
 This API reference includes detailed information about the endpoints of the edX
 Discovery API, including the request, response data, and examples. You can use
 any technology to send REST API requests as HTTP messages to the edX API. The
 example API requests shown in this reference use the ``curl`` command-line program
 to show the syntax and data for a request in a way that is easy to read. To view all
-the endpoints hosted by Discovery service go to ``/api-docs/``
+these endpoints hosted by Discovery service go to ``/api-docs/``
 
-*********
+******************
 Taxonomy Endpoints
-*********
+******************
 
-The following endpoints are available in the Discovery API under Taxonomy app.
+The following endpoints are available in Taxonomy app under the Discovery API.
 
-* **/skills** - You can make GET calls to the
-  ``/skills`` endpoint to get all the skills available in the system.
-  see :ref:`skills_list Endpoint`.
-
-* **/skills/{skill_id}** - You can make GET calls to the
-  ``/skills/{skill_id}`` endpoint to get a details of a specified
-  skill For details, see
-  :ref:`skills_detailed Endpoint`.
-
-* **/jobs** - You can make GET calls to the
-  ``/jobs`` endpoint to get all the jobs available in the system.
-  :ref:`jobs_list Endpoint`.
-
-* **/jobs/{job_id}** - You can make GET calls to the
-  ``/jobs/{job_id}`` endpoint to get a details of a specified
-  job For details, see
-  :ref:`jobs_detailed Endpoint`.
-
-* **/jobpostings** - You can make GET calls to the
-  ``/skills`` endpoint to get all the job postings available in the system.
-  :ref:`jobpostings_list Endpoint`.
-
-* **/jobpostings/{jobpostings_id}** - You can make GET calls to the
-  ``/jobpostings/{jobpostings_id}`` endpoint to get a details of a specified
-  job postings For details, see
-  :ref:`jobpostings_detailed Endpoint`.
+* **/skills**
+    Skills are extracted by text processing provided in course
+    full description. These skills are linked with the relevant courses. You can
+    make GET calls to the ``/skills`` endpoint to get all the skills available
+    in the system. See :ref:`skills_list Endpoint` for more details.
 
 
+* **/skills/{skill_id}**
+    You can make GET calls to the ``/skills/{skill_id}``
+    endpoint to get details for a specified skill. For details, see
+    :ref:`skills_detailed Endpoint`.
 
-=====================
+
+* **/jobs**
+    We also collect and save the data about `jobs` that are related to
+    `skills`. We extract this imformation using third party tools and services.
+    Jobs are linked with the skills that can help the learners to those jobs in
+    the market. You can make GET calls to the ``/jobs`` endpoint to get all the jobs.
+    See, :ref:`jobs_list Endpoint` for more details.
+
+* **/jobs/{job_id}**
+    You can make GET calls to the ``/jobs/{job_id}`` endpoint to get details of
+    a specified job. For details, see :ref:`jobs_detailed Endpoint`.
+
+* **/jobpostings**
+    JobPostings is information about the number of job postings available in market,
+    median salary and companies offering the job, etc. You can make GET calls to
+    the ``/jobpostings`` endpoint to get all the job postings
+    available in the system. See :ref:`jobpostings_list Endpoint` for more details.
+
+* **/jobpostings/{jobpostings_id}**
+    You can make GET calls to the ``/jobpostings/{jobpostings_id}`` endpoint to get
+    details of a specified JobPostings object. For details,
+    see :ref:`jobpostings_detailed Endpoint`.
+
+
+
+==================================
 Taxonomy Endpoints Response layout
-=====================
+==================================
 
 Responses to GET requests for the edX Discovery API frequently contain
 the ``results`` response value. The ``results`` response value is a variable
-that represents the intended object from the GET request. here is the details.
+that represents the intended object from the GET request. Here are the details.
 
 
 .. list-table::
@@ -64,7 +72,7 @@ that represents the intended object from the GET request. here is the details.
      - Description
    * - ``count``
      - integer
-     - The number of objects in our system.
+     - The number of objects in the system.
    * - ``next``
      - string
      - The URL for the next page of results.
@@ -81,9 +89,9 @@ See :ref:`skills<skills Fields>` for information about the fields in a skill ite
 
 .. _skills_list Endpoint:
 
-*****************************************
+********************
 Skills List Endpoint
-*****************************************
+********************
 
 GET calls to ``/skills`` endpoint return a list of all the available skills in the system.
 
@@ -101,22 +109,22 @@ Method and Endpoint
      - ``/taxonomy/api/v1/skills/``
 
 
-=====================
+===============
 Example Request
-=====================
+===============
 ::
 
    curl -X GET \
    https://discovery.edx.org/taxonomy/api/v1/skills/ \
    -H "Authorization: JWT {access token}"
 
-=====================
+==========
 Parameters
-=====================
+==========
 
 You can use an optional ``page_size`` parameter to specify the number of
-records you want to load in a single page. if you will not specify the
-`page_size` it will take 20 as default. For example:
+records you want to load in a single page. If not provided the default of
+20 is used for `page_size`. For example:
 
 ::
 
@@ -128,12 +136,11 @@ records you want to load in a single page. if you will not specify the
 
 .. _skills_detailed Endpoint:
 
-*********************************************************************
+**************************
 skills/{skill_id} Endpoint
-*********************************************************************
+**************************
 
-GET calls to the ``skills/{skill_id}``
-endpoint return information about a single skill.
+GET call to the ``skills/{skill_id}`` endpoint returns information about a single skill.
 In the GET call, The information returned is described in
 :ref:`Skill Fields <skills Fields>`.
 
@@ -150,9 +157,9 @@ Method and Endpoint
    * - GET
      - ``/taxonomy/api/v1/skills/{skill_id}``
 
-=====================
+===============
 Example Request
-=====================
+===============
 ::
 
    curl -X GET \
@@ -160,18 +167,18 @@ Example Request
    -H "Authorization: JWT {access token}"
 
 
-=====================
+===============
 Response Values
-=====================
+===============
 
 The ``GET https://discovery.edx.org/taxonomy/api/v1/skills/{skill_id}``
 request returns the response values described in :ref:`Skill Fields <skills Fields>`.
 
 .. _skills Fields:
 
-====================================
+=================
 Fields in a Skill
-====================================
+=================
 
 
 .. list-table::
@@ -207,10 +214,10 @@ Fields in a Skill
      - object modified time. Example: "2021-02-23T11:01:08.164127Z".
    * - ``external_id``
      - string
-     - An identifier for the object in EMSI system. Example: "KS122LN6CLX3P61KWSP2".
+     - An identifier for the skill in the source system. Example: "KS122LN6CLX3P61KWSP2".
    * - ``info_url``
      - string
-     - URL to get more details for skill from EMSI.
+     - URL to get more details for skill from the source.
    * - ``type_id``
      - string
      - Skill type id, Example: "ST1"
@@ -219,9 +226,9 @@ Fields in a Skill
      - Skill type name, Example: "Hard Skill"
 
 
-=======================================================
+================================================
 Example Response Showing Information skills list
-=======================================================
+================================================
 
 The following example response shows a skills list response for 3 page_size.
 
@@ -357,11 +364,11 @@ The following example response shows a skills list response for 3 page_size.
 
 .. _jobs_list Endpoint:
 
-*****************************************
+******************
 Jobs List Endpoint
-*****************************************
+******************
 
-GET calls to ``/jobs`` endpoint return a list of all the available jobs in the system.
+GET call to ``/jobs`` endpoint returns a list of all the available jobs in the system.
 
 ===================
 Method and Endpoint
@@ -377,22 +384,22 @@ Method and Endpoint
      - ``/taxonomy/api/v1/jobs/``
 
 
-=====================
+===============
 Example Request
-=====================
+===============
 ::
 
    curl -X GET \
    https://discovery.edx.org/taxonomy/api/v1/jobs/ \
    -H "Authorization: JWT {access token}"
 
-=====================
+==========
 Parameters
-=====================
+==========
 
 You can use an optional ``page_size`` parameter to specify the number of
-records you want to load in a single page. if you will not specify the
-`page_size` it will take 20 as default. For example:
+records you want to load in a single page. If not provided the default of
+20 is used for `page_size`. For example:
 
 ::
 
@@ -404,12 +411,12 @@ records you want to load in a single page. if you will not specify the
 
 .. _jobs_detailed Endpoint:
 
-*********************************************************************
+**********************
 jobs/{job_id} Endpoint
-*********************************************************************
+**********************
 
-GET calls to the ``jobs/{job_id}``
-endpoint return information about a single job.
+GET call to the ``jobs/{job_id}``
+endpoint returns information about a single job.
 In the GET call, The information returned is described in
 :ref:`Jobs Fields <jobs Fields>`.
 
@@ -426,9 +433,9 @@ Method and Endpoint
    * - GET
      - ``/taxonomy/api/v1/jobs/{job_id}``
 
-=====================
+===============
 Example Request
-=====================
+===============
 ::
 
    curl -X GET \
@@ -436,18 +443,18 @@ Example Request
    -H "Authorization: JWT {access token}"
 
 
-=====================
+===============
 Response Values
-=====================
+===============
 
 The ``GET https://discovery.edx.org/taxonomy/api/v1/jobs/{jobs}``
 request returns the response values described in :ref:`Jobs Fields <jobs Fields>`.
 
 .. _jobs Fields:
 
-====================================
+===============
 Fields in a Job
-====================================
+===============
 
 
 .. list-table::
@@ -480,12 +487,12 @@ Fields in a Job
      - object modified time. Example: "2021-02-23T11:01:08.164127Z".
    * - ``external_id``
      - string
-     - An identifier for the object in EMSI system. Example: "ETB716DA673BC8BE08".
+     - An identifier for the job in the source system. Example: "ETB716DA673BC8BE08".
 
 
-=======================================================
+================================================
 Example Response Showing Information Job details
-=======================================================
+================================================
 
 The following example response shows a job detail response.
 
@@ -594,11 +601,11 @@ The following example response shows a job detail response.
 
 .. _jobpostings_list Endpoint:
 
-*****************************************
-Job postings List Endpoint
-*****************************************
+*************************
+JobPostings List Endpoint
+*************************
 
-GET calls to ``/jobpostings`` endpoint return a list of all the available job postings in the system.
+GET calls to ``/jobpostings`` endpoint return a list of all the available JobPostings in the system.
 
 ===================
 Method and Endpoint
@@ -614,22 +621,22 @@ Method and Endpoint
      - ``/taxonomy/api/v1/jobpostings/``
 
 
-=====================
+===============
 Example Request
-=====================
+===============
 ::
 
    curl -X GET \
    https://discovery.edx.org/taxonomy/api/v1/jobpostings/ \
    -H "Authorization: JWT {access token}"
 
-=====================
+==========
 Parameters
-=====================
+==========
 
 You can use an optional ``page_size`` parameter to specify the number of
-records you want to load in a single page. if you will not specify the
-`page_size` it will take 20 as default. For example:
+records you want to load in a single page. If not provided the default of
+20 is used for `page_size`. For example:
 
 ::
 
@@ -641,12 +648,12 @@ records you want to load in a single page. if you will not specify the
 
 .. _jobpostings_detailed Endpoint:
 
-*********************************************************************
+*************************************
 jobpostings/{jobpostings_id} Endpoint
-*********************************************************************
+*************************************
 
-GET calls to the ``jobpostings/{jobpostings_id}``
-endpoint return information about a single JobPostings object.
+GET call to the ``jobpostings/{jobpostings_id}``
+endpoint returns information about a single JobPostings object.
 In the GET call, The information returned is described in
 :ref:`JobsPostings Fields <_JobPostings Fields>`.
 
@@ -663,9 +670,9 @@ Method and Endpoint
    * - GET
      - ``/taxonomy/api/v1/jobpostings/{jobpostings_id}``
 
-=====================
+===============
 Example Request
-=====================
+===============
 ::
 
    curl -X GET \
@@ -673,18 +680,18 @@ Example Request
    -H "Authorization: JWT {access token}"
 
 
-=====================
+===============
 Response Values
-=====================
+===============
 
 The ``GET https://discovery.edx.org/taxonomy/api/v1/jobpostings/{jobpostings_id}``
-request returns the response values described in :ref:`Job Postings Fields <JobPostings Fields>`.
+request returns the response values described in :ref:`JobPostings Fields <JobPostings Fields>`.
 
 .. _JobPostings Fields:
 
-====================================
+==============================
 Fields in a JobPostings Object
-====================================
+==============================
 
 
 .. list-table::
@@ -720,9 +727,9 @@ Fields in a JobPostings Object
      - object modified time. Example: "2021-02-23T11:01:08.164127Z".
 
 
-=======================================================
+================================================
 Example Response Showing Information JobPostings
-=======================================================
+================================================
 
 The following example response shows a JobPostings List response.
 

--- a/en_us/discovery_api/source/api_reference/reference.rst
+++ b/en_us/discovery_api/source/api_reference/reference.rst
@@ -20,7 +20,7 @@ The following endpoints are available in Taxonomy application under the Discover
 * **/skills**
     The ``skills`` are extracted using course's full description by third party tools
     and services. Skills are linked with courses to help learners choose their courses
-    their for desired skills. You can make GET calls to the ``/skills`` endpoint to get
+    for their desired skills. You can make GET calls to the ``/skills`` endpoint to get
     all the skills available in the system. See :ref:`skills_list Endpoint` for more details.
 
 

--- a/en_us/discovery_api/source/api_reference/reference.rst
+++ b/en_us/discovery_api/source/api_reference/reference.rst
@@ -1,0 +1,785 @@
+.. _Discovery API Reference:
+
+################################
+EdX Discovery API Reference
+################################
+
+This API reference includes detailed information about the endpoints of the edX
+Discovery API, including the request, response data, and examples. You can use
+any technology to send REST API requests as HTTP messages to the edX API. The
+example API requests shown in this reference use the ``curl`` command-line program
+to show the syntax and data for a request in a way that is easy to read. To view all
+the endpoints hosted by Discovery service go to ``/api-docs/``
+
+*********
+Taxonomy Endpoints
+*********
+
+The following endpoints are available in the Discovery API under Taxonomy app.
+
+* **/skills** - You can make GET calls to the
+  ``/skills`` endpoint to get all the skills available in the system.
+  see :ref:`skills_list Endpoint`.
+
+* **/skills/{skill_id}** - You can make GET calls to the
+  ``/skills/{skill_id}`` endpoint to get a details of a specified
+  skill For details, see
+  :ref:`skills_detailed Endpoint`.
+
+* **/jobs** - You can make GET calls to the
+  ``/jobs`` endpoint to get all the jobs available in the system.
+  :ref:`jobs_list Endpoint`.
+
+* **/jobs/{job_id}** - You can make GET calls to the
+  ``/jobs/{job_id}`` endpoint to get a details of a specified
+  job For details, see
+  :ref:`jobs_detailed Endpoint`.
+
+* **/jobpostings** - You can make GET calls to the
+  ``/skills`` endpoint to get all the job postings available in the system.
+  :ref:`jobpostings_list Endpoint`.
+
+* **/jobpostings/{jobpostings_id}** - You can make GET calls to the
+  ``/jobpostings/{jobpostings_id}`` endpoint to get a details of a specified
+  job postings For details, see
+  :ref:`jobpostings_detailed Endpoint`.
+
+
+
+=====================
+Taxonomy Endpoints Response layout
+=====================
+
+Responses to GET requests for the edX Discovery API frequently contain
+the ``results`` response value. The ``results`` response value is a variable
+that represents the intended object from the GET request. here is the details.
+
+
+.. list-table::
+   :widths: 25 20 80
+   :header-rows: 1
+
+   * - Field
+     - Data Type
+     - Description
+   * - ``count``
+     - integer
+     - The number of objects in our system.
+   * - ``next``
+     - string
+     - The URL for the next page of results.
+   * - ``previous``
+     - string
+     - The URL for the previous page of results.
+   * - ``results``
+     - array
+     - A list of objects of relative data.
+
+For example in :ref:`skills_list Endpoint` Each top-level object in the ``results`` array represents a skill.
+See :ref:`skills<skills Fields>` for information about the fields in a skill item in the ``results``.
+
+
+.. _skills_list Endpoint:
+
+*****************************************
+Skills List Endpoint
+*****************************************
+
+GET calls to ``/skills`` endpoint return a list of all the available skills in the system.
+
+===================
+Method and Endpoint
+===================
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Method
+     - Endpoint
+   * - GET
+     - ``/taxonomy/api/v1/skills/``
+
+
+=====================
+Example Request
+=====================
+::
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/skills/ \
+   -H "Authorization: JWT {access token}"
+
+=====================
+Parameters
+=====================
+
+You can use an optional ``page_size`` parameter to specify the number of
+records you want to load in a single page. if you will not specify the
+`page_size` it will take 20 as default. For example:
+
+::
+
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/skills/?page_size=10 \
+   -H "Authorization: JWT {access token}"
+
+
+.. _skills_detailed Endpoint:
+
+*********************************************************************
+skills/{skill_id} Endpoint
+*********************************************************************
+
+GET calls to the ``skills/{skill_id}``
+endpoint return information about a single skill.
+In the GET call, The information returned is described in
+:ref:`Skill Fields <skills Fields>`.
+
+===================
+Method and Endpoint
+===================
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Method
+     - Endpoint
+   * - GET
+     - ``/taxonomy/api/v1/skills/{skill_id}``
+
+=====================
+Example Request
+=====================
+::
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/skills/14 \
+   -H "Authorization: JWT {access token}"
+
+
+=====================
+Response Values
+=====================
+
+The ``GET https://discovery.edx.org/taxonomy/api/v1/skills/{skill_id}``
+request returns the response values described in :ref:`Skill Fields <skills Fields>`.
+
+.. _skills Fields:
+
+====================================
+Fields in a Skill
+====================================
+
+
+.. list-table::
+   :widths: 25 20 80
+   :header-rows: 1
+
+   * - Field
+     - Data Type
+     - Description
+   * - ``id``
+     - integer
+     - Unique identifier in edx system. It is Used to get detailed views.
+   * - ``name``
+     - string
+     - Skill title
+   * - ``description``
+     - string
+     - Skill short description
+   * - ``courses``
+     - array
+     - A list of all the courses relevant to the skill.
+   * - ``course_key``
+     - string
+     - Course unique identifier in edx system. Example: "TUMx+QPLS4x".
+   * - ``confidence``
+     - float
+     - Represents the relevance the skill to course. It's value ranges from 0 to 1.
+   * - ``created``
+     - string
+     - object creation time. Example: "2021-02-23T11:01:08.164127Z".
+   * - ``modified``
+     - string
+     - object modified time. Example: "2021-02-23T11:01:08.164127Z".
+   * - ``external_id``
+     - string
+     - An identifier for the object in EMSI system. Example: "KS122LN6CLX3P61KWSP2".
+   * - ``info_url``
+     - string
+     - URL to get more details for skill from EMSI.
+   * - ``type_id``
+     - string
+     - Skill type id, Example: "ST1"
+   * - ``type_name``
+     - string
+     - Skill type name, Example: "Hard Skill"
+
+
+=======================================================
+Example Response Showing Information skills list
+=======================================================
+
+The following example response shows a skills list response for 3 page_size.
+
+::
+
+      {
+      "count": 3522,
+      "next": "https://discovery.edx.org/taxonomy/api/v1/skills/?page=2&page_size=3",
+      "previous": null,
+      "results": [
+        {
+          "id": 124,
+          "courses": [
+            {
+              "course_key": "TUMx+QPLS4x",
+              "confidence": 1
+            },
+            {
+              "course_key": "BerkeleyX+BUSADM466.3x",
+              "confidence": 1
+            },
+            {
+              "course_key": "TUMx+QEMx",
+              "confidence": 1
+            },
+            {
+              "course_key": "IIMBx+MK102x",
+              "confidence": 1
+            },
+            {
+              "course_key": "KyotoUx+008x",
+              "confidence": 1
+            },
+            {
+              "course_key": "LinuxFoundationX+LFS163x",
+              "confidence": 1
+            },
+            {
+              "course_key": "QueensX+QBUS502x",
+              "confidence": 1
+            },
+            {
+              "course_key": "QueensX+QBUS503x",
+              "confidence": 1
+            },
+            {
+              "course_key": "TecdeMonterreyX+DCRx",
+              "confidence": 1
+            },
+            {
+              "course_key": "logycaX+ECLLM002",
+              "confidence": 1
+            }
+          ],
+          "created": "2021-02-23T11:01:08.164127Z",
+          "modified": "2021-04-21T07:09:24.779053Z",
+          "external_id": "KS122LN6CLX3P61KWSP2",
+          "name": "Customer Satisfaction",
+          "description": "Customer satisfaction is a term frequently used in marketing. It is a measure of how products and services supplied by a company meet or surpass customer expectation. Customer satisfaction is defined as \"the number of customers, or percentage of total customers, whose reported experience with a firm, its products, or its services (ratings) exceeds specified satisfaction goals.\" Customers play an important role and are essential in keeping a product or service relevant so it is in the best interest of the business to ensure customer satisfaction, and build customer loyalty.",
+          "info_url": "https://skills.emsidata.com/skills/KS122LN6CLX3P61KWSP2",
+          "type_id": "ST1",
+          "type_name": "Hard Skill"
+        },
+        {
+          "id": 125,
+          "courses": [
+            {
+              "course_key": "TUMx+QPLS4x",
+              "confidence": 1
+            }
+          ],
+          "created": "2021-02-23T11:01:08.229934Z",
+          "modified": "2021-04-21T07:09:24.812122Z",
+          "external_id": "KS127CR6S5TQJVYMG3HB",
+          "name": "Operational Excellence",
+          "description": "Operational excellence of an organization is the execution of its operations in an excellent way. Given two commercial companies with the same strategy, the operationally more excellent company will in general have better operational results, creating value for customers and shareholders. The term can be explained and applied in many ways, and is popular with management.",
+          "info_url": "https://skills.emsidata.com/skills/KS127CR6S5TQJVYMG3HB",
+          "type_id": "ST1",
+          "type_name": "Hard Skill"
+        },
+        {
+          "id": 126,
+          "courses": [
+            {
+              "course_key": "TUMx+QPLS4x",
+              "confidence": 1
+            },
+            {
+              "course_key": "UC3Mx+IM.1x",
+              "confidence": 1
+            },
+            {
+              "course_key": "USMx+CC607x",
+              "confidence": 1
+            },
+            {
+              "course_key": "Microsoft+DAT227x",
+              "confidence": 1
+            },
+            {
+              "course_key": "USMx+BUMM621",
+              "confidence": 1
+            },
+            {
+              "course_key": "WitsX+DTx",
+              "confidence": 1
+            },
+            {
+              "course_key": "USMx+DIGITAL01",
+              "confidence": 1
+            },
+            {
+              "course_key": "UTAustin_BUx+LDSCTx",
+              "confidence": 1
+            },
+            {
+              "course_key": "State-Bank-of-India+SBIIT002x",
+              "confidence": 1
+            }
+          ],
+          "created": "2021-02-23T11:01:08.277514Z",
+          "modified": "2021-04-21T07:09:24.844532Z",
+          "external_id": "KS1218Y74WJ6YV4KH0DM",
+          "name": "Business Process",
+          "description": "A business process, business method or business function is a collection of related, structured activities or tasks by people or equipment in which a specific sequence produces a service or product for a particular customer or customers. Business processes occur at all organizational levels and may or may not be visible to the customers. A business process may often be visualized (modeled) as a flowchart of a sequence of activities with interleaving decision points or as a process matrix of a sequence of activities with relevance rules based on data in the process. The benefits of using business processes include improved customer satisfaction and improved agility for reacting to rapid market change. Process-oriented organizations break down the barriers of structural departments and try to avoid functional silos.",
+          "info_url": "https://skills.emsidata.com/skills/KS1218Y74WJ6YV4KH0DM",
+          "type_id": "ST1",
+          "type_name": "Hard Skill"
+        }
+      ]
+    }
+
+
+.. _jobs_list Endpoint:
+
+*****************************************
+Jobs List Endpoint
+*****************************************
+
+GET calls to ``/jobs`` endpoint return a list of all the available jobs in the system.
+
+===================
+Method and Endpoint
+===================
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Method
+     - Endpoint
+   * - GET
+     - ``/taxonomy/api/v1/jobs/``
+
+
+=====================
+Example Request
+=====================
+::
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/jobs/ \
+   -H "Authorization: JWT {access token}"
+
+=====================
+Parameters
+=====================
+
+You can use an optional ``page_size`` parameter to specify the number of
+records you want to load in a single page. if you will not specify the
+`page_size` it will take 20 as default. For example:
+
+::
+
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/jobs/?page_size=10 \
+   -H "Authorization: JWT {access token}"
+
+
+.. _jobs_detailed Endpoint:
+
+*********************************************************************
+jobs/{job_id} Endpoint
+*********************************************************************
+
+GET calls to the ``jobs/{job_id}``
+endpoint return information about a single job.
+In the GET call, The information returned is described in
+:ref:`Jobs Fields <jobs Fields>`.
+
+===================
+Method and Endpoint
+===================
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Method
+     - Endpoint
+   * - GET
+     - ``/taxonomy/api/v1/jobs/{job_id}``
+
+=====================
+Example Request
+=====================
+::
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/jobs/14 \
+   -H "Authorization: JWT {access token}"
+
+
+=====================
+Response Values
+=====================
+
+The ``GET https://discovery.edx.org/taxonomy/api/v1/jobs/{jobs}``
+request returns the response values described in :ref:`Jobs Fields <jobs Fields>`.
+
+.. _jobs Fields:
+
+====================================
+Fields in a Job
+====================================
+
+
+.. list-table::
+   :widths: 25 20 80
+   :header-rows: 1
+
+   * - Field
+     - Data Type
+     - Description
+   * - ``id``
+     - integer
+     - Unique identifier in edx system. It is Used to get detailed views.
+   * - ``name``
+     - string
+     - Job title
+   * - ``skills``
+     - array
+     - A list of all the skills relevant to the job. see :ref:`Skills Fields <Skills Fields>` for skill details.
+   * - ``unique_postings``
+     - integer
+     - Number of unique posting for the job for the particular skill.
+   * - ``significance``
+     - float
+     - Represents the significance of the skill to job. It's value ranges from 0 to 100.
+   * - ``created``
+     - string
+     - object creation time. Example: "2021-02-23T11:01:08.164127Z".
+   * - ``modified``
+     - string
+     - object modified time. Example: "2021-02-23T11:01:08.164127Z".
+   * - ``external_id``
+     - string
+     - An identifier for the object in EMSI system. Example: "ETB716DA673BC8BE08".
+
+
+=======================================================
+Example Response Showing Information Job details
+=======================================================
+
+The following example response shows a job detail response.
+
+::
+
+    {
+      "id": 101,
+      "skills": [
+        {
+          "skill": {
+            "id": 167,
+            "created": "2021-02-26T16:37:21.922596Z",
+            "modified": "2021-03-15T14:28:41.168869Z",
+            "external_id": "KS120HM73ZTBQQFJZY52",
+            "name": "Annuities",
+            "description": "An annuity is a series of payments made at equal intervals. Examples of annuities are regular deposits to a savings account, monthly home mortgage payments, monthly insurance payments and pension payments. Annuities can be classified by the frequency of payment dates. The payments (deposits) may be made weekly, monthly, quarterly, yearly, or at any other regular interval of time. Annuities may be calculated by mathematical functions known as \"annuity functions\".",
+            "info_url": "https://skills.emsidata.com/skills/KS120HM73ZTBQQFJZY52",
+            "type_id": "ST1",
+            "type_name": "Hard Skill"
+          },
+          "significance": 166.0414834976898,
+          "unique_postings": 2986
+        },
+        {
+          "skill": {
+            "id": 181,
+            "created": "2021-02-26T16:49:37.542590Z",
+            "modified": "2021-03-15T14:28:31.605044Z",
+            "external_id": "KS680DR6QC1G86H8NYBK",
+            "name": "Securities (Finance)",
+            "description": "A security is a tradable financial asset. The term commonly refers to any form of financial instrument, but its legal definition varies by jurisdiction. In some countries and languages people commonly use the term \"security\" to refer to any form of financial instrument, even though the underlying legal and regulatory regime may not have such a broad definition. In some jurisdictions the term specifically excludes financial instruments other than equities and fixed-income instruments. In some jurisdictions it includes some instruments that are close to equities and fixed income, e.g., equity warrants.",
+            "info_url": "https://skills.emsidata.com/skills/KS680DR6QC1G86H8NYBK",
+            "type_id": "ST1",
+            "type_name": "Hard Skill"
+          },
+          "significance": 119.89026886137088,
+          "unique_postings": 2987
+        },
+        {
+          "skill": {
+            "id": 159,
+            "created": "2021-02-26T16:28:23.211533Z",
+            "modified": "2021-03-23T17:18:20.511619Z",
+            "external_id": "KS123Y170CZM0V5Z3XXB",
+            "name": "Financial Services",
+            "description": "",
+            "info_url": "https://skills.emsidata.com/skills/KS123Y170CZM0V5Z3XXB",
+            "type_id": "ST1",
+            "type_name": "Hard Skill"
+          },
+          "significance": 52.45900298889593,
+          "unique_postings": 5237
+        },
+        {
+          "skill": {
+            "id": 3446,
+            "created": "2021-03-11T22:09:18.464621Z",
+            "modified": "2021-03-15T14:27:46.046679Z",
+            "external_id": "KS123YS74NRDCKYXNS7Z",
+            "name": "Financial Industry Regulatory Authorities",
+            "description": "",
+            "info_url": "https://skills.emsidata.com/skills/KS123YS74NRDCKYXNS7Z",
+            "type_id": "ST1",
+            "type_name": "Hard Skill"
+          },
+          "significance": 12.739547451804325,
+          "unique_postings": 619
+        },
+        {
+          "skill": {
+            "id": 2334,
+            "created": "2021-03-11T22:04:18.375199Z",
+            "modified": "2021-03-15T14:22:53.139528Z",
+            "external_id": "KS44253607FYTYCJNMPZ",
+            "name": "Workplace Diversity",
+            "description": "",
+            "info_url": "https://skills.emsidata.com/skills/KS44253607FYTYCJNMPZ",
+            "type_id": "ST1",
+            "type_name": "Hard Skill"
+          },
+          "significance": 8.049648490659921,
+          "unique_postings": 229
+        },
+        {
+          "skill": {
+            "id": 183,
+            "created": "2021-02-26T16:49:37.629231Z",
+            "modified": "2021-08-03T06:20:03.927297Z",
+            "external_id": "KS121CX75Q8F638ZCJVZ",
+            "name": "Investments",
+            "description": "To invest is to allocate money in the expectation of some benefit in the future.",
+            "info_url": "https://skills.emsidata.com/skills/KS121CX75Q8F638ZCJVZ",
+            "type_id": "ST1",
+            "type_name": "Hard Skill"
+          },
+          "significance": 6.686575375167631,
+          "unique_postings": 1361
+        }
+      ],
+      "created": "2021-03-01T00:04:39.398313Z",
+      "modified": "2021-03-16T00:04:44.054473Z",
+      "external_id": "ETB716DA673BC8BE08",
+      "name": "Financial Services Representative"
+    }
+
+
+.. _jobpostings_list Endpoint:
+
+*****************************************
+Job postings List Endpoint
+*****************************************
+
+GET calls to ``/jobpostings`` endpoint return a list of all the available job postings in the system.
+
+===================
+Method and Endpoint
+===================
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Method
+     - Endpoint
+   * - GET
+     - ``/taxonomy/api/v1/jobpostings/``
+
+
+=====================
+Example Request
+=====================
+::
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/jobpostings/ \
+   -H "Authorization: JWT {access token}"
+
+=====================
+Parameters
+=====================
+
+You can use an optional ``page_size`` parameter to specify the number of
+records you want to load in a single page. if you will not specify the
+`page_size` it will take 20 as default. For example:
+
+::
+
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/jobpostings/?page_size=10 \
+   -H "Authorization: JWT {access token}"
+
+
+.. _jobpostings_detailed Endpoint:
+
+*********************************************************************
+jobpostings/{jobpostings_id} Endpoint
+*********************************************************************
+
+GET calls to the ``jobpostings/{jobpostings_id}``
+endpoint return information about a single JobPostings object.
+In the GET call, The information returned is described in
+:ref:`JobsPostings Fields <_JobPostings Fields>`.
+
+===================
+Method and Endpoint
+===================
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Method
+     - Endpoint
+   * - GET
+     - ``/taxonomy/api/v1/jobpostings/{jobpostings_id}``
+
+=====================
+Example Request
+=====================
+::
+
+   curl -X GET \
+   https://discovery.edx.org/taxonomy/api/v1/jobpostings/14 \
+   -H "Authorization: JWT {access token}"
+
+
+=====================
+Response Values
+=====================
+
+The ``GET https://discovery.edx.org/taxonomy/api/v1/jobpostings/{jobpostings_id}``
+request returns the response values described in :ref:`Job Postings Fields <JobPostings Fields>`.
+
+.. _JobPostings Fields:
+
+====================================
+Fields in a JobPostings Object
+====================================
+
+
+.. list-table::
+   :widths: 25 20 80
+   :header-rows: 1
+
+   * - Field
+     - Data Type
+     - Description
+   * - ``id``
+     - integer
+     - Unique identifier in edx system. It is Used to get detailed views.
+   * - ``job``
+     - object
+     - The related job object. see :ref:`Jobs Fields <Jobs Fields>` for job details.
+   * - ``median_salary``
+     - integer
+     - Median Salary for the post.
+   * - ``median_posting_duration``
+     - integer
+     - Median posting duration for the post.
+   * - ``unique_postings``
+     - integer
+     - Number of unique posting for the job.
+   * - ``unique_companies``
+     - integer
+     - Number of unique companies offering the post.
+   * - ``created``
+     - string
+     - object creation time. Example: "2021-02-23T11:01:08.164127Z".
+   * - ``modified``
+     - string
+     - object modified time. Example: "2021-02-23T11:01:08.164127Z".
+
+
+=======================================================
+Example Response Showing Information JobPostings
+=======================================================
+
+The following example response shows a JobPostings List response.
+
+::
+
+    {
+      "count": 216,
+      "next": "https://discovery.edx.org/taxonomy/api/v1/jobpostings/?page=6&page_size=3",
+      "previous": "https://discovery.edx.org/taxonomy/api/v1/jobpostings/?page=4&page_size=3",
+      "results": [
+        {
+          "id": 63,
+          "job": {
+            "id": 39,
+            "created": "2021-03-01T00:04:36.457661Z",
+            "modified": "2021-03-16T00:04:43.507558Z",
+            "external_id": "ETD8659FB16C6E7A79",
+            "name": "Team Member"
+          },
+          "created": "2021-03-10T00:04:50.051149Z",
+          "modified": "2021-08-25T00:01:44.399651Z",
+          "median_salary": 26048,
+          "median_posting_duration": 41,
+          "unique_postings": 85538,
+          "unique_companies": 3368
+        },
+        {
+          "id": 64,
+          "job": {
+            "id": 17,
+            "created": "2021-03-01T00:04:35.263889Z",
+            "modified": "2021-03-16T00:04:42.418874Z",
+            "external_id": "ET32340120BB9E6B7C",
+            "name": "Assistant Manager"
+          },
+          "created": "2021-03-10T00:04:50.066938Z",
+          "modified": "2021-08-25T00:01:44.420155Z",
+          "median_salary": 34496,
+          "median_posting_duration": 39,
+          "unique_postings": 85159,
+          "unique_companies": 4068
+        },
+        {
+          "id": 65,
+          "job": {
+            "id": 42,
+            "created": "2021-03-01T00:04:36.613092Z",
+            "modified": "2021-03-16T00:04:42.155163Z",
+            "external_id": "ET6659D06425508C0D",
+            "name": "Maintenance Technician"
+          },
+          "created": "2021-03-10T00:04:50.083016Z",
+          "modified": "2021-08-25T00:01:44.356245Z",
+          "median_salary": 41664,
+          "median_posting_duration": 34,
+          "unique_postings": 91321,
+          "unique_companies": 10701
+        }
+      ]
+    }

--- a/en_us/discovery_api/source/api_reference/reference.rst
+++ b/en_us/discovery_api/source/api_reference/reference.rst
@@ -4,7 +4,7 @@
 EdX Discovery API Reference
 ###########################
 
-This API reference includes detailed information about the endpoints of the edX
+This API reference includes information about the endpoints of the edX
 Discovery API, including the request, response data, and examples. You can use
 any technology to send REST API requests as HTTP messages to the edX API. The
 example API requests shown in this reference use the ``curl`` command-line program
@@ -15,7 +15,7 @@ these endpoints hosted by Discovery service go to ``/api-docs/``
 Taxonomy Endpoints
 ******************
 
-The following endpoints are available in Taxonomy app under the Discovery API.
+The following endpoints are available in Taxonomy application under the Discovery API.
 
 * **/skills**
     Skills are extracted by text processing provided in course
@@ -32,18 +32,18 @@ The following endpoints are available in Taxonomy app under the Discovery API.
 
 * **/jobs**
     We also collect and save the data about `jobs` that are related to
-    `skills`. We extract this imformation using third party tools and services.
-    Jobs are linked with the skills that can help the learners to those jobs in
-    the market. You can make GET calls to the ``/jobs`` endpoint to get all the jobs.
-    See, :ref:`jobs_list Endpoint` for more details.
+    `skills`. We extract this information using third party tools and services.
+    Jobs are linked with the skills to help learners align their career plans
+    with their course work. You can make GET calls to the ``/jobs`` endpoint
+    to get all the jobs. See, :ref:`jobs_list Endpoint` for more details.
 
 * **/jobs/{job_id}**
     You can make GET calls to the ``/jobs/{job_id}`` endpoint to get details of
     a specified job. For details, see :ref:`jobs_detailed Endpoint`.
 
 * **/jobpostings**
-    JobPostings is information about the number of job postings available in market,
-    median salary and companies offering the job, etc. You can make GET calls to
+    JobPostings contains the number of job postings with posting companies and
+    median salary information. You can make GET calls to
     the ``/jobpostings`` endpoint to get all the job postings
     available in the system. See :ref:`jobpostings_list Endpoint` for more details.
 
@@ -226,9 +226,9 @@ Fields in a Skill
      - Skill type name, Example: "Hard Skill"
 
 
-================================================
-Example Response Showing Information skills list
-================================================
+======================================================
+Example Response Showing Information about skills list
+======================================================
 
 The following example response shows a skills list response for 3 page_size.
 
@@ -490,9 +490,9 @@ Fields in a Job
      - An identifier for the job in the source system. Example: "ETB716DA673BC8BE08".
 
 
-================================================
-Example Response Showing Information Job details
-================================================
+======================================================
+Example Response Showing Information about Job details
+======================================================
 
 The following example response shows a job detail response.
 
@@ -727,9 +727,9 @@ Fields in a JobPostings Object
      - object modified time. Example: "2021-02-23T11:01:08.164127Z".
 
 
-================================================
-Example Response Showing Information JobPostings
-================================================
+======================================================
+Example Response Showing Information about JobPostings
+======================================================
 
 The following example response shows a JobPostings List response.
 

--- a/en_us/discovery_api/source/api_reference/reference.rst
+++ b/en_us/discovery_api/source/api_reference/reference.rst
@@ -18,10 +18,10 @@ Taxonomy Endpoints
 The following endpoints are available in Taxonomy application under the Discovery API.
 
 * **/skills**
-    Skills are extracted by text processing provided in course
-    full description. These skills are linked with the relevant courses. You can
-    make GET calls to the ``/skills`` endpoint to get all the skills available
-    in the system. See :ref:`skills_list Endpoint` for more details.
+    The ``skills`` are extracted using course's full description by third party tools
+    and services. Skills are linked with courses to help learners choose their courses
+    their for desired skills. You can make GET calls to the ``/skills`` endpoint to get
+    all the skills available in the system. See :ref:`skills_list Endpoint` for more details.
 
 
 * **/skills/{skill_id}**

--- a/en_us/discovery_api/source/api_reference/reference.rst
+++ b/en_us/discovery_api/source/api_reference/reference.rst
@@ -93,7 +93,7 @@ See :ref:`skills<skills Fields>` for information about the fields in a skill ite
 Skills List Endpoint
 ********************
 
-GET calls to ``/skills`` endpoint return a list of all the available skills in the system.
+GET call to the ``/skills`` endpoint returns a list of all the available skills in the system.
 
 ===================
 Method and Endpoint
@@ -605,7 +605,7 @@ The following example response shows a job detail response.
 JobPostings List Endpoint
 *************************
 
-GET calls to ``/jobpostings`` endpoint return a list of all the available JobPostings in the system.
+GET call to the ``/jobpostings`` endpoint returns a list of all the available JobPostings in the system.
 
 ===================
 Method and Endpoint

--- a/en_us/discovery_api/source/authentication.rst
+++ b/en_us/discovery_api/source/authentication.rst
@@ -1,0 +1,70 @@
+.. _edX API Authentication:
+
+###############################################
+Authenticating as an edX REST Web Service User
+###############################################
+
+API clients must authenticate when they make API requests to the Discovery
+API. Authenticating allows the Discovery API to verify the identity of the
+client and associate that identity with a specific edX for Business customer.
+To use the Discovery API, you need to generate a set of API credentials,
+consisting of a client identifier and a client secret string. To obtain your
+API credentials, complete the following steps.
+
+#. Register at http://www.edx.org by creating a new user account for your
+   company. The name you enter in the Public Username field must match the
+   name of your company. For example, if your company is named Example, Inc.,
+   enter a name like Example or ExampleInc in the Public Username field.
+
+#. After you have created an account, go to ``http://courses.edx.org/api-admin``
+   and fill out the API Access Request form. The name you enter in the
+   **Company Name** field must be identical to the **Public Username** that you
+   used to register on edx.org. For example,  if your Public Username is
+   ExampleInc, the Company Name must also be ExampleInc.
+
+#. After you submit the API Access Request form, edX will create a course
+   catalog for you and then send you an email describing how to generate
+   your client identifier and client secret string. You can then use the
+   client identifier and secret string to access your Discovery APIs
+
+When a client authenticates with the edX Enterprise API, the client
+completes the following process.
+
+* The client presents a client identifier and a secret string to the
+  ``https://api.edx.org/oauth2/v1/access_token`` authentication resource and receives an access
+  token.
+
+* The client includes the access token when the client makes another API
+  request.
+
+An access token is a text string that includes encoded information
+about the client, the user, and the period of time in which the token is valid.
+Access tokens expire after a period of time that is specified when you request
+them. After an access token expires, you must get a new token from the
+``https://api.edx.org/oauth2/v1/access_token`` authentication resource.
+
+**************************
+Obtaining an Access Token
+**************************
+
+To obtain an access token, you submit a POST request to the
+``https://api.edx.org/oauth2/v1/access_token`` authentication resource. Include a string in the
+message body of your POST request that contains your client identifier,
+client secret, grant type (``client_credential``), and token type (``jwt``),
+as shown in the following example, replacing ``{client_id}`` and
+``{client_secret}`` with your actual client ID and secret.
+::
+
+  curl -X POST https://api.edx.org/oauth2/v1/access_token -d "grant_type=client_credentials&client_id={client_id}&client_secret={client_secret}&token_type=jwt"
+
+
+The response you receive contains the access token value that you can use to
+submit further requests to the edX Enterprise API. For example:
+::
+
+  {
+    “access_token”: “g1Bb0usqwe345ty…”,
+    “token_type”: “JWT”,
+    “expires_in”: “36000”,
+    “scope”: “read write profile email”
+  }

--- a/en_us/discovery_api/source/conf.py
+++ b/en_us/discovery_api/source/conf.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import sys
+
+sys.path.append('../../../')
+
+from shared.conf import *
+
+project = u'Discovery Service API Guide'
+
+tags.add('Partners')
+set_audience(PARTNER, COURSE_TEAMS)
+
+product = 'Partners'
+
+
+def setup(app):
+    app.add_config_value('product', '', True)

--- a/en_us/discovery_api/source/index.rst
+++ b/en_us/discovery_api/source/index.rst
@@ -1,0 +1,15 @@
+
+
+.. _document index:
+
+#####################################
+EdX Discovery API Guide
+#####################################
+
+.. toctree::
+    :numbered:
+    :maxdepth: 2
+
+    intro_edx_apis
+    authentication
+    api_reference/reference

--- a/en_us/discovery_api/source/intro_edx_apis.rst
+++ b/en_us/discovery_api/source/intro_edx_apis.rst
@@ -9,7 +9,6 @@ It does this primarily through a REST API that supports ``courses``, ``course ru
 ``catalogs``, and ``search``.
 
 It also provides ``skills``, ``jobs`` and ``job postings`` data for all the published ``courses``.
-the ``skills`` are extracted by text processing provided in course's full description. We
-also collect and save the data about ``jobs`` that are related to ``skills`` in our system
-using third party tools and services. ``JobPostings`` contains the number of job postings with
-posting companies and median salary information.
+The ``skills`` are extracted using course's full description by third party tools and services. We
+also collect and save the data about ``jobs`` that is relevant to the ``skills`` in our system.
+``JobPostings`` contains the number of job postings with posting companies and median salary information.

--- a/en_us/discovery_api/source/intro_edx_apis.rst
+++ b/en_us/discovery_api/source/intro_edx_apis.rst
@@ -9,7 +9,7 @@ It does this primarily through a REST API that supports ``courses``, ``course ru
 ``catalogs``, and ``search``.
 
 It also provides ``skills``, ``jobs`` and ``job postings`` data for all the published ``courses``.
-These ``skills`` are extracted by text processing provided in course's full description. We
+the ``skills`` are extracted by text processing provided in course's full description. We
 also collect and save the data about ``jobs`` that are related to ``skills`` in our system
-using third party tools and services. ``Job posting`` is information about the number of job postings
-available in market, median salary and companies offering the job, etc.
+using third party tools and services. ``JobPostings`` contains the number of job postings with
+posting companies and median salary information.

--- a/en_us/discovery_api/source/intro_edx_apis.rst
+++ b/en_us/discovery_api/source/intro_edx_apis.rst
@@ -1,0 +1,9 @@
+.. _Discovery API Introduction:
+
+#############################
+Introduction
+#############################
+
+Discovery is a service that provides access to consolidated course and program metadata.
+It does this primarily through a REST API that supports courses, course runs, programs,
+catalogs, and search. It also provides skills, jobs and job postings data for courses.

--- a/en_us/discovery_api/source/intro_edx_apis.rst
+++ b/en_us/discovery_api/source/intro_edx_apis.rst
@@ -1,9 +1,15 @@
 .. _Discovery API Introduction:
 
-#############################
+############
 Introduction
-#############################
+############
 
 Discovery is a service that provides access to consolidated course and program metadata.
-It does this primarily through a REST API that supports courses, course runs, programs,
-catalogs, and search. It also provides skills, jobs and job postings data for courses.
+It does this primarily through a REST API that supports ``courses``, ``course runs``, ``programs``,
+``catalogs``, and ``search``.
+
+It also provides ``skills``, ``jobs`` and ``job postings`` data for all the published ``courses``.
+These ``skills`` are extracted by text processing provided in course's full description. We
+also collect and save the data about ``jobs`` that are related to ``skills`` in our system
+using third party tools and services. ``Job posting`` is information about the number of job postings
+available in market, median salary and companies offering the job, etc.


### PR DESCRIPTION
## [ENT-4877](https://openedx.atlassian.net/browse/ENT-4877)

Added documentation for EdX discovery API, specifically for taxonomy.


### Testing

-  clone this repo.
-  create new virtual env
-  install requirement by `make requirements`
-  install more requirements by `pip install -r shared/tools.txt`
-  run server by `./develop.sh en_us/discovery_api/`
- open `http://127.0.0.1:9090` to see docs

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.


### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

