### PR TITLE
docs: be more explicit about access token expiry

### DIFF
--- a/en_us/course_catalog_api_user_guide/source/authentication/index.rst
+++ b/en_us/course_catalog_api_user_guide/source/authentication/index.rst
@@ -236,7 +236,8 @@ following list.
 
 * ``expires_in``: The length of time, in seconds, that the access token will be
   accepted. The period of time starts when the authentication service issues
-  the token.
+  the token. Note that this value may change at any time and should not be
+  hard-coded in any scripts that make requests for an access token.
 
 * ``scope``: The internal resources that your API client has access to. You do
   not need to use the information in the ``scope`` value.
@@ -250,14 +251,18 @@ the access token string.
 
 .. code-block:: json
 
-    { "access_token": "4IHZlbCB2aXZlcnJhIGdyYXZpZGEsIHJpc3V.TG9yZW0gaXBzdW0gZG9
-        sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRXRpYW0gdGluY2
-        lkdW50IG9kaW8gZWdldCB0aW5jaWR1bnQgcG9ydGEuIEZ1c2NlIHZlaGljdWxhIGFyY3Ugd
-        GVsbHVzLCBzaXQgYW1ldCBmcmluZ2lsbGEgZXN0IHByZXRpdW0gc2VkLiBDdXJhYml0dXIg
-        Y29uc2VxdWF0IHVsdHJpY2llcyB0cmlzdGlxdWUuIEluIGVzdCBwdXJ1cywgZmFjaWxpc2l
-        zIGFjIGxlY3R1cyBxdWlzLCBsdWN0dXMgdGVtcG9yIG9yY2kuIEludGVnZXIgdml0.YWUgb
-        mVxdWUgbGlndWxhLiBVdCBjb25zZXF1YXQsIGV", "expires_in": 36000, "scope":
-        "read write profile email", "token_type": "JWT" }
+    {
+      "access_token": "4IHZlbCB2aXZlcnJhIGdyYXZpZGEsIHJpc3V.TG9yZW0gaXBzdW0gZG9
+      sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gRXRpYW0gdGluY2
+      lkdW50IG9kaW8gZWdldCB0aW5jaWR1bnQgcG9ydGEuIEZ1c2NlIHZlaGljdWxhIGFyY3Ugd
+      GVsbHVzLCBzaXQgYW1ldCBmcmluZ2lsbGEgZXN0IHByZXRpdW0gc2VkLiBDdXJhYml0dXIg
+      Y29uc2VxdWF0IHVsdHJpY2llcyB0cmlzdGlxdWUuIEluIGVzdCBwdXJ1cywgZmFjaWxpc2l
+      zIGFjIGxlY3R1cyBxdWlzLCBsdWN0dXMgdGVtcG9yIG9yY2kuIEludGVnZXIgdml0.YWUgb
+      mVxdWUgbGlndWxhLiBVdCBjb25zZXF1YXQsIGV",
+      "expires_in": 180,
+      "scope": "read write profile email",
+      "token_type": "JWT"
+    }
 
 .. _using_an_access_token:
 

--- a/en_us/enterprise_api/source/authentication.rst
+++ b/en_us/enterprise_api/source/authentication.rst
@@ -69,6 +69,30 @@ submit further requests to the edX Enterprise API. For example:
     “access_token”:
     “g1Bb0usqwe345ty…”,
     “token_type”: “JWT”,
-    “expires_in”: “36000”,
+    “expires_in”: “180”,
     “scope”: “read write profile email”
   }
+
+==================================================
+Understanding the Authentication Endpoint Response
+==================================================
+
+The edX API authentication endpoint returns JSON data that includes an
+access token string and information about that access token.
+
+The values in the authentication endpoint response data are described in the
+following list.
+
+* ``access_token``: The access token string that you can use to make API
+  requests.
+
+* ``expires_in``: The length of time, in seconds, that the access token will be
+  accepted. The period of time starts when the authentication service issues
+  the token. Note that this value may change at any time and should not be
+  hard-coded in any scripts that make requests for an access token.
+
+* ``scope``: The internal resources that your API client has access to. You do
+  not need to use the information in the ``scope`` value.
+
+* ``token_type``: A description of the format of the access token. You specify
+  the format of an access token when you use that token to make API requests.


### PR DESCRIPTION
* Update course_catalog_api_user_guide to make it clear that `expires_in` may change and should not be hard-coded.
* Make similar update in enterprise_api.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [x] Subject matter expert: @robrap 
- [ ] Partner support: 
- [x] PM review: @mattdrayer 

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
