### PR TITLE
docs: add 'Redwood' to titles

### DIFF
--- a/en_us/install_operations/source/conf.py
+++ b/en_us/install_operations/source/conf.py
@@ -6,7 +6,7 @@ sys.path.append('../../../')
 from shared.conf import *
 
 # General information about the project.
-project = u'Installing, Configuring, and Running the Open edX Platform'
+project = u'Installing, Configuring, and Running the Open edX Platform: Redwood Release'
 set_audience(OPENEDX, DEVELOPERS)
 
 # remove directory when content is first added to it, and add it to index

--- a/en_us/install_operations/source/index.rst
+++ b/en_us/install_operations/source/index.rst
@@ -1,8 +1,8 @@
 .. _Installing, Configuring, and Running the Open edX Platform:
 
-###########################################################
-Installing, Configuring, and Running the Open edX Platform
-###########################################################
+###########################################################################
+Installing, Configuring, and Running the Open edX Platform: Redwood Release
+###########################################################################
 
 This guide provides instructions for using your own instance of the Open edX
 platform and associated applications.

--- a/en_us/open_edx_course_authors/source/conf.py
+++ b/en_us/open_edx_course_authors/source/conf.py
@@ -14,4 +14,4 @@ product = 'Open_edX'
 def setup(app):
     app.add_config_value('product', '', True)
 
-project = u'Building and Running an Open edX Course'
+project = u'Building and Running an Open edX Course: Redwood Release'

--- a/en_us/open_edx_course_authors/source/index.rst
+++ b/en_us/open_edx_course_authors/source/index.rst
@@ -1,8 +1,8 @@
 .. _Building and Running an Open edX Course:
 
-#######################################
-Building and Running an Open edX Course
-#######################################
+########################################################
+Building and Running an Open edX Course: Redwood Release
+########################################################
 
 .. toctree::
    :numbered:

--- a/en_us/open_edx_students/source/conf.py
+++ b/en_us/open_edx_students/source/conf.py
@@ -5,7 +5,7 @@ sys.path.append('../../../')
 
 from shared.conf import *
 
-project = u'Open edX Learner\'s Guide'
+project = u'Open edX Learner\'s Guide: Redwood Release'
 
 exclude_patterns = ['links.rst', 'reusables/*', 'SFD_mathformatting.rst']
 

--- a/en_us/open_edx_students/source/index.rst
+++ b/en_us/open_edx_students/source/index.rst
@@ -1,8 +1,8 @@
 .. _Open edX Learner's Guide:
 
-########################
-Open edX Learner's Guide
-########################
+#########################################
+Open edX Learner's Guide: Redwood Release
+#########################################
 
 .. toctree::
    :numbered:

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 # What release line is this?  Use "master" for master, and the release name
 # on release branches.  Zebrawood should have "zebrawood".
-release_line = "master"
+release_line = "redwood"
 
 # The slug that is used by ReadTheDocs for this version of the projects.
 project_version = "latest" if (release_line == "master") else f"open-release-{release_line}.master"


### PR DESCRIPTION
This adds "Redwood Release" to titles in the open-release/redwood.master branch as instructed by the release instructions:
https://openedx.atlassian.net/wiki/spaces/COMM/pages/19662426/Process+to+Create+an+Open+edX+Release#5.-Update-the-documentation

