### PR TITLE
fix: xblock-sdk setup instructions

### DIFF
--- a/en_us/xblock-tutorial/source/reusable/clone_sdk.rst
+++ b/en_us/xblock-tutorial/source/reusable/clone_sdk.rst
@@ -15,17 +15,24 @@ requirements. To do this, complete the following steps at a command prompt.
 
       (venv) $ git clone https://github.com/openedx/xblock-sdk.git
 
+#. In the same directory, create an empty directory called `var`.
+
+   .. code-block:: bash
+
+      (venv) $ mkdir var
+
 #. Run the following command to change to the ``xblock-sdk`` directory.
 
    .. code-block:: bash
   
       (venv) $ cd xblock-sdk
 
-#. Run the following command to install the XBlock SDK requirements.
+#. Run the following commands to install the XBlock SDK requirements.
 
    .. code-block:: bash
   
       (venv) $ pip install -r requirements/base.txt
+      (venv) $ make install
 
 #. Run the following command to return to the ``xblock_development`` directory,
    where you will perform the rest of your work.

--- a/en_us/xblock-tutorial/source/reusable/clone_sdk.rst
+++ b/en_us/xblock-tutorial/source/reusable/clone_sdk.rst
@@ -31,7 +31,6 @@ requirements. To do this, complete the following steps at a command prompt.
 
    .. code-block:: bash
   
-      (venv) $ pip install -r requirements/base.txt
       (venv) $ make install
 
 #. Run the following command to return to the ``xblock_development`` directory,


### PR DESCRIPTION
Fixes #1714

I was not able to run the xblock-sdk locally without adding the steps I added to the documentation, in line with the mentioned issue and the user discussion here: https://groups.google.com/g/edx-code/c/PAru0A1k3No/m/IfFXAu80AQAJ?pli=1

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
