### PR TITLE
docs: add Olive release pages

### DIFF
--- a/en_us/install_operations/source/platform_releases/index.rst
+++ b/en_us/install_operations/source/platform_releases/index.rst
@@ -10,6 +10,7 @@ platform:
 .. toctree::
     :maxdepth: 2
 
+    olive
     nutmeg
     maple
     lilac

--- a/en_us/install_operations/source/platform_releases/olive.rst
+++ b/en_us/install_operations/source/platform_releases/olive.rst
@@ -60,13 +60,5 @@ Upgrading a Docker Installation
 Devstack is installed using Docker. To upgrade from one Olive
 release to another, follow the instructions in `devstack`_.
 
-===============================
-Upgrading a Native Installation
-===============================
-
-If you installed Open edX using the `Open edX Native Installation`_, you can
-upgrade from one Olive release to another by re-running those steps using
-your desired Olive tag as the new value for ``OPENEDX_RELEASE``.
-
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/platform_releases/olive.rst
+++ b/en_us/install_operations/source/platform_releases/olive.rst
@@ -1,0 +1,72 @@
+.. _Open edX Olive Release:
+
+######################
+Open edX Olive Release
+######################
+
+This section describes how to install the Open edX Olive release.
+
+.. contents::
+ :local:
+ :depth: 1
+
+*************************
+What's Included in Olive
+*************************
+
+The Open edX Olive release contains several new features for learners,
+course teams, and developers. For more information, see the
+`Open edX Platform Release Notes`__.
+
+__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/olive.html
+
+**************************
+What Is the Olive Git Tag?
+**************************
+
+A git tag identifies the version of Open edX code that is the Olive release.
+Over fourty repositories are tagged as part of an Open edX release. Many
+other repositories are installed as dependencies of those repositories. You can
+find the most up-to-date git tag for Olive on the
+`Open edX Named Releases page`_.
+
+****************************
+Installing the Olive Release
+****************************
+
+TODO: Write this for Tutor.
+
+Olive releases have git tag names like ``open-release/olive.1``.
+The available names are detailed on the `Open edX Named Releases page`_.
+
+*********************************
+Upgrading from the Nutmeg Release
+*********************************
+
+TODO: This needs to be written for Tutor.
+
+***************************************
+Upgrading to a Subsequent Olive Release
+***************************************
+
+Occasionally, we release updates to Olive.  For example, the second
+release of Olive will be ``open-release/olive.2``.
+The steps to upgrade differ based on your original installation method.
+
+===============================
+Upgrading a Docker Installation
+===============================
+
+Devstack is installed using Docker. To upgrade from one Olive
+release to another, follow the instructions in `devstack`_.
+
+===============================
+Upgrading a Native Installation
+===============================
+
+If you installed Open edX using the `Open edX Native Installation`_, you can
+upgrade from one Olive release to another by re-running those steps using
+your desired Olive tag as the new value for ``OPENEDX_RELEASE``.
+
+
+.. include:: ../../../links/links.rst

--- a/en_us/open_edx_release_notes/source/index.rst
+++ b/en_us/open_edx_release_notes/source/index.rst
@@ -11,6 +11,7 @@ The *Open edX Platform Release Notes* provide information about releases, migrat
 
     front_matter/index
     os_documentation
+    olive
     nutmeg
     maple
     lilac

--- a/en_us/open_edx_release_notes/source/olive.rst
+++ b/en_us/open_edx_release_notes/source/olive.rst
@@ -1,0 +1,25 @@
+.. _Open edX Olive Release:
+
+######################
+Open edX Olive Release
+######################
+
+These are the release notes for the Olive release, the 15th community release of the Open edX Platform, spanning changes from April 11 2022 to October 11 2022.  You can also review details about `earlier releases`_ or learn more about the `Open edX Platform`_.
+
+.. _earlier releases: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/named_releases.html
+.. _Open edX Platform: https://openedx.org
+
+.. contents::
+ :depth: 1
+ :local:
+
+================
+Breaking Changes
+================
+
+TODO
+
+
+.. include:: links.rst
+.. include:: ../../links/links.rst
+


### PR DESCRIPTION
This kicks off the Olive docs as outlined on [the release process page](https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#Make-release-specific-changes-on-the-release-branch).

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
