### PR TITLE
docs: Remove IE from supported browsers

### DIFF
--- a/en_us/shared/browsers.rst
+++ b/en_us/shared/browsers.rst
@@ -14,7 +14,6 @@ Most current browsers will work on edX.org. For best performance, we recommend t
 We also support the latest versions of:
 
 * `Microsoft Edge`_
-* `Microsoft Internet Explorer`_
 * `Safari`_
 
 


### PR DESCRIPTION
See https://github.com/openedx/edx-platform/pull/30162

Per https://github.com/openedx/frontend-wg/issues/3 we no longer support IE 🎉 

Note that the [Learner Help Center for edX.org](https://support.edx.org/hc/en-us/articles/206211848-What-are-the-system-requirements-and-supported-browsers-on-edX-) indicates that IE is not supported but the [Open edX learner's guide](https://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html) does not, so this update fixes that.

@davidjoy 