### PR TITLE
build: Correct xblock tutorial conf.py location.

### DIFF
--- a/en_us/xblock-tutorial/.readthedocs.yaml
+++ b/en_us/xblock-tutorial/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: en_us/xblock-tutorial/source/conf.py
+  configuration: en_us/xblock-tutorial/conf.py
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
The generated .readthedocs.yml file had the location in the
wrong place.  This project is now just a stub.