### PR TITLE
docs: update ORA size / file limits

### DIFF
--- a/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
+++ b/en_us/shared/subsections/open_response_assessments/OpenResponseAssessments.rst
@@ -681,6 +681,11 @@ that are relevant to your course.
 Before you decide to ask learners to upload files along with their text
 responses, however, be aware of the following limitations and best practices.
 
+* Course teams can configure an ORA to allow one or multiple file uploads.
+  With multiple file uploads, a learner can upload up to 20 files.
+
+* Each uploaded file must be less than 500 MB.
+
 * During the peer assessment step, learners download the files that other
   learners uploaded. To reduce the potential for problems from files with
   malicious content, learners cannot upload files with certain file extensions.
@@ -690,8 +695,6 @@ responses, however, be aware of the following limitations and best practices.
   Uploaded file content is not included in the reports of answer submissions
   that are available from the instructor dashboard, and course data packages do
   not include any of the uploaded files.
-
-* The cumulative size of all uploaded files must be less than 500 MB.
 
 * Image files must be in .jpg, .gif, or .png format.
 


### PR DESCRIPTION
I noticed these limits were out of date when trying to point someone to our ORA docs. Have updated with correct limits.

### Testing

- [ ] Ran ./run_tests.sh without warnings or errors

### HTML Version (optional)

- [ ] Build an RTD draft for your branch and add a link here

### Sandbox (optional)

- [ ] Point to or build a sandbox for the software change and add a link here

### Post-review

- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits
