### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -64,8 +64,7 @@ overview of the process is here:
    :target: ../_images/pr-process.png
 
 .. _Open edX Proposal (OEP) process: http://open-edx-proposals.readthedocs.io/en/latest/
-.. _The instructions here: https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst#step-0-join-the-conversation
-.. _contribution agreement: https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst#step-1-sign-a-contribution-agreement
+.. _contribution agreement: https://openedx.org/cla
 
 General Guidelines
 ------------------


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide and the CLA
can be linked to directly.

The 'instructions here' link was not being referenced anywhere.


