### PR TITLE
feat: molecule editor tool deprecated

### DIFF
--- a/en_us/open_edx_course_authors/locales/pot/exercises_tools.pot
+++ b/en_us/open_edx_course_authors/locales/pot/exercises_tools.pot
@@ -7104,7 +7104,7 @@ msgid "A composite image of four views of the same multiple choice problem. The\
 msgstr ""
 
 #: ../../../shared/exercises_tools/molecule_editor.rst:5
-msgid "Molecule Editor Tool"
+msgid "Molecule Editor Tool (Deprecated)"
 msgstr ""
 
 #: ../../../shared/exercises_tools/molecule_editor.rst:9

--- a/en_us/shared/exercises_tools/molecule_editor.rst
+++ b/en_us/shared/exercises_tools/molecule_editor.rst
@@ -1,8 +1,8 @@
 .. _Molecule Editor:
 
-#######################
-Molecule Editor Tool
-#######################
+#################################
+Molecule Editor Tool (Deprecated)
+#################################
 
 .. note:: EdX does not support this tool.
 


### PR DESCRIPTION
Quick and simple change to update the Molecule Editor Tool to say 'Deprecated' as the tool was deprecated back on July 6th.
TNL-10031 https://2u-internal.atlassian.net/browse/TNL-10031
