### PR TITLE
fix: Update xblock tutorial link in the glossary.

### DIFF
--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -1152,7 +1152,7 @@ XYZ
 
   Third parties can create components as web applications that can run within
   the edX learning management system. For more information, see
-  :ref:`xblocktutorial:Open edX XBlock Tutorial`.
+  `the Open edX XBlock Tutorial. <https://docs.openedx.org/projects/xblock/en/latest/xblock-tutorial/index.html>`_
 
 
 **XSeries**


### PR DESCRIPTION
The documents have moved and redirects were put in place in the old version of the documentation.  This change updates
the glossary to just point to the latest xblock tutorial in the new location.
