### PR TITLE
docs: warning on class values

### DIFF
--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -603,12 +603,13 @@ OLX specifications can be found under each problem type in
    Editor instead of the Advanced Editor.
 
 .. warning::
-   Be careful when using the following values in your tag's class attribute. They
-   are used when running the problem. 
-   ``capa_inputtype``, ``choicegroup``, ``collapsible``, ``full``, ``inputtype``, 
-   ``longform``, ``message``, ``notification-gentle-alert``, ``notification-hint``,
-   ``notification-message``, ``notification-save``, ``problem``, ``script_placeholder``,
-   ``shortform``, ``shortform-custom``, ``show``, ``wrapper-problem-response``
+   Be careful when using certain values in your tag's class attribute. The
+   following are used when running the problem: ``capa_inputtype``,
+   ``choicegroup``, ``collapsible``, ``full``, ``inputtype``, ``longform``,
+   ``message``, ``notification-gentle-alert``, ``notification-hint``,
+   ``notification-message``, ``notification-save``, ``problem``,
+   ``script_placeholder``, ``shortform``, ``shortform-custom``, ``show``,
+   ``wrapper-problem-response``
 
 .. _Advanced Editor Features:
 

--- a/en_us/shared/course_components/create_problem.rst
+++ b/en_us/shared/course_components/create_problem.rst
@@ -602,6 +602,14 @@ OLX specifications can be found under each problem type in
    problem editor can fully parse the OLX, the editor will open as the Simple
    Editor instead of the Advanced Editor.
 
+.. warning::
+   Be careful when using the following values in your tag's class attribute. They
+   are used when running the problem. 
+   ``capa_inputtype``, ``choicegroup``, ``collapsible``, ``full``, ``inputtype``, 
+   ``longform``, ``message``, ``notification-gentle-alert``, ``notification-hint``,
+   ``notification-message``, ``notification-save``, ``problem``, ``script_placeholder``,
+   ``shortform``, ``shortform-custom``, ``show``, ``wrapper-problem-response``
+
 .. _Advanced Editor Features:
 
 ***************************************************


### PR DESCRIPTION
Adds a warning for advanced problem OLX to avoid certain values for the class attribute. Partners occasionally runs into this issue when creating advanced problem OLX. Recently, a partner used the `choicegroup` class in a div and this disabled the submit answer button.

https://2u-internal.atlassian.net/browse/TNL-11607

### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:.

- [ ] Subject matter expert:
- [ ] Subject matter expert:
- [ ] Product review:
- [ ] Partner support:
- [ ] PM review:
