### PR TITLE
docs: add note for html content subsections as prerequisite

### DIFF
--- a/en_us/shared/developing_course/controlling_content_visibility.rst
+++ b/en_us/shared/developing_course/controlling_content_visibility.rst
@@ -249,6 +249,12 @@ subsection, follow these steps.
     Two>` that have a point value of 0 as the prerequisite for other course
     subsections.
 
+.. note::
+    You should not use a subsection that only has :ref:`HTML components<Working 
+    with HTML Components>` as a prerequisite as HTML blocks are not considered 
+    for completion or grading and they will be automtically considered passed 
+    if the student tries to access the subsection with the prerequisite.
+
 #. Enable subsection prerequisites for your course. For more information, see
    :ref:`enabling_subsection_gating`.
 


### PR DESCRIPTION
Add a description of your changes with links to any relevant material.

Added a note to use subsections that only include HTML content as a prerequisite for other subsections. This is because after [this PR](https://github.com/openedx/edx-platform/pull/19033), HTML components are not counted for grading or completion percentage and are automatically considered passed.

In a scenario where a subsection that has only HTML content is utilized as a prerequisite for another subsection, the student can just jump to that subsection from the main course outline page in the learning MFE and that subsection will be unlocked for the student. To mitigate this, subsections with just HTML content should not be used as prerequisites.

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:

FYI: Tag anyone else who might be interested in this PR here.

### Testing

- [x] Ran ./run_tests.sh without warnings or errors

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
