### PR TITLE
feat: problem editor advanced problem show answer

### DIFF
--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -575,7 +575,7 @@ settings to the right of the problem editor after clicking
 **Show advanced settings**.
 
 The Advanced Editor retains several settings from the simple editor such as
-**Scoring**, **Show answer**, **Show reset option**, **Time between attempts**
+**Scoring**, **Show answer**, **Time between attempts**
 and **MATLAB API Key** as well as introduces the **Randomization** setting.
 While the other settings are not shown on the collapsible panes to the right of
 the problem editor, they can be added via editing the OLX.


### PR DESCRIPTION
This PR makes a minor change to ch 8.4 Working with Problem Components. In the advanced problem editor, there is no `Show reset` settings widget. This PR updates the docs to reflect this.

https://2u-internal.atlassian.net/browse/TNL-10622