### PR TITLE
docs: Cross link the two types of contirbuting docs.

### DIFF
--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -6,7 +6,7 @@ Process for Contributing Code
 
    Looking for fewer words? Check out the `concise contributing guide <https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+Start+Contributing+Code>`_.
 
-Open edX is a massive project, and we would love you to help us build
+The Open edX project is massive, and we would love you to help us build
 the best online education system in the world -- we can't do it alone!
 However, the core committers on the project are also developing features
 and creating pull requests, so we need to balance reviewing time with

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -4,7 +4,7 @@ Process for Contributing Code
 
 .. tip::
 
-   Looking for fewer words? Checkout the `concise contributing guide <https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+Start+Contributing+Code>`_
+   Looking for fewer words? Check out the `concise contributing guide <https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+Start+Contributing+Code>`_.
 
 Open edX is a massive project, and we would love you to help us build
 the best online education system in the world -- we can't do it alone!

--- a/en_us/developers/source/process/overview.rst
+++ b/en_us/developers/source/process/overview.rst
@@ -2,6 +2,10 @@
 Process for Contributing Code
 *****************************
 
+.. tip::
+
+   Looking for fewer words? Checkout the `concise contributing guide <https://openedx.atlassian.net/wiki/spaces/COMM/pages/941457737/How+to+Start+Contributing+Code>`_
+
 Open edX is a massive project, and we would love you to help us build
 the best online education system in the world -- we can't do it alone!
 However, the core committers on the project are also developing features


### PR DESCRIPTION
The verbose docs can be really useful if you need a lot of hand holding and details
but the quick docs are a better entrypoint for most people getting started if we
don't want to overwhelm them.

Cross link the two docs so that people can jump back and forth as it makes
sense for them.

closes https://github.com/openedx/docs.openedx.org/issues/251