### PR TITLE
fix: restore a missing reference and improve the build process

### DIFF
--- a/en_us/shared/course_assets/pages.rst
+++ b/en_us/shared/course_assets/pages.rst
@@ -141,6 +141,8 @@ To disable or enable the Calculator resource, follow these steps.
 
 #. Select **Apply** to save your configuration changes.
 
+.. _Add Page:
+
 .. _Add Custom Page:
 
 ============================

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -173,7 +173,7 @@ def ism_location(dir_name):
         return None
 
 intersphinx_mapping = {
-    "opencoursestaff" : (edx_rtd_url("open-edx-building-and-running-a-course"), None),
+    "opencoursestaff" : (edx_rtd_url("open-edx-building-and-running-a-course"), ism_location("open_edx_course_authors")),
     "data" : (edx_rtd_url("devdata"), ism_location("data")),
     "partnercoursestaff": (edx_rtd_url("edx-partner-course-staff"), ism_location("course_authors")),
     "insights" : (edx_rtd_url("edx-insights"), None),
@@ -181,14 +181,14 @@ intersphinx_mapping = {
     "xblocktutorial" : (edx_rtd_url("xblock-tutorial"), ism_location("xblock-tutorial")),
     "installation" : (edx_rtd_url("edx-installing-configuring-and-running"), ism_location("install_operations")),
     "olx" : (edx_rtd_url("edx-open-learning-xml"), ism_location("olx")),
-    "learners" : (edx_rtd_url("edx-guide-for-students"), None),
-    "openlearners" : (edx_rtd_url("open-edx-learner-guide"), None),
-    "opendevelopers" : (edx_rtd_url("edx-developer-guide"), None),
+    "learners" : (edx_rtd_url("edx-guide-for-students"), ism_location("students")),
+    "openlearners" : (edx_rtd_url("open-edx-learner-guide"), ism_location("open_edx_students")),
+    "opendevelopers" : (edx_rtd_url("edx-developer-guide"), ism_location("developers")),
     "opendataapi" : (edx_rtd_url("edx-data-analytics-api"), None),
-    "openreleasenotes" : (edx_rtd_url("open-edx-release-notes"), None),
-    "partnerreleasenotes": (edx_rtd_url("edx-release-notes"), None),
-    "2014releasenotes" : (edx_rtd_url("edx-2013-2014-release-notes"), None),
-    "retirement" : ("https://user-retirement-guide.readthedocs.io/en/latest/", None),
+    "openreleasenotes" : (edx_rtd_url("open-edx-release-notes"), ism_location("open_edx_release_notes")),
+    "partnerreleasenotes": (edx_rtd_url("edx-release-notes"), ism_location("release_notes")),
+    "2014releasenotes" : (edx_rtd_url("edx-2013-2014-release-notes"), ism_location("release_notes_2014")),
+    "retirement" : ("https://user-retirement-guide.readthedocs.io/en/latest/", ism_location("user_retirement")),
 }
 
 extlinks = {


### PR DESCRIPTION
A missing reference was causing builds to fail.  This also improves the build process to prevent future missing references from slipping through the cracks.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors
