### PR TITLE
fix: Use the correct default minimium password length mentioned in install operation document

### DIFF
--- a/en_us/install_operations/source/configuration/password.rst
+++ b/en_us/install_operations/source/configuration/password.rst
@@ -35,7 +35,7 @@ under the ``AUTH_PASSWORD_VALIDATORS`` setting::
   -   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
   -   NAME: common.djangoapps.util.password_policy_validators.MinimumLengthValidator
         OPTIONS:
-          min_length: 2
+          min_length: 8
   -   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
         OPTIONS:
           max_length: 75


### PR DESCRIPTION
The default minimum password length  mentioned in `edx-platform/lms/envs/common.py` is 8 characters but at install operation documents you see 2. 
For more info check out [edx documentation](https://github.com/openedx/edx-documentation/blob/a339af378f2f6c923ed49cef5be7935930617ab7/en_us/install_operations/source/configuration/password.rst#id7), [edx-platform configuration](https://github.com/openedx/edx-platform/blob/644e7e786af351231eb09bdba8d5599a979894d2/lms/envs/common.py#L3797), [`MinimumLengthValidator`](https://github.com/openedx/edx-platform/blob/master/common/djangoapps/util/password_policy_validators.py#L146) also Django class the OpenEdx `MinimumLengthValidator` inherits from [MinimumLengthValidator](https://docs.djangoproject.com/en/5.1/topics/auth/passwords/#django.contrib.auth.password_validation.MinimumLengthValidator)
closes #2119 