### PR TITLE
Add Reusable Rubrics feature documentation

### DIFF
--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -164,6 +164,38 @@ To provide a comment field without options, complete these steps.
 
 #. Next to **Feedback for This Criterion**, select **Required** from the list.
 
+=============
+Reuse Rubrics
+=============
+
+If your course uses multiple Open Response Assessments with similar assessment
+criteria, reusing rubrics may save time and prevent having to re-author the same
+rubric across many ORAs.
+
+To reuse a rubric, complete the following steps:
+
+#. In Studio, navigate to an ORA with a completed rubric you'd like to copy.
+
+#. In the ORA component editor, select the **Rubric** tab.
+
+#. Expand the **Clone Rubric** section (if it is not already expanded) and copy or note
+   the value following "Block ID for this ORA". This will allow you to uniquely
+   identify this ORA later.
+
+#. Navigate to (or create) an unpublished ORA where you'd like to copy the rubric.
+
+#. In the ORA component editor, select the **Rubric** tab and expand the
+   **Clone Rubric** section.
+
+#. In the "Block ID" dropdown, paste or select the ID of the ORA to copy rubric data
+   from.
+
+#. Click "Clone". A banner should appear saying "Rubric Successfully Cloned from
+   Block ID: <block ID>".
+
+#. **Note**: Cloning rubric data clears Learner Training examples. If applicable,
+   follow the instructions at :ref:`learner training step<PA Student Training Step>` to
+   add updated Learner Training examples.
 
 .. _PA Specify Additional Settings:
 

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -182,7 +182,7 @@ To reuse a rubric, complete the following steps:
    the value following "Block ID for this ORA". This will allow you to uniquely
    identify this ORA later.
 
-#. Navigate to (or create) an unpublished ORA where you'd like to copy the rubric.
+#. Navigate to (or create) an unpublished ORA where you'd like to reuse the rubric.
 
 #. In the ORA component editor, select the **Rubric** tab and expand the
    **Clone Rubric** section.

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -197,6 +197,10 @@ To reuse a rubric, complete the following steps:
    follow the instructions at :ref:`learner training step<PA Student Training Step>` to
    add updated Learner Training examples.
 
+#. **Note**: When a rubric is cloned, the version of the rubric that is cloned is the
+   currently *saved* version, not the currently *published* version. This is done to support
+   the ability to clone from ORAs that have not yet been published.
+
 .. _PA Specify Additional Settings:
 
 ***********************************


### PR DESCRIPTION
## [AU-284](https://openedx.atlassian.net/browse/AU-284)

Adds documentation for how to reuse rubrics across multiple ORAs.

### Date Needed (optional)

Roll-out with [AU-205](https://openedx.atlassian.net/browse/AU-205)

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: 
- [ ] Doc team review (sanity check): @edx/doc
- [x] PM review: @sapanathomas523 

FYI: @edx/masters-devs-gta 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits