### PR TITLE
fix: change the current param's description for subscription summary

### DIFF
--- a/en_us/enterprise_api/source/api_reference/reference.rst
+++ b/en_us/enterprise_api/source/api_reference/reference.rst
@@ -138,7 +138,7 @@ You can use optional query parameters to get specific subscription plans.
      - The page number of the results.
    * - ``current``
      - bool (Nullable)
-     - Whether to return the most recently created subscription plan with an active ``start_date``. Can only be used with ``enterprise_customer_uuid``.
+     - returns the active subscription plan
 
 For example:
 


### PR DESCRIPTION
A small fix for the description of the `current` param for the subscription summary endpoint.

### Date Needed (optional)

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
