### PR TITLE
Rename HTML component to Text component in documentation.

### DIFF
--- a/en_us/data/source/internal_data_formats/course_structure.rst
+++ b/en_us/data/source/internal_data_formats/course_structure.rst
@@ -58,7 +58,7 @@ objects for each of the other categories. For each object in the file, the
      - The content-specific discussion components defined for the course. For
        more information, see :ref:`Course Component Data`.
    * - html
-     - The HTML components defined for the course. For more information, see
+     - The Text components defined for the course. For more information, see
        :ref:`Course Component Data`.
    * - problem
      - The problem components defined for the course. For

--- a/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
+++ b/en_us/data/source/internal_data_formats/tracking_logs/student_event_types.rst
@@ -2468,7 +2468,7 @@ adds a note in the course.
      - Details
    * - ``component_usage_id``
      - string
-     - The unique identifier for the HTML component where the learner added
+     - The unique identifier for the Text component where the learner added
        the note. For more information about the components that a course
        includes, see :ref:`partnercoursestaff:Developing Course Components`.
    * - ``highlighted_content``
@@ -2613,7 +2613,7 @@ searches notes on the **Notes** page.
 =====================================================
 
 The browser emits ``edx.course.student_notes.used_unit_link`` events when a
-learner uses a note link on the **Notes** page to go to the HTML component that
+learner uses a note link on the **Notes** page to go to the Text component that
 contains that note.
 
 **History**: Added 16 March 2016.

--- a/en_us/edx_style_guide/source/images.rst
+++ b/en_us/edx_style_guide/source/images.rst
@@ -199,7 +199,7 @@ information.
 
   .. image:: Images/HTMLEditor.png
     :width: 450
-    :alt: An image of the HTML component in the visual editor.
+    :alt: An image of the Text component in the visual editor.
 
 
 ===========================

--- a/en_us/install_operations/source/configuration/enable_public_course.rst
+++ b/en_us/install_operations/source/configuration/enable_public_course.rst
@@ -108,7 +108,7 @@ including the following.
   groups for your private content, and ensure that your enrolled learners are
   members of a cohort that can see this content group.
 
-* Only HTML components, Video components, and course handouts have a "public" 
+* Only Text components, Video components, and course handouts have a "public"
   view. Unenrolled learners will see a message requesting that they enroll to 
   see more complex content types, such as discussion forums, problem blocks, 
   randomized content blocks, exams, Open Response Assessment, and other XBlocks.

--- a/en_us/olx/source/components/discussion-components.rst
+++ b/en_us/olx/source/components/discussion-components.rst
@@ -65,7 +65,7 @@ attribute of the ``discussion`` element in the vertical XML file.
 Discussion Component XML File Elements
 ***************************************
 
-The root element of the XML file for the HTML component is file is
+The root element of the XML file for the discussion component file is
 ``discussion``.
 
 The ``discussion`` element contains no children.

--- a/en_us/shared/accessibility/best_practices_course_content_dev.rst
+++ b/en_us/shared/accessibility/best_practices_course_content_dev.rst
@@ -965,7 +965,7 @@ Keep the following guidelines in mind when you create HTML content.
   document. Well-structured headings help learners and screen reader users to
   navigate a page and efficiently find what they are looking for.
 
-  In your :ref:`HTML<Working with HTML Components>` and
+  In your :ref:`HTML<Working with Text Components>` and
   :ref:`problem<Working with Problem Components>` components, be sure to apply
   only heading levels 2 through 6 to your content. Because the components
   that you add are part of a complete page, and heading level 1 is

--- a/en_us/shared/course_assets/course_files.rst
+++ b/en_us/shared/course_assets/course_files.rst
@@ -241,7 +241,7 @@ update, or a course handout, follow these steps.
 
 #. In the component or other content, paste the Studio URL.
 
-For more information, see :ref:`Add an Image to an HTML Component`.
+For more information, see :ref:`Add an Image to a Text Component`.
 
 .. _Add a File or Image Outside the Course:
 

--- a/en_us/shared/course_assets/handouts_updates.rst
+++ b/en_us/shared/course_assets/handouts_updates.rst
@@ -59,7 +59,7 @@ To add a course update, follow these steps.
 #. Create your update in the text editor that opens.
 
    * Enter text for the update, using HTML tags for formatting. This editor is
-     like the :ref:`raw HTML editor<The Raw HTML Editor>` in HTML components.
+     like the :ref:`raw HTML editor<The Raw HTML Editor>` in Text components.
      The course update editor does not have a :ref:`visual editor<The Visual
      Editor>`.
 

--- a/en_us/shared/course_assets/pages.rst
+++ b/en_us/shared/course_assets/pages.rst
@@ -181,7 +181,7 @@ To add a custom page and its content to your course, follow these steps.
 #. Enter the content for your page.
 
     To add HTML tags to your content, select HTML to open the :ref:`the raw HTML editor<The Raw HTML Editor>`.
-    For more information about entering content, see :ref:`Options for Editing HTML Components`.
+    For more information about entering content, see :ref:`Options for Editing Text Components`.
 
     .. note:: If you copy text from another source and paste it into the visual editor,be sure to proofread the result carefully. Some applications automatically change quotation marks and apostrophes from the “straight” version to the “smart” or “curly” version. The raw HTML editor requires “straight” quotation marks and apostrophes.
 

--- a/en_us/shared/course_components/create_discussion.rst
+++ b/en_us/shared/course_components/create_discussion.rst
@@ -34,7 +34,7 @@ For more information about discussions, see these topics.
 Create a Discussion Component
 *****************************
 
-.. note:: EdX recommends that you add an HTML component before each discussion
+.. note:: EdX recommends that you add a Text component before each discussion
    component to introduce the topic that you want learners to discuss. The
    discussion component itself does not contain any text and can be easy for
    learners to overlook.

--- a/en_us/shared/course_components/create_html_component.rst
+++ b/en_us/shared/course_components/create_html_component.rst
@@ -1,17 +1,17 @@
-.. _Working with HTML Components:
+.. _Working with Text Components:
 
 #############################
-Working with HTML Components
+Working with Text Components
 #############################
 
-This section describes how to work with HTML components in Studio.
+This section describes how to work with Text components in Studio.
 
 .. contents::
  :local:
  :depth: 1
 
 ***********************
-HTML Component Overview
+Text Component Overview
 ***********************
 
 HTML, or HyperText Markup Language, is the standard markup language used to
@@ -22,26 +22,26 @@ that is formatted and presented by their browsers. For more information about
 HTML, see `Wikipedia <https://en.wikipedia.org/wiki/HTML>`_.
 
 ===================
-HTML Components
+Text Components
 ===================
 
-HTML components are the basic building blocks of your course content. You use
-HTML components to add and format text, links, images, and more. You can work
-with your HTML components in a "visual" or WYSIWYG editor that hides the HTML
+Text components are the basic building blocks of your course content. You use
+Text components to add and format text, links, images, and more. You can work
+with your Text components in a "visual" or WYSIWYG editor that hides the HTML
 code details, or in a "raw" editor that requires you to mark up your content.
 
 .. note::
  Review :ref:`Developing Your Course Index` and :ref:`Best Practices for HTML
- Markup` before you start working with HTML components.
+ Markup` before you start working with Text components.
 
 
-.. _Options for Editing HTML Components:
+.. _Options for Editing Text Components:
 
 ********************************************
-Options for Editing HTML Components
+Options for Editing Text Components
 ********************************************
 
-You can use two different editing interfaces to work with an HTML component.
+You can use two different editing interfaces to work with a Text component.
 
 * :ref:`The Visual Editor`
 
@@ -53,7 +53,7 @@ You can use two different editing interfaces to work with an HTML component.
   HTML option does not provide the detailed control you can get with the raw
   HTML editor, and does not support custom formatting or scripts.
 
-  If you add an HTML component and select **Text**, when you select **Edit**
+  If you add a Text component and select **Text**, when you select **Edit**
   the visual editor opens by default.
 
 * :ref:`The Raw HTML Editor`
@@ -62,11 +62,11 @@ You can use two different editing interfaces to work with an HTML component.
   the raw HTML editor. If you need to include custom formatting or scripts in
   your content, you must use the raw HTML editor.
 
-  If you add an HTML component and select **Raw HTML**, when you select
+  If you add a Text component and select **Raw HTML**, when you select
   **Edit** the raw HTML editor opens by default.
 
 You can switch back and forth between these two editing interfaces at any time.
-For more information, see :ref:`Set the Editor for an HTML Component`.
+For more information, see :ref:`Set the Editor for a Text Component`.
 
 .. note::
     If you copy text from another source and paste it into either the visual or
@@ -75,13 +75,13 @@ For more information, see :ref:`Set the Editor for an HTML Component`.
     "straight" version to the "smart" or "curly" version. Both editors require
     "straight" quotation marks and apostrophes.
 
-.. _Set the Editor for an HTML Component:
+.. _Set the Editor for a Text Component:
 
 ======================================
-Set the Editor for an HTML Component
+Set the Editor for a Text Component
 ======================================
 
-#. Add or locate the HTML component in your course.
+#. Add or locate the Text component in your course.
 
 #. Select **Edit**, and then select **Settings**.
 
@@ -117,11 +117,11 @@ descriptions.
    ``preformatted`` (monospace), or a heading level.
 
    .. note::
-     The available heading levels in the HTML component editor begin with
-     heading 3 (``<h3>``). HTML components are part of a complete page, and
-     elements outside the HTML component use heading levels 1 and 2 by default.
+     The available heading levels in the Text component editor begin with
+     heading 3 (``<h3>``). Text components are part of a complete page, and
+     elements outside the Text component use heading levels 1 and 2 by default.
      Because tools such as screen readers use heading levels to navigate
-     through pages, using heading levels 1 or 2 inside an HTML component can
+     through pages, using heading levels 1 or 2 inside a Text component can
      interfere with the functionality of these tools.
 
 #. Select a font family for selected text, such as Arial, Courier New, or Times
@@ -170,12 +170,12 @@ descriptions.
    separate paragraph in a monospace font.
 
 #. Create a hypertext link from the selected text. For more information, see
-   :ref:`Add a Link in an HTML Component`.
+   :ref:`Add a Link in a Text Component`.
 
 #. Remove a hypertext link from the selected text.
 
 #. Insert an image at the cursor. For more information, see :ref:`Add an Image
-   to an HTML Component`.
+   to a Text Component`.
 
 #. Review the HTML markup.
 
@@ -208,7 +208,7 @@ You can then continue working in the visual editor.
 
 .. warning::
  Selecting **OK** in the source code editor does not save your changes to the
- HTML component. To save your changes and close the component, select **Save**
+ Text component. To save your changes and close the component, select **Save**
  in the visual editor. If you select **Cancel**, the changes you made in the
  HTML source code editor are discarded.
 
@@ -230,32 +230,32 @@ not validate your HTML code. If you use this editor, you should thoroughly test
 the HTML content in your course.
 
 .. important::
- When you add a heading to an HTML component, make sure that you use only
- heading level 3 ``<h3>`` through heading level 6 ``<h6>``. HTML components are
- part of a complete page, and elements outside the HTML component use heading
+ When you add a heading to a Text component, make sure that you use only
+ heading level 3 ``<h3>`` through heading level 6 ``<h6>``. Text components are
+ part of a complete page, and elements outside the Text component use heading
  levels 1 and 2 by default. Because tools such as screen readers use heading
- levels to navigate through pages, using heading levels 1 or 2 inside an HTML
+ levels to navigate through pages, using heading levels 1 or 2 inside a Text
  component can interfere with the functionality of these tools.
 
-.. _Create an HTML Component:
+.. _Create a Text Component:
 
 *****************************
-Create an HTML Component
+Create a Text Component
 *****************************
 
-#. Under **Add New Component**, select **HTML**.
+#. Under **Add New Component**, select **Text**.
 
 #. Select the template.
 
    The rest of these instructions assume that you selected **Text**, which
-   creates an empty HTML component with the :ref:`visual editor<The Visual
+   creates an empty Text component with the :ref:`visual editor<The Visual
    Editor>` selected.
 
-   An empty HTML component appears at the bottom of the unit.
+   An empty Text component appears at the bottom of the unit.
 
 #. In the component, select **Edit**.
 
-   The HTML component opens in the visual editor.
+   The Text component opens in the visual editor.
 
 #. Enter and format your content. You can :ref:`review the HTML markup<Work
    with HTML code>`.
@@ -275,18 +275,18 @@ Create an HTML Component
 
 When you use the visual editor, you can also perform the following tasks.
 
-* :ref:`Add a Link in an HTML Component`
-* :ref:`Add an Image to an HTML Component`
+* :ref:`Add a Link in a Text Component`
+* :ref:`Add an Image to a Text Component`
 * :ref:`Import LaTeX Code`
 
 
-.. _HTML Component Templates:
+.. _Text Component Templates:
 
 =========================
-HTML Component Templates
+Text Component Templates
 =========================
 
-When you create an HTML component, you select one of the following templates.
+When you create a Text component, you select one of the following templates.
 
 * Text
 * Announcement
@@ -295,17 +295,17 @@ When you create an HTML component, you select one of the following templates.
 
 The raw HTML template uses the raw HTML editor by default. All of the other
 templates use the visual editor by default. You can switch between the editors
-in any HTML component. For more information, see :ref:`Set the Editor for an
-HTML Component`.
+in any Text component. For more information, see :ref:`Set the Editor for a
+Text Component`.
 
-.. _Add a Link in an HTML Component:
+.. _Add a Link in a Text Component:
 
 ***********************************
-Add a Link in an HTML Component
+Add a Link in a Text Component
 ***********************************
 
 When you use the visual editor, to add a link to a website, course unit, or
-file in an HTML component, you work with the **Insert link** dialog box.
+file in a Text component, you work with the **Insert link** dialog box.
 
 For more information, see the following tasks.
 
@@ -332,7 +332,7 @@ Add a Link to a Website
 
 #. Select **OK**.
 
-#. Save the HTML component.
+#. Save the Text component.
 
 #. To test the link, select **View Live Version** or **Preview**. When the unit
    opens in the LMS, select the linked text and verify that the correct website
@@ -360,7 +360,7 @@ Add a Link to a Course Unit
        :alt: The **Unit Location** area in the right pane of a unit page, with
            the unit's location ID circled.
 
-#. Open the HTML component where you want to add the link.
+#. Open the Text component where you want to add the link.
 
 #. Select the text that you want to make into the link.
 
@@ -387,7 +387,7 @@ Add a Link to a Course Unit
 
 #. Select **Insert**.
 
-#. Save the HTML component and test the link.
+#. Save the Text component and test the link.
 
 .. _Add a Link to a File:
 
@@ -396,17 +396,17 @@ Add a Link to a File
 ====================
 
 .. tip::
- When you add links to files, open the HTML component and the **Files &
+ When you add links to files, open the Text component and the **Files &
  Uploads** page in separate browser windows. You can then more quickly copy
  file URLs.
 
-You can add a link in an HTML component to any file that is uploaded for the
+You can add a link in a Text component to any file that is uploaded for the
 course. For more information about uploading files, see :ref:`Add Files to a
 Course`.
 
 .. note::
- Do not use this method to add images to HTML components. Instead, use the
- method in :ref:`Add an Image to an HTML Component`.
+ Do not use this method to add images to Text components. Instead, use the
+ method in :ref:`Add an Image to a Text Component`.
 
 
 #. On the **Files & Uploads** page, locate the file that you want, and then
@@ -416,7 +416,7 @@ Course`.
    You must use the **Studio** URL to link to the file, not the **Web** URL.
    For more information, see :ref:`Add Files to a Course`.
 
-#. In the HTML component where you want to add the link, select the text that
+#. In the Text component where you want to add the link, select the text that
    you want to make into the link.
 
 #. In the toolbar, select the link icon.
@@ -434,20 +434,19 @@ Course`.
 
 #. Select **OK**.
 
-#. Save the HTML component and test the link.
+#. Save the Text component and test the link.
 
-.. _Add an Image to an HTML Component:
+.. _Add an Image to a Text Component:
 
 *********************************
-Add an Image to an HTML Component
+Add an Image to a Text Component
 *********************************
 
-When you use the visual editor, you can add any image from your computer to an
-HTML component. You can see a preview of the image before you add it to the
+When you use the visual editor, you can add any image from your computer to
+a Text component. You can see a preview of the image before you add it to the
 component.
 
 .. note::
-
  * Before you add an image, make sure that you obtain copyright permissions for
    images you use in your course, and that you cite sources appropriately.
  * To add effective alternative text for images, review :ref:`Best Practices
@@ -455,11 +454,11 @@ component.
  * You can only add one image at one time.
  * Each individual image file must be smaller than 10 MB.
 
-To add an image to an HTML component, you can use one of the following
+To add an image to a Text component, you can use one of the following
 procedures.
 
 * :ref:`Drag an image <Drag an Image into the Add Image Dialog Box>` from your
-  computer into the **Add Image** dialog box in the HTML component.
+  computer into the **Add Image** dialog box in the Text component.
 * :ref:`Locate an image <Locate an Image on Your Computer>` by using the
   **Browse Your Computer** option in the **Add Image** dialog box.
 * :ref:`Select an image <Select a Previously Uploaded Image>` that you have
@@ -471,7 +470,7 @@ procedures.
 Drag an Image into the Add Image Dialog Box
 ===========================================
 
-#. In the HTML component, position the cursor where you want to add an image,
+#. In the Text component, position the cursor where you want to add an image,
    and then select the image icon on the toolbar.
 
 #. In the **Add an Image** dialog box, drag an image from your computer into
@@ -494,7 +493,7 @@ Drag an Image into the Add Image Dialog Box
 
 #. Select **Insert Image**.
 
-#. Save the HTML component and test the image.
+#. Save the Text component and test the image.
 
 .. _Locate an Image on Your Computer:
 
@@ -502,7 +501,7 @@ Drag an Image into the Add Image Dialog Box
 Locate an Image on Your Computer
 ===========================================
 
-#. In the HTML component, position the cursor where you want to add an image,
+#. In the Text component, position the cursor where you want to add an image,
    and then select the image icon on the toolbar.
 
 #. In the **Add an Image** dialog box, **Browse Your Computer**.
@@ -527,7 +526,7 @@ Locate an Image on Your Computer
 
 #. Select **Insert Image**.
 
-#. Save the HTML component and test the image.
+#. Save the Text component and test the image.
 
 .. _Select a Previously Uploaded Image:
 
@@ -540,9 +539,9 @@ Select a Previously Uploaded Image
    about uploading images, see :ref:`Add Files to a Course`.
 
    When you upload an image, the image automatically becomes available in a
-   list that opens when you add an image to an HTML component.
+   list that opens when you add an image to a Text component.
 
-#. In the HTML component, position the cursor where you want to add an image,
+#. In the Text component, position the cursor where you want to add an image,
    and then select the image icon on the toolbar.
 
 #. In the **Add an Image** dialog box, locate the image in the **Select a
@@ -564,15 +563,15 @@ Select a Previously Uploaded Image
 
 #. Select **Insert Image**.
 
-#. Save the HTML component and test the image.
+#. Save the Text component and test the image.
 
-.. _Format an Image in an HTML Component:
+.. _Format an Image in a Text Component:
 
 =========================================
-Format an Image in an HTML Component
+Format an Image in a Text Component
 =========================================
 
-You have several options for formatting an image in an HTML component.
+You have several options for formatting an image in a Text component.
 
 .. contents::
  :local:
@@ -585,7 +584,7 @@ Align an Image
 
 To align your image to the right, the left, or the center, follow these steps.
 
-#. In the HTML component, select the image.
+#. In the Text component, select the image.
 
 #. On the toolbar, select the left align, right align, or center icon.
 
@@ -596,7 +595,7 @@ Change the Image Size
 
 To change the size of your image, follow these steps.
 
-#. In the HTML component, select the image that you want to edit, and then
+#. In the Text component, select the image that you want to edit, and then
    select the image icon on the toolbar.
 
 #. In the **Edit Image Settings** dialog box, locate **Image Dimensions**, and
@@ -625,7 +624,7 @@ the **Width** and **Height** fields.
 .. Add a Border to an Image
 .. ************************
 
-.. #. In the HTML component, select the image that you want to edit, and then
+.. #. In the Text component, select the image that you want to edit, and then
 ..   select the image icon on the toolbar.
 .. #. In the **Add or Edit Image** dialog box, select **Advanced**.
 .. #. In the **Border** field, enter the width in pixels of the border for
@@ -637,7 +636,7 @@ the **Width** and **Height** fields.
 .. Add Margins to an Image
 .. ************************
 
-.. #. In the HTML component, select the image that you want to edit, and then
+.. #. In the Text component, select the image that you want to edit, and then
 ..   select the image icon on the toolbar.
 .. #. In the **Add or Edit Image** dialog box, select **Advanced**.
 .. #. In the **Vertical space** and **Horizontal space** fields, enter the
@@ -649,15 +648,15 @@ the **Width** and **Height** fields.
 .. _Import LaTeX Code:
 
 ****************************************
-Import LaTeX Code into an HTML Component
+Import LaTeX Code into a Text Component
 ****************************************
 
-You can import LaTeX code into an HTML component. You might do this, for
+You can import LaTeX code into a Text component. You might do this, for
 example, if you want to create "beautiful math" such as the math in the
 following image.
 
 .. image:: ../../../shared/images/HTML_LaTeX_LMS.png
- :alt: Math formulas created with LaTeX in an HTML component.
+ :alt: Math formulas created with LaTeX in a Text component.
 
 .. warning::
  The LaTeX processor that Studio uses to convert LaTeX code to XML is a third
@@ -679,13 +678,13 @@ the advanced settings in your course.
 #. At the bottom of the page, select **Save Changes**.
 
 ==============================================
-Add an HTML Component that Contains LaTeX Code
+Add a Text Component that Contains LaTeX Code
 ==============================================
 
-When the LaTeX processor is enabled, you can create an HTML component that
+When the LaTeX processor is enabled, you can create a Text component that
 contains LaTeX code.
 
-#. In the unit where you want to create the component, select **html** under
+#. In the unit where you want to create the component, select **Text** under
    **Add New Component**, and then select **E-text Written in LaTeX**. The new
    component is added to the unit.
 

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -202,7 +202,7 @@ You can also add text, without formatting, to a problem. Note that screen
 readers read all of the text that you supply for the problem, and then repeat
 the text that is identified as the question or prompt immediately before
 reading the answer choices for the problem. For problems that require
-descriptions or other text, you might consider adding an HTML component for the
+descriptions or other text, you might consider adding a Text component for the
 text immediately before the problem component.
 
 When you enter unformatted text, note that the simple editor cannot interpret

--- a/en_us/shared/course_components/libraries.rst
+++ b/en_us/shared/course_components/libraries.rst
@@ -17,7 +17,7 @@ Content Libraries Overview
 **************************
 
 In Studio, you can create a library to build a pool of components for use in
-randomized assignments in your courses. You can add HTML components, problems,
+randomized assignments in your courses. You can add Text components, problems,
 and video components to a library. Open response assessment and discussion
 components are not supported in libraries.
 
@@ -144,7 +144,7 @@ follow these steps.
 For more information about the types of components you can add to a library,
 see these topics.
 
-* :ref:`Working with HTML Components`
+* :ref:`Working with Text Components`
 * :ref:`Working with Problem Components`
 * :ref:`Working with Video Components`
 

--- a/en_us/shared/course_features/content_experiments/content_experiments_add.rst
+++ b/en_us/shared/course_features/content_experiments/content_experiments_add.rst
@@ -125,7 +125,7 @@ You add content for both groups as needed, just as you would add content to
 any container page. For more information, see :ref:`Components that Contain
 Other Components`.
 
-For example, you can add an HTML component and a video to Group A.
+For example, you can add a Text component and a video to Group A.
 
 .. image:: ../../../../shared/images/a_b_test_child_expanded.png
  :alt: An image of an expanded content experiment component with an HTML and

--- a/en_us/shared/course_features/lti/lti_address_content.rst
+++ b/en_us/shared/course_features/lti/lti_address_content.rst
@@ -221,7 +221,7 @@ LTI URLs for a unit include "vertical", as follows.
 
   ``https://edx-lti.org/lti_provider/courses/edX/DemoX/2014/i4x:;_;_edX;_DemoX;_vertical;_d6cee45205a449369d7ef8f159b22bdf``
 
-LTI URLs for HTML components include "html+block" or "html", as follows.
+LTI URLs for Text components include "html+block" or "html", as follows.
 
   ``https://edx-lti.org/lti_provider/courses/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@html+block@f9f3a25e7bab46e583fd1fbbd7a2f6a0``
 

--- a/en_us/shared/course_features/lti/lti_prepare_content.rst
+++ b/en_us/shared/course_features/lti/lti_prepare_content.rst
@@ -136,7 +136,7 @@ removing components, or disable course features that you do not plan to use.
      - No
    * - Discussion Components
      - No
-   * - HTML Components
+   * - Text Components
      - Yes
    * - Internal Links
      - No

--- a/en_us/shared/developing_course/course_components.rst
+++ b/en_us/shared/developing_course/course_components.rst
@@ -30,8 +30,8 @@ your course.
 * **Discussion** components provide discussion spaces in the body of your
   course. Learners can explore ideas about a lesson with their peers in a
   discussion space.
-* **HTML** components allow you to add text, images, and some types of learning
-  tools to your course. Content in HTML components is formatted as HTML.
+* **Text** components allow you to add text, images, and some types of learning
+  tools to your course. Content in Text components is formatted as HTML.
 * **Problem** components enable you to add many different types of exercises
   and problems to your course, from simple multiple choice problems to complex
   circuit schematic exercises.
@@ -54,7 +54,7 @@ For more information, see the documentation for the specific component type
 that you want to work with.
 
 - :ref:`Working with Discussion Components`
-- :ref:`Working with HTML Components`
+- :ref:`Working with Text Components`
 - :ref:`Working with Problem Components`
 - :ref:`Working with Video Components`
 
@@ -359,7 +359,7 @@ View Child Components
 
 When you select **View** in the parent component, the parent component page
 opens, showing all child components. In this example, Child Component A
-contains an HTML component and a video.
+contains a Text component and a video.
 
 .. image:: ../../../shared/images/child-components-a.png
  :alt: An expanded child component.
@@ -390,7 +390,7 @@ For more information, see the section for the specific component type that you
 want.
 
 - :ref:`Working with Discussion Components`
-- :ref:`Working with HTML Components`
+- :ref:`Working with Text Components`
 - :ref:`Working with Problem Components`
 - :ref:`Working with Video Components`
 

--- a/en_us/shared/developing_course/course_units.rst
+++ b/en_us/shared/developing_course/course_units.rst
@@ -24,7 +24,7 @@ A unit is a part of a :ref:`subsection<Developing Course Subsections>` that
 learners view as a single page.
 
 A unit contains one or more :ref:`components<Developing Course Components>`,
-such as text with :ref:`HTML<Working with HTML Components>` markup,
+such as text with :ref:`HTML<Working with Text Components>` markup,
 :ref:`problems<Working with Problem Components>`, a :ref:`discussion<Working
 with Discussion Components>`, or a
 :ref:`video<Working with Video Components>`.

--- a/en_us/shared/developing_course/workflow.rst
+++ b/en_us/shared/developing_course/workflow.rst
@@ -106,7 +106,7 @@ For more information, see :ref:`Controlling Content Visibility`.
   Making Course Content Searchable
   ***********************************
 
-  Learners can search course text in :ref:`HTML components<Working with HTML
+  Learners can search course text in :ref:`Text components<Working with Text
   Components>` and video transcripts by using the **Search** box at the top of
   the **Course** page.
 

--- a/en_us/shared/exercises_tools/completion.rst
+++ b/en_us/shared/exercises_tools/completion.rst
@@ -51,7 +51,7 @@ The Completion Control
 
 When you add a completion component to a unit, learners see a control that is
 labeled **Mark as complete**. In this example, the completion component follows
-an HTML component.
+a Text component.
 
 .. image:: ../../../shared/images/completion_markcomplete.png
   :alt: The completion component in an incomplete state.

--- a/en_us/shared/exercises_tools/create_exercises_and_tools.rst
+++ b/en_us/shared/exercises_tools/create_exercises_and_tools.rst
@@ -31,7 +31,7 @@ varies. The levels of support are categorized as full, provisional, or no
 support. This table provides the definition for each level of support.
 
 In Studio, the support level for each exercise, problem type, or tool is
-represented with an icon when you select **Advanced**, **HTML**, or
+represented with an icon when you select **Advanced**, **Text**, or
 **Problem** to add a new component to your course. By default, only fully
 supported or provisionally supported exercises, problem types, or tools are
 available for adding to your course. To add unsupported problem types and
@@ -87,7 +87,7 @@ types of course content.
   information, see :ref:`Enable Additional Exercises and Tools`.
 
 * After you enable an exercise or tool for use in your course, you might need
-  to select **Advanced**, **HTML**, or **Problem** on the unit page to
+  to select **Advanced**, **Text**, or **Problem** on the unit page to
   add content of that type to your course.
 
 The topics in this section introduce the core set of problem types and a
@@ -343,7 +343,7 @@ tools that you can add to your course.
      - Provisional support
    * - :ref:`IFrame`
      - With the iframe tool, you can integrate ungraded exercises and tools
-       from any Internet site into an HTML component in your course.
+       from any Internet site into a Text component in your course.
      - Provisional support
    * - :ref:`LTI Component`
      - LTI components allow you to add an external learning application or non-

--- a/en_us/shared/exercises_tools/enable_exercises_tools.rst
+++ b/en_us/shared/exercises_tools/enable_exercises_tools.rst
@@ -12,7 +12,7 @@ expression input. To add these problem types to a course, you select
 You can expand the types of content you include in your course by enabling
 additional exercises and tools. After you enable an exercise or tool for use
 with your course, when you add a component to a unit, that type of content
-might be listed as one of the **Advanced**, **HTML**, or **Problem** options
+might be listed as one of the **Advanced**, **Text**, or **Problem** options
 
 ******************************************
 Enable an Exercise or Tool for Your Course

--- a/en_us/shared/exercises_tools/full_screen_image.rst
+++ b/en_us/shared/exercises_tools/full_screen_image.rst
@@ -43,7 +43,7 @@ Create a Full Screen Image
 #. Upload your image file to the **Files & Uploads** page. For more
    information, see :ref:`Add Files to a Course`.
 
-#. Under **Add New Component**, select **HTML**, and then select **Full Screen
+#. Under **Add New Component**, select **Text**, and then select **Full Screen
    Image Tool**.
 
 #. In the new component that appears, select **Edit**.
@@ -79,7 +79,7 @@ Create a Full Screen Image
      </a>
 
    .. note::
-     You can use this same HTML code in any HTML component, not just those
+     You can use this same HTML code in any Text component, not just those
      components you created as full screen images.
 
 #. Select **Save**.

--- a/en_us/shared/exercises_tools/iframe.rst
+++ b/en_us/shared/exercises_tools/iframe.rst
@@ -35,7 +35,7 @@ For more information about iframes, see the `iframe: The Inline Frame element
 Create an IFrame Tool
 ****************************
 
-To add an exercise or tool in an iframe, you create an iframe HTML component
+To add an exercise or tool in an iframe, you create an iframe Text component
 and add the URL of the page that contains the exercise or tool to the
 component. You can also add text and images both before and after the iframe.
 
@@ -44,7 +44,7 @@ component. You can also add text and images both before and after the iframe.
  the owner of that page to find out if an ``https`` version is available. Some
  websites do not allow their content to be embedded in iframes.
 
-#. Under **Add New Component**, select **HTML**, and then select **IFrame
+#. Under **Add New Component**, select **Text**, and then select **IFrame
    Tool**.
 
 #. In the new component, select **Edit**.

--- a/en_us/shared/exercises_tools/mathjax.rst
+++ b/en_us/shared/exercises_tools/mathjax.rst
@@ -6,7 +6,7 @@ Using MathJax for Mathematics
 
 To produce clear and professional-looking symbols and equations in web browser,
 edX uses `MathJax <https://www.mathjax.org/>`_. MathJax automatically formats
-the mathematical symbols and equations that you enter in HTML and problem
+the mathematical symbols and equations that you enter in Text and problem
 components using LaTeX notation into beautiful math.
 
 This topic provides some pointers to get you started. Many resources for
@@ -41,15 +41,15 @@ For display equations, you can do either of the following.
     ``[mathjax] equation [/mathjax]``
 
 *************************************
-Adding MathJax to HTML Components
+Adding MathJax to Text Components
 *************************************
 
-In the HTML component editor, you can use MathJax in both visual view and
+In the Text component editor, you can use MathJax in both visual view and
 HTML view.
 
 .. image:: ../../../shared/images/MathJax_HTML.png
  :alt: A composite image of four views of the same text and MathJax markup. The
-   HTML component editor visual view and HTML view are shown at the top, with
+   Text component editor visual view and HTML view are shown at the top, with
    the rendered text and equation on the Studio unit page and in the LMS below.
 
 *****************************************

--- a/en_us/shared/exercises_tools/molecule_editor.rst
+++ b/en_us/shared/exercises_tools/molecule_editor.rst
@@ -54,17 +54,17 @@ component followed by a problem component.
 
 #. Upload all of the files listed above to the **Files & Uploads** page in your
    course.
-#. Create the HTML component.
+#. Create the Text component.
 
-  #. In the unit where you want to create the problem, click **HTML** under
-     **Add New Component**, and then click **HTML**.
+  #. In the unit where you want to create the problem, click **Text** under
+     **Add New Component**, and then click **Text**.
   #. In the component that appears, click **Edit**.
-  #. In the component editor, paste the HTML component code from below.
+  #. In the component editor, paste the Text component code from below.
   #. Make any changes that you want, and then click **Save**.
 
 #. Create the problem component.
 
-  #. Under the HTML component, click **Problem** under **Add New Component**,
+  #. Under the Text component, click **Problem** under **Add New Component**,
      and then click **Blank Advanced Problem**.
   #. In the component that appears, click **Edit**.
   #. In the component editor, paste the problem component code from below.
@@ -76,9 +76,9 @@ component followed by a problem component.
 Molecule Editor Code
 ========================
 
-To create the molecule editor, you need an HTML component and a problem component.
+To create the molecule editor, you need a Text component and a problem component.
 
-HTML Component Code
+Text Component Code
 ***************************
 
 .. code-block:: xml

--- a/en_us/shared/exercises_tools/molecule_viewer.rst
+++ b/en_us/shared/exercises_tools/molecule_viewer.rst
@@ -41,7 +41,7 @@ Creating a molecule viewer tool has several steps.
 #. Move or edit some of the files that you downloaded.
 #. Upload a folder that contains all of the files that you downloaded and
    edited to your own file hosting site.
-#. Create an HTML component that contains an ``iframe`` element in Studio. The
+#. Create a Text component that contains an ``iframe`` element in Studio. The
    iframe references the files that you upload to the file hosting site.
 
 ================================================
@@ -102,7 +102,7 @@ Create a Component in Studio
 ===============================
 
 #. In Studio, open the unit where you want to add the molecule viewer.
-#. Under **Add New Component**, select **HTML**, and then select **IFrame
+#. Under **Add New Component**, select **Text**, and then select **IFrame
    Tool**.
 #. In the component editor that opens, replace the existing content with your
    own text.

--- a/en_us/shared/exercises_tools/notes.rst
+++ b/en_us/shared/exercises_tools/notes.rst
@@ -14,7 +14,7 @@ they read in the body of the course.
   :alt: Image of a course page that includes highlighted text and a note.
 
 .. note:: The notes tool is available for text, including text in
- HTML components. However, the tool is currently not available for discussions,
+ Text components. However, the tool is currently not available for discussions,
  exercises, video transcripts, or PDF documents.
 
 Learners can access their notes either in the body of the course or on a

--- a/en_us/shared/exercises_tools/peer_instruction_tool.rst
+++ b/en_us/shared/exercises_tools/peer_instruction_tool.rst
@@ -83,7 +83,7 @@ for the exercise.
 After your design is complete, you use Studio to add the assignment to your
 course.
 
-.. note:: You might consider including an HTML component before the peer
+.. note:: You might consider including a Text component before the peer
  instruction component to describe the workflow that learners will experience
  in this assessment type. You might also consider including a content-specific
  discussion component after the peer instruction component to give learners an

--- a/en_us/shared/exercises_tools/periodic_table.rst
+++ b/en_us/shared/exercises_tools/periodic_table.rst
@@ -30,16 +30,16 @@ To create a periodic table, you need the following files:
 To download all of these files in a .zip archive, go to
 http://files.edx.org/PeriodicTableFiles.zip.
 
-To create the periodic table, you need an HTML component.
+To create the periodic table, you need a Text component.
 
 #. Upload all of the files listed above *except PeriodicTable.txt* to the
    **Files & Uploads** page in your course.
-#. In the unit where you want to create the problem, click **HTML** under **Add
-   New Component**, and then click **HTML**.
+#. In the unit where you want to create the problem, click **Text** under **Add
+   New Component**, and then click **Text**.
 #. In the component that appears, click **Edit**.
 #. In the component editor, switch to the **HTML** tab.
 #. Open the PeriodicTable.txt file in any text editor.
 #. Copy all of the text in the PeriodicTable.txt file, and paste it into the
-   HTML component editor. (Note that the PeriodicTableHTML.txt file contains
+   Text component editor. (Note that the PeriodicTableHTML.txt file contains
    over 6000 lines of code. Paste all of this code into the component editor.)
 #. Click **Save**.

--- a/en_us/shared/exercises_tools/poll.rst
+++ b/en_us/shared/exercises_tools/poll.rst
@@ -89,7 +89,7 @@ Create a Poll
 
    The file contains a list of all the components in the unit, together with
    the URL names of the components. For example, the following file contains an
-   HTML component followed by a discussion component.
+   Text component followed by a discussion component.
 
    .. code-block:: xml
 

--- a/en_us/shared/exercises_tools/qualtrics.rst
+++ b/en_us/shared/exercises_tools/qualtrics.rst
@@ -38,8 +38,8 @@ Add a Qualtrics Survey to Your Course
 *************************************
 
 To add a Qualtrics survey to your course, you must :ref:`create the survey in
-Qualtrics <Create the Qualtrics Survey>`, and then :ref:`create an HTML
-component in Studio <Create the HTML Component in Studio>`.
+Qualtrics <Create the Qualtrics Survey>`, and then :ref:`create a Text
+component in Studio <Create the Text Component in Studio>`.
 
 .. _Create the Qualtrics Survey:
 
@@ -69,21 +69,21 @@ Create the Qualtrics Survey
 #. On the page that opens, select **Activate Survey** in the upper right
    corner.
 #. On the page that opens, locate the URL that is listed under **Your
-   Anonymous Survey Link**. You will add this URL to the HTML component for
+   Anonymous Survey Link**. You will add this URL to the Text component for
    your survey in Studio.
 
    .. note:: If you need to find this URL in the future, open your survey
     in Qualtrics, and then select the **Distribute Survey** tab at the top of
     the page.
 
-.. _Create the HTML Component in Studio:
+.. _Create the Text Component in Studio:
 
 =====================================
-Create the HTML Component in Studio
+Create the Text Component in Studio
 =====================================
 
 #. Open the unit where you want the survey to appear.
-#. Under **Add New Component**, select **HTML**, and then select **IFrame
+#. Under **Add New Component**, select **Text**, and then select **IFrame
    Tool**.
 #. Select **Edit** to open the component editor, and then select **HTML** in
    the menu bar.

--- a/en_us/shared/exercises_tools/zooming_image.rst
+++ b/en_us/shared/exercises_tools/zooming_image.rst
@@ -46,7 +46,7 @@ Create a Zooming Image Tool
    files for your course, see :ref:`Add Files to a Course`.
 
 #. Add a zooming image tool to your course. In the course outline in Studio,
-   select **Add New Component**, select **HTML**, and then select **Zooming
+   select **Add New Component**, select **Text**, and then select **Zooming
    Image Tool**.
 
 #. In the new component that appears, select **Edit**.

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -553,13 +553,13 @@ H
 
   See :ref:`Course Page`.
 
-.. _HTML Component:
+.. _Text Component:
 
-**HTML component**
+**Text component**
 
   A type of component that you can use to add and format text for your course.
-  An HTML component can contain text, lists, links, and images. For more
-  information, see :ref:`partnercoursestaff:Working with HTML Components`.
+  A Text component can contain text, lists, links, and images. For more
+  information, see :ref:`partnercoursestaff:Working with Text Components`.
 
 
 

--- a/en_us/shared/manage_live_course/bulk_email.rst
+++ b/en_us/shared/manage_live_course/bulk_email.rst
@@ -180,10 +180,10 @@ Styling
 =======
 
 Messages can include HTML styling, including text formatting and links. The
-email message editor offers the same formatting options as the HTML component
+email message editor offers the same formatting options as the Text component
 editor in Studio.
 
-For more information, see :ref:`Working with HTML Components`.
+For more information, see :ref:`Working with Text Components`.
 
 ======
 Images

--- a/en_us/shared/reaching_learners/design_for_mobile.rst
+++ b/en_us/shared/reaching_learners/design_for_mobile.rst
@@ -64,7 +64,7 @@ you design, test, and run your course.
 
 * When learners access your course using the edX Android and iPhone apps, they
   progress from component to component by swiping through them. It might seem
-  useful to include an HTML component in a unit for the purpose of providing a
+  useful to include a Text component in a unit for the purpose of providing a
   demarcation point or guiding learners to the next unit, but having to swipe
   through too many "markers" with no real course content is not a good
   experience for mobile users.

--- a/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
+++ b/en_us/shared/subsections/open_response_assessments/CreateORAAssignment.rst
@@ -67,7 +67,7 @@ Step 2. Add Prompts
 ******************************
 
 You can format text and add images inside an open response assessment prompt
-the same way you would for an HTML component. For more information, see
+the same way you would for a Text component. For more information, see
 :ref:`The Visual Editor`.
 
 To add :ref:`prompts<PA Prompts>`, or questions, to your ORA assignment,


### PR DESCRIPTION
## [TNL-9321](https://openedx.atlassian.net/browse/TNL-9321)

The Studio HTML component is being renamed as the Text component, with accompanying changes to the Studio text & icon. Modify the documentation to reflect this change. The name change is an external change only - the code still refers to the component as the HTML component.

Related edx-platform PR: https://github.com/edx/edx-platform/pull/29553

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [x] Subject matter expert: @marcotuts 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

