### PR TITLE
fix: Remove missed reference of Molecule Editor

### DIFF
--- a/en_us/shared/exercises_tools/custom_python.rst
+++ b/en_us/shared/exercises_tools/custom_python.rst
@@ -29,7 +29,6 @@ problem types.
 * :ref:`Chemical Equation`
 * :ref:`Custom JavaScript`
 * :ref:`Gene Explorer`
-* :ref:`Molecule Editor`
 * :ref:`Protein Builder`
 
 ********************************************************


### PR DESCRIPTION
@feanil I missed this one, and it failed the master build https://github.com/openedx/edx-documentation/actions/runs/4188038291/jobs/7258665351