### PR TITLE
build: Change how we run `make upgrade`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,18 @@ $(COMMON_CONSTRAINTS_TXT):
 	wget -O "$(@)" https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt || touch "$(@)"
 
 # Define PIP_COMPILE_OPTS=-v to get more information during make upgrade.
-PIP_COMPILE = pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
+PIP_COMPILE = cd requirements/; pip-compile --rebuild --upgrade $(PIP_COMPILE_OPTS)
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: $(COMMON_CONSTRAINTS_TXT)  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!
-	$(PIP_COMPILE) --allow-unsafe -o requirements/pip.txt requirements/pip.in
-	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
+	$(PIP_COMPILE) --allow-unsafe -o pip.txt pip.in
+	$(PIP_COMPILE) -o pip-tools.txt pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt
-	$(PIP_COMPILE) -o requirements/base.txt requirements/base.in
-	$(PIP_COMPILE) -o requirements/dev.txt requirements/dev.in
+	$(PIP_COMPILE) -o base.txt base.in
+	$(PIP_COMPILE) -o dev.txt dev.in
 
 clean: ## remove built html files
 	make -C en_us clean


### PR DESCRIPTION
Previously we use to run all the complie commands from the top-level
directory. We change it so that we run the command from within the
`requirements` directory so that the output paths match how pip-compile
is being run by dependabot.

This is an experiment to see if we can replace our own github actions
with Dependabot for python upgrades.
