### PR TITLE
docs: catalog jump navigation event

### DIFF
--- a/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
@@ -790,11 +790,72 @@ This section includes descriptions of the following events.
   :depth: 1
 
 =============================================================================
+``edx.ui.lms.jump_nav.selected``
+=============================================================================
+The browser emits this event when a user selects a hyperlink using the breadcrumb jump navigation menus.
+
+**History**: Added Semptember 20 2021.
+
+**Component**: Sequence
+
+**Event Source**: Browser
+
+``event`` **Member Fields**:
+
+The ``edx.ui.lms.link_clicked`` event includes both a ``name`` field
+and an ``event_type`` field. For more information about these common fields,
+see :ref:`common`.
+
+``event`` **Member Fields**:
+
+.. list-table::
+   :widths: 15 15 60
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Details
+
+   * - ``target_name``
+     - string
+     - The string title of the intended destination of the navigation.
+
+   * - ``id``
+     - string
+     - the block id of the intended destination of the navigation.
+
+   * - ``current_id``
+     - string
+     - The block id of the current unit block before navigating away.
+
+   * - ``widget_placement``
+     - string
+     - The location on the browser the event originates from.
+
+=============================================================================
+Example ``edx.ui.lms.jump_nav.selected`` Event
+=============================================================================
+
+The following example shows the relevant fields of the event that is emitted
+when a user selects any hypertext link from the course breadcrumb content.
+
+.. code-block:: json
+
+ {
+     "name": "edx.ui.lms.jump_nav.selected",
+     "event": {
+         "target_name": "Part 3: Getting Social"
+         "id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@simulations/block-v1:edX+DemoX+Demo_Course+type@vertical+block@d0d804e8863c4a95a659c04d8a2b2bc0",
+         "current_id": "block-v1:edX+DemoX+Demo_Course+type@sequential+block@basic_questions/block-v1:edX+DemoX+Demo_Course+type@vertical+block@2152d4a4aadc4cb0af5256394a3d1fc7",
+         "widget_placement": "breadcrumb"
+         }
+ }
+
+=============================================================================
 ``edx.ui.lms.link_clicked``
 =============================================================================
 
-The browser emits this event when a user selects any hypertext link from the
-course content.
+The browser emits this event when a user selects any hypertext link from the course content.
 
 **History**: Added May 5 2016.
 


### PR DESCRIPTION
## [ Jump Navigation Segment Event](https://github.com/edx/frontend-app-learning/pull/647/files)

In order to capture the navigation of learners around the course using the breadcrumb jump navigation feature, I have created a new navigation event which follows the usage patterns of similar navigation events to capture relevant information.

The event is as follows: 

``edx.ui.lms.jump_nav.selected``
The browser emits this event when a user selects a hyperlink using the breadcrumb jump navigation menus.

**History**: Added Semptember 20 2021.

**Component**: Sequence

**Event Source**: Browser

``event`` **Member Fields**:

The ``edx.ui.lms.link_clicked`` event includes both a ``name`` field
and an ``event_type`` field. For more information about these common fields,
see :ref:`common`.

``event`` **Member Fields**:
   * - ``target_name``
     - string
     - The string title of the intended destination of the navigation.

   * - ``id``
     - string
     - the block id of the intended destination of the navigation.

   * - ``current_id``
     - string
     - The block id of the current unit block before navigating away.

   * - ``widget_placement``
     - string
     - The location on the browser the event originates from.


### Date Needed (optional)
No deadline required for documentation, but event will come into use on prod sometime the week of the 27th for all course staff and learners using the courseware MFE.

About
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

