### PR TITLE
fix: inter-book references need to be sensitive to the version of the book

### DIFF
--- a/shared/conf.py
+++ b/shared/conf.py
@@ -7,6 +7,13 @@ import urllib
 
 import edx_theme
 
+# What release line is this?  Use "master" for master, and the release name
+# on release branches.  Zebrawood should have "zebrawood".
+release_line = "master"
+
+# The slug that is used by ReadTheDocs for this version of the projects.
+project_version = "latest" if (release_line == "master") else f"open-release-master.{release_line}"
+
 # on_rtd is whether we are on readthedocs.io, this line of code grabbed from docs.readthedocs.io
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
@@ -158,7 +165,7 @@ copyright = '{year}, edX Inc.'.format(year=datetime.datetime.now().year)
 
 def edx_rtd_url(slug):
     """Use this with the readthedoc project slug to create the full URL."""
-    return f"https://edx.readthedocs.io/projects/{slug}/en/latest/"
+    return f"https://edx.readthedocs.io/projects/{slug}/en/{project_version}/"
 
 def ism_location(dir_name):
     """Calculate the intersphinx_mapping location to use for a book.
@@ -195,4 +202,3 @@ extlinks = {
     # :jira:`TNL-4904` becomes: <a href='https://openedx.atlassian.net/browse/TNL-4904'>TNL-4904</a>
     'jira': ('https://openedx.atlassian.net/browse/%s', ''),
 }
-


### PR DESCRIPTION
A reference in the glossary was changed on master after maple, and now
maple builds fail because the reference goes to /latest/ rather than
/maple/.   This variable will let us change Maple to refer to other
maple books.

## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

Add a description of your changes with links to any relevant material.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 

- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

