### PR TITLE
docs: adds note about the auto linking flag in LTI Consumer configuration

### DIFF
--- a/en_us/install_operations/source/configuration/lti/authentication_options_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/authentication_options_lti.rst
@@ -16,6 +16,8 @@ The Open edX system supports these user authentication flows for LTI.
    :local:
    :depth: 1
 
+.. _Anonymous User Authentication:
+
 ******************************
 Anonymous User Authentication
 ******************************

--- a/en_us/install_operations/source/configuration/lti/configure_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/configure_lti.rst
@@ -93,11 +93,10 @@ follow these steps.
        - Setting this flag only associates future interactions of the learner.
          This flag cannot be used to migrate data from existing anonymous accounts
          to corresponding user accounts.
-       - Unchecking the flag will not roll back the auto-linked users and
-         might cause the LTI content to break completely. In situations
-         requiring rollback of this feature, it is recommended to create a
-         new LTI Consumer with this flag turned off and the new credentials
-         be used in the LTI consumer application.
+       - Unchecking the flag will not roll back the auto-linked users. In
+         situations requiring rollback of this feature, it is recommended
+         to create a new LTI Consumer with this flag turned off, and the
+         new credentials be used in the LTI consumer application.
 
 
 #. Select **Save** at the bottom of the page.

--- a/en_us/install_operations/source/configuration/lti/configure_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/configure_lti.rst
@@ -49,23 +49,38 @@ follow these steps.
      tool consumer. Alternatively, you can use an external application to
      generate the secret, and then enter it here.
 
-   .. important:: Do not supply a value for the **Instance guid** field. The
-      tool consumer generates and supplies a globally unique identifier.
+     .. important::
+       Do not supply a value for the **Instance guid** field. The
+       tool consumer generates and supplies a globally unique identifier.
 
-    - **Auto link users using email:** Check this if the learners accessing the
-      content via LTI already have an account in the edX platform using the same
-      email as the LTI Consumer and you want the data they generate (like
-      submissions and grades) on the platform to be associated with that
-      account instead of the Anonymous account that's created by default. This
-      is done by making use of the ``lis_person_contact_primary_email``
-      attribute shared by the LTI Consumer during the LTI Launch and the auto
-      linking will not work if the LTI Consumer does not send this value or sends
-      a default value due to stricter privacy settings.
+   - **Auto link users using email**: Check this to automatically link learners
+     accessing content via LTI using their email ID.
 
-   .. note:: The **Auto link users using email** field can only set when a new
-        LTI Consumer is created. This helps the LTI Consumer to have consistency
-        in the way it stores learner data.
+     Usually :ref:`an anonymous Open edX system user is created<Anonymous User Authentication>`
+     to record the learner data internally and pass it on the the LTI Consumers.
+     However, in cases where the learners already have an account in the Open
+     edX system, it might be desirable to directly link the existing account instead
+     of creating a new anonymous account. Marking this flag as checked enables
+     such auto linking.
+
+     The auto linking happens only when the following conditions are met
+
+     #. the learner already has an account in the Open edX system
+     #. the LTI Consumer sends the email of the learner to the Open edX
+        system when loading the content, by setting the POST data attribute
+        ``lis_person_contact_primary_email`` in the LTI Launch request.
+
+     .. important::
+      The **Auto link users using email** field can only set when a new
+      LTI Consumer is created. This helps the LTI Consumer to have consistency
+      in the way it stores learner data. If you run into a situation where the
+      auto-linking needs to be turned off, you can create a new LTI Consumer
+      configuration with the flag unset and use the new consumer key and secret
+      in your external system.
 
 #. Select **Save** at the bottom of the page.
+
+
+
 
 .. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/configuration/lti/configure_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/configure_lti.rst
@@ -52,6 +52,20 @@ follow these steps.
    .. important:: Do not supply a value for the **Instance guid** field. The
       tool consumer generates and supplies a globally unique identifier.
 
+    - **Auto link users using email:** Check this if the learners accessing the
+      content via LTI already have an account in the edX platform using the same
+      email as the LTI Consumer and you want the data they generate (like
+      submissions and grades) on the platform to be associated with that
+      account instead of the Anonymous account that's created by default. This
+      is done by making use of the ``lis_person_contact_primary_email``
+      attribute shared by the LTI Consumer during the LTI Launch and the auto
+      linking will not work if the LTI Consumer does not send this value or sends
+      a default value due to stricter privacy settings.
+
+   .. note:: The **Auto link users using email** field can only set when a new
+        LTI Consumer is created. This helps the LTI Consumer to have consistency
+        in the way it stores learner data.
+
 #. Select **Save** at the bottom of the page.
 
 .. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/configuration/lti/configure_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/configure_lti.rst
@@ -80,7 +80,4 @@ follow these steps.
 
 #. Select **Save** at the bottom of the page.
 
-
-
-
 .. include:: ../../../../links/links.rst


### PR DESCRIPTION
A new flag was introduced in the LTI Consumer configuration which allows automatically linking LTI users with the edX platform users by matching the email ID. This commit describes the purpose of the flag with its caveats.

Ref: https://github.com/openedx/edx-platform/pull/33310

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
