### PR TITLE
feat: edX projects get edX logos

### DIFF
--- a/en_us/course_authors/source/conf.py
+++ b/en_us/course_authors/source/conf.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('../../../')
 
 from shared.conf import *
+from shared.edxconf import *
 
 project = u'Building and Running an edX Course'
 

--- a/en_us/course_catalog_api_user_guide/source/conf.py
+++ b/en_us/course_catalog_api_user_guide/source/conf.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('../../../')
 
 from shared.conf import *
+from shared.edxconf import *
 
 project = u'EdX Course Catalog API User Guide'
 

--- a/en_us/discovery_api/source/conf.py
+++ b/en_us/discovery_api/source/conf.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('../../../')
 
 from shared.conf import *
+from shared.edxconf import *
 
 project = u'Discovery Service API Guide'
 

--- a/en_us/enterprise_api/source/conf.py
+++ b/en_us/enterprise_api/source/conf.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('../../../')
 
 from shared.conf import *
+from shared.edxconf import *
 
 project = u'EdX Enterprise API Guide'
 

--- a/en_us/students_redirect/source/conf.py
+++ b/en_us/students_redirect/source/conf.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('../../../')
 
 from shared.conf import *
+from shared.edxconf import *
 
 project = u'EdX Learner\'s Guide'
 

--- a/shared/edxconf.py
+++ b/shared/edxconf.py
@@ -1,0 +1,12 @@
+"""
+Settings common to all edX projects.
+
+Import this into conf.py after the common configuration::
+
+    from shared.conf import *
+    from shared.edxconf import *
+
+"""
+
+html_logo = "https://www.edx.org/images/logos/edx-logo-elm.svg"
+html_favicon = "https://www.edx.org/favicon.ico"


### PR DESCRIPTION
The projects that are specific to edX now get edX logos and favicon instead of Open edX ones.  Here's an example of the result: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/nedbat-edx-logos/

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
