### PR TITLE
feat: problem editor correct build error

### DIFF
--- a/en_us/shared/exercises_tools/single_select.rst
+++ b/en_us/shared/exercises_tools/single_select.rst
@@ -355,6 +355,8 @@ Adding Hints
 
 .. include:: ../../../shared/exercises_tools/Subsection_configure_hints_advanced.rst
 
+.. _Awarding Partial Credit in a Multiple Choice Problem:
+
 ========================================
 Awarding Partial Credit
 ========================================


### PR DESCRIPTION
There was a build error after merging https://github.com/openedx/edx-documentation/pull/2124. The error is for a missing link.

This PR corrects that build error by adding the link.