### PR TITLE
docs: replace ginkgo links with maple links

### DIFF
--- a/en_us/open_edx_release_notes/source/links.rst
+++ b/en_us/open_edx_release_notes/source/links.rst
@@ -41,6 +41,12 @@
 
 .. Maple doc links:
 
+.. _Installing, Configuring, and Running the Open edX Platform\: Maple Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-maple.master
+
+.. _Building and Running an Open edX Course\: Maple Release: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-maple.master
+
+.. _Open edX Learner's Guide\: Maple Release: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-maple.master
+
 .. _Tutor: https://docs.tutor.overhang.io/
 
 .. _Studio OAuth migration runbook: https://github.com/edx/edx-platform/blob/open-release/maple.master/docs/guides/studio_oauth.rst
@@ -78,14 +84,6 @@
 .. _certificate availability date: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/set_up_course/studio_add_course_information/studio_creating_certificates.html#specify-a-different-certificates-available-date
 
 .. _fake the migration: https://docs.djangoproject.com/en/2.2/ref/django-admin/#cmdoption-migrate-fake
-
-.. Ginkgo doc links:
-
-.. _Installing, Configuring, and Running the Open edX Platform\: Ginkgo Release: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-ginkgo.master
-
-.. _Building and Running an Open edX Course\: Ginkgo Release: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-ginkgo.master
-
-.. _Open edX Learner's Guide\: Ginkgo Release: http://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-ginkgo.master
 
 
 .. Ficus doc links

--- a/en_us/open_edx_release_notes/source/os_documentation.rst
+++ b/en_us/open_edx_release_notes/source/os_documentation.rst
@@ -5,16 +5,16 @@ Open edX Documentation
 All Open edX documentation is available at `docs.edx.org`_.
 
 *****************************
-Ginkgo Release Documentation
+Maple Release Documentation
 *****************************
 
-The following documentation is available for the Open edX Ginkgo release.
+The current release of Open EdX is named Maple. The following documentation is available for the Open edX Maple release.
 
-* `Installing, Configuring, and Running the Open edX Platform: Ginkgo Release`_
+* `Installing, Configuring, and Running the Open edX Platform: Maple Release`_
 
-* `Building and Running an Open edX Course: Ginkgo Release`_
+* `Building and Running an Open edX Course: Maple Release`_
 
-* `Open edX Learner's Guide: Ginkgo Release`_
+* `Open edX Learner's Guide: Maple Release`_
 
 *******************************
 Latest Documentation


### PR DESCRIPTION
The page at https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/os_documentation.html is linking to ginkgo docs as if they are current. 

### Date Needed (optional)

we should merge this before nutmeg is release on June 9, 2022. 

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc

FYI: Tag anyone else who might be interested in this PR here.

@sarina 

### Testing

- [x] Ran `./run_tests.sh en_us/open_edx_release_notes` without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
