### PR TITLE
docs: Add a tip with link for commit style

### DIFF
--- a/en_us/developers/source/process/contributor.rst
+++ b/en_us/developers/source/process/contributor.rst
@@ -46,6 +46,9 @@ list of requirements to be sure that your pull request is ready to be reviewed:
    docstrings, and good variable naming conventions are expected. See the
    :doc:`../style_guides/index` for more details.
 
+#. Commit messages should conform to `OEP-51\: Conventional Commits`_.
+This style categorizes commits to make them easier to understand.
+
 #. The pull request should be as small as possible. Each pull request should
    encompass only one idea: one bugfix, one feature, etc. Multiple features (or
    multiple bugfixes) should not be bundled into one pull request. A handful of
@@ -155,3 +158,4 @@ following links:
 
 .. _contributor's agreement with edX: http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf
 .. _compatible licenses: https://open.edx.org/open-edx-licensing
+.. _OEP-51\: Conventional Commits: https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html


### PR DESCRIPTION
It just adds a tip in the contributor guide, about the commit style
which is coverd [OEP 51](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html). 

Add a description of your changes with links to any relevant material.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
