### PR TITLE
docs: add 'Olive' to titles

### DIFF
--- a/en_us/install_operations/source/conf.py
+++ b/en_us/install_operations/source/conf.py
@@ -6,7 +6,7 @@ sys.path.append('../../../')
 from shared.conf import *
 
 # General information about the project.
-project = u'Installing, Configuring, and Running the Open edX Platform'
+project = u'Installing, Configuring, and Running the Open edX Platform: Olive Release'
 set_audience(OPENEDX, DEVELOPERS)
 
 # remove directory when content is first added to it, and add it to index

--- a/en_us/install_operations/source/index.rst
+++ b/en_us/install_operations/source/index.rst
@@ -1,8 +1,8 @@
 .. _Installing, Configuring, and Running the Open edX Platform:
 
-###########################################################
-Installing, Configuring, and Running the Open edX Platform
-###########################################################
+#########################################################################
+Installing, Configuring, and Running the Open edX Platform: Olive Release
+#########################################################################
 
 This guide provides instructions for using your own instance of the Open edX
 platform and associated applications.

--- a/en_us/open_edx_course_authors/source/conf.py
+++ b/en_us/open_edx_course_authors/source/conf.py
@@ -14,4 +14,4 @@ product = 'Open_edX'
 def setup(app):
     app.add_config_value('product', '', True)
 
-project = u'Building and Running an Open edX Course'
+project = u'Building and Running an Open edX Course: Olive Release'

--- a/en_us/open_edx_course_authors/source/index.rst
+++ b/en_us/open_edx_course_authors/source/index.rst
@@ -1,8 +1,8 @@
 .. _Building and Running an Open edX Course:
 
-#######################################
-Building and Running an Open edX Course
-#######################################
+######################################################
+Building and Running an Open edX Course: Olive Release
+######################################################
 
 .. toctree::
    :numbered:

--- a/en_us/open_edx_students/source/conf.py
+++ b/en_us/open_edx_students/source/conf.py
@@ -5,7 +5,7 @@ sys.path.append('../../../')
 
 from shared.conf import *
 
-project = u'Open edX Learner\'s Guide'
+project = u'Open edX Learner\'s Guide: Olive Release'
 
 exclude_patterns = ['links.rst', 'reusables/*', 'SFD_mathformatting.rst']
 

--- a/en_us/open_edx_students/source/index.rst
+++ b/en_us/open_edx_students/source/index.rst
@@ -1,8 +1,8 @@
 .. _Open edX Learner's Guide:
 
-########################
-Open edX Learner's Guide
-########################
+#######################################
+Open edX Learner's Guide: Olive Release
+#######################################
 
 .. toctree::
    :numbered:


### PR DESCRIPTION
This adds "Olive Release" to titles in the `open-release/olive.master` branch as instructed by the release instructions:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#Make-release-specific-changes-on-the-release-branch

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Doc team review (sanity check, copy edit, or dev edit?): @edx/doc
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
