### PR TITLE
feat: [AA-922] update weekly goals docs

### DIFF
--- a/en_us/install_operations/source/configuration/enable_weekly_learning_goals.rst
+++ b/en_us/install_operations/source/configuration/enable_weekly_learning_goals.rst
@@ -26,13 +26,11 @@ For more details on this feature or screenshots see this `blog post <https://ope
 Enable the feature
 **********************
 
-The following waffle flags need to be enabled:
+The following waffle flag needs to be enabled:
 
-#. course_goals.number_of_days_goals
+   ``course_experience.enable_course_goals``
 
-#. course_experience.enable_course_goals
-
-To send goal reminder emails, you need to regularly run the following `management command <https://github.com/edx/edx-platform/blob/master/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py#L101>`_.  
+To send goal reminder emails, you need to regularly run the following `management command <https://github.com/edx/edx-platform/blob/master/lms/djangoapps/course_goals/management/commands/goal_reminder_email.py#L101>`_.
 
 edx.org runs this command at the following cron schedule H \*/3 \* \* \*
 


### PR DESCRIPTION
## [AA-922](https://openedx.atlassian.net/browse/AA-922)

Remove the reference to the course_goals.number_of_days_goals flag
since it is no longer used.

Related to changes:
https://github.com/edx/edx-platform/pull/29705
https://github.com/openedx/frontend-app-learning/pull/789
