### PR TITLE
fix: enhanced staff grader not in Maple

### DIFF
--- a/en_us/open_edx_release_notes/source/maple.rst
+++ b/en_us/open_edx_release_notes/source/maple.rst
@@ -228,8 +228,6 @@ Other ORA features
 - Add a new button to edit an ORA in Studio
 - Make submission feedback full-width
 - UI Changes for Rubric Reuse
-- add toggle feature for enhanced staff grade
-
 
 
 LTI 1.3 and LTI Advantage Support


### PR DESCRIPTION
Hi @pdpinch - was writing blog posts and noticed this feature hasn't yet landed (see active work on the feature branch: https://github.com/edx/edx-ora2/tree/feature/ora_staff_grader) - so I think we should remove the reference to ESG in the docs.

Let me know if you know more than I do about this. I couldn't really find any "esg" PRs in the repo that would indicate a big feature merge.