### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/en_us/students_redirect/source/completing_assignments/SFD_proctored_exams.rst
+++ b/en_us/students_redirect/source/completing_assignments/SFD_proctored_exams.rst
@@ -1,1 +1,0 @@
-.. include:: ../../../shared/learner_moved.rst

--- a/en_us/students_redirect/source/completing_assignments/online_proctoring_rules_students.rst
+++ b/en_us/students_redirect/source/completing_assignments/online_proctoring_rules_students.rst
@@ -1,1 +1,0 @@
-.. include:: ../../../shared/learner_moved.rst

--- a/en_us/students_redirect/source/index.rst
+++ b/en_us/students_redirect/source/index.rst
@@ -41,10 +41,8 @@ edX Learner's Guide
    completing_assignments/proctored_exams/SFD_proctoring_technical_problems
    completing_assignments/proctored_exams/online_proctoring_rules_students
    completing_assignments/timed_exams
-   completing_assignments/SFD_proctored_exams
    completing_assignments/SFD_mathformatting
    completing_assignments/interactive_multiple_choice
-   completing_assignments/online_proctoring_rules_students
    SFD_ORA
    SFD_mathformatting
    SFD_google_docs

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,7 +1,7 @@
 # Core dependencies for documentation builds
 -c constraints.txt
 
-edx-sphinx-theme                    # edX theme for the generated documentation
+sphinx-book-theme                   # Common theme for all Open edX projects
 sphinx                              # Documentation builder
 sphinx-intl                         # i18n tool to create .po files
 sphinx-reredirects                  # Redirect pages that have moved.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,12 +4,17 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 babel==2.12.1
     # via
+    #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-intl
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 certifi==2022.12.7
     # via requests
 charset-normalizer==3.1.0
@@ -17,9 +22,9 @@ charset-normalizer==3.1.0
 click==8.1.3
     # via sphinx-intl
 docutils==0.19
-    # via sphinx
-edx-sphinx-theme==3.1.0
-    # via -r base.in
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
 idna==3.4
     # via requests
 imagesize==1.4.1
@@ -31,24 +36,34 @@ jinja2==3.1.2
 markupsafe==2.1.2
     # via jinja2
 packaging==23.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.0
-    # via sphinx
+    # via
+    #   accessible-pygments
+    #   pydata-sphinx-theme
+    #   sphinx
 pytz==2023.3
     # via babel
 requests==2.28.2
     # via sphinx
-six==1.16.0
-    # via edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -c common_constraints.txt
     #   -r base.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
     #   sphinx-intl
     #   sphinx-reredirects
+sphinx-book-theme==1.0.1
+    # via -r base.in
 sphinx-intl==2.1.0
     # via -r base.in
 sphinx-reredirects==0.1.1
@@ -65,6 +80,8 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+typing-extensions==4.5.0
+    # via pydata-sphinx-theme
 urllib3==1.26.15
     # via requests
 zipp==3.15.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via
+    #   -r base.txt
+    #   pydata-sphinx-theme
 alabaster==0.7.13
     # via
     #   -r base.txt
@@ -11,8 +15,13 @@ alabaster==0.7.13
 babel==2.12.1
     # via
     #   -r base.txt
+    #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-intl
+beautifulsoup4==4.12.2
+    # via
+    #   -r base.txt
+    #   pydata-sphinx-theme
 build==0.10.0
     # via pip-tools
 certifi==2022.12.7
@@ -31,9 +40,8 @@ click==8.1.3
 docutils==0.19
     # via
     #   -r base.txt
+    #   pydata-sphinx-theme
     #   sphinx
-edx-sphinx-theme==3.1.0
-    # via -r base.txt
 idna==3.4
     # via
     #   -r base.txt
@@ -58,12 +66,19 @@ packaging==23.1
     # via
     #   -r base.txt
     #   build
+    #   pydata-sphinx-theme
     #   sphinx
 pip-tools==6.13.0
     # via -r dev.in
+pydata-sphinx-theme==0.13.3
+    # via
+    #   -r base.txt
+    #   sphinx-book-theme
 pygments==2.15.0
     # via
     #   -r base.txt
+    #   accessible-pygments
+    #   pydata-sphinx-theme
     #   sphinx
 pyproject-hooks==1.0.0
     # via build
@@ -75,20 +90,23 @@ requests==2.28.2
     # via
     #   -r base.txt
     #   sphinx
-six==1.16.0
-    # via
-    #   -r base.txt
-    #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via
     #   -r base.txt
     #   sphinx
+soupsieve==2.4.1
+    # via
+    #   -r base.txt
+    #   beautifulsoup4
 sphinx==5.3.0
     # via
     #   -r base.txt
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
     #   sphinx-intl
     #   sphinx-reredirects
+sphinx-book-theme==1.0.1
+    # via -r base.txt
 sphinx-intl==2.1.0
     # via -r base.txt
 sphinx-reredirects==0.1.1
@@ -119,6 +137,10 @@ sphinxcontrib-serializinghtml==1.1.5
     #   sphinx
 tomli==2.0.1
     # via build
+typing-extensions==4.5.0
+    # via
+    #   -r base.txt
+    #   pydata-sphinx-theme
 urllib3==1.26.15
     # via
     #   -r base.txt

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -4,8 +4,7 @@ import datetime
 import os
 import sys
 import urllib
-
-import edx_theme
+from pathlib import Path
 
 # What release line is this?  Use "master" for master, and the release name
 # on release branches.  Zebrawood should have "zebrawood".
@@ -38,7 +37,6 @@ pygments_style = 'sphinx'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'edx_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -68,14 +66,45 @@ if on_rtd:
     html_context["github_base_account"] = 'edx'
     html_context["github_project"] = 'edx-documentation'
 
-html_theme = 'edx_theme'
+html_theme = 'sphinx_book_theme'
+path_to_docs = '/'.join(Path.cwd().parts[-3:])
 
-html_theme_path = [edx_theme.get_html_theme_path()]
-
-html_theme_options = {}
+# html_theme_path = []
+html_theme_options = {
+    "repository_url": "https://github.com/openedx/edx-documentation",
+    "repository_branch": "master",
+    "path_to_docs": path_to_docs,
+    "home_page_in_toc": True,
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+    # Please don't change unless you know what you're doing.
+    "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >The Axim Collaborative</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
 html_theme_options['navigation_depth'] = 3
 
-html_favicon = os.path.join(edx_theme.get_html_theme_path(), 'edx_theme', 'static', 'css', 'favicon.ico')
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 # Help and Feedback links.  These are customized for the category and audience
 # of the book.  Add a line to the book's conf.py like this:
@@ -150,7 +179,7 @@ if the_builder != "json":
 
 # General information about the project.
 
-copyright = '{year}, edX Inc.'.format(year=datetime.datetime.now().year)
+copyright = '{year}, The Axim Collaborative'.format(year=datetime.datetime.now().year)
 
 # Intersphinx manages the connections between books.
 # Normally the references in a book are downloaded from readthedocs.  But you


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:**
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

See https://github.com/openedx/public-engineering/issues/200