### PR TITLE
fix: handle error when conf.py is running by sphinx-intl

### DIFF
--- a/shared/conf.py
+++ b/shared/conf.py
@@ -12,7 +12,10 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # OK, this is gross: I don't know of a way to find out what builder is running,
 # so let's examine the command line, and take the word after -b.
-the_builder = sys.argv[sys.argv.index("-b") + 1]
+try:
+    the_builder = sys.argv[sys.argv.index("-b") + 1]
+except ValueError:
+    the_builder = None
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

Wrapped the statement which extracts the buidler from `sys.argv`, because when `sphinx-intl` runs `conf.py` is doesn't   have the `- b` arg. 

For more context about why `sphinx-intl` is being used, please refer to this [ticket](https://trello.com/c/q4JJOHeo/4-we-would-like-to-have-user-documentation-translated-into-the-10-languages-that-we-are-focusing-our-transifex-strategy-on-in-orde). 


### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

