### PR TITLE
build: Update intersphinx mapping

### DIFF
--- a/en_us/course_authors/source/getting_started/CA_get_started_Studio.rst
+++ b/en_us/course_authors/source/getting_started/CA_get_started_Studio.rst
@@ -19,7 +19,7 @@ If your organization has an agreement with edX and approval to do so, you can
 run courses on the edX Edge and edx.org websites.
 
 If you are using an instance of Open edX to create a course, see
-:ref:`opencoursestaff:Getting Started with Studio` in the *Building and Running
+:ref:`Getting Started with Studio` in the *Building and Running
 an Open edX Course* guide.
 
 .. _What is Studio?:

--- a/en_us/course_authors/source/proctored_exams/overview.rst
+++ b/en_us/course_authors/source/proctored_exams/overview.rst
@@ -8,7 +8,7 @@ Proctored exams are timed exams that learners take while online proctoring
 software monitors their computer, environment, and behavior. When learners
 complete a proctored exam, the recording of the exam is examined to
 determine whether the learner complied with the :ref:`online proctoring rules
-<CA Online Proctoring Rules>`.
+<Online Proctoring Rules>`.
 
 All courses can include proctored exams, but proctored exams are most common
 in courses that offer academic credit. Course teams can require that learners

--- a/en_us/course_authors/source/proctored_exams/pt_results.rst
+++ b/en_us/course_authors/source/proctored_exams/pt_results.rst
@@ -246,7 +246,7 @@ Values in the ``review_status`` Column
 
 After learners complete a proctored exam, a reviewer from the proctoring
 service provider reviews the exam according to specific criteria, including the
-:ref:`Online Proctoring Rules <CA Online Proctoring Rules>`. The value in the
+:ref:`Online Proctoring Rules <Online Proctoring Rules>`. The value in the
 ``review_status`` column shows the outcome of the proctored exam review.
 
 Additionally, the value in the ``review_status`` column affects the following

--- a/en_us/course_authors/source/proctored_exams/rpnow_create.rst
+++ b/en_us/course_authors/source/proctored_exams/rpnow_create.rst
@@ -50,8 +50,7 @@ steps.
    to allow for the exam as HH:MM, where HH is hours and MM is minutes.
 
 #. (optional) For a proctored exam, in the **Review Rules** field, enter any
-   additions or exceptions to the :ref:`default rules for proctored exams<CA
-   Online Proctoring Rules>`. For more information, see
+   additions or exceptions to the :ref:`default rules for proctored exams<Online Proctoring Rules>`. For more information, see
    :ref:`specifying_exam_rules_and_exceptions`.
 
 #. Select **Save**.
@@ -63,7 +62,7 @@ Specify Exam Rules and Exceptions
 **************************************
 
 By default, reviewers evaluate exam attempts according to a standard set of
-:ref:`online proctoring rules <CA Online Proctoring Rules>` that the
+:ref:`online proctoring rules <Online Proctoring Rules>` that the
 proctoring service has provided.
 
 .. note::

--- a/en_us/course_authors/source/proctored_exams/rpnow_results.rst
+++ b/en_us/course_authors/source/proctored_exams/rpnow_results.rst
@@ -216,7 +216,7 @@ Values in the ``review_status`` Column
 
 After learners complete a proctored exam, a reviewer from the proctoring
 service provider reviews the exam according to specific criteria, including the
-:ref:`Online Proctoring Rules <CA Online Proctoring Rules>`. The value in the
+:ref:`Online Proctoring Rules <Online Proctoring Rules>`. The value in the
 ``review_status`` column shows the outcome of the proctored exam review.
 
 Additionally, the value in the ``review_status`` column affects the following

--- a/en_us/course_authors/source/video/upload_video.rst
+++ b/en_us/course_authors/source/video/upload_video.rst
@@ -166,7 +166,7 @@ the process has the following steps.
 
 After the automated video process is complete, the course team creates a video
 component and adds the video ID to the video component. For more information,
-see :ref:`Add a Video to a Course`.
+see :ref:`Adding a video to a Course`.
 
 .. _Automated Video Process for Non Integrated Transcripts:
 
@@ -202,7 +202,7 @@ page, the course team :ref:`obtains transcripts <Obtain a Video Transcript>`
 from a transcript provider. When the edX video process is complete, and the
 course team has obtained transcripts from the transcript provider, the course
 team creates a video component and adds the video ID and transcript to the
-component. For more information, see :ref:`Add a Video to a Course`.
+component. For more information, see :ref:`Adding a video to a Course`.
 
 =============================================================
 Upload a Video for an edx.org Course (for Videos page)
@@ -396,7 +396,7 @@ The .csv file includes the following columns.
 
 * The unique, identifying **Video ID**. When you add a video component to your
   course, you supply the video ID for the file you want to add. For more
-  information, see :ref:`Add a Video to a Course`.
+  information, see :ref:`Adding a video to a Course`.
 
 * The **Status** of the encoding and hosting process for the file. For more
   information, see :ref:`Video Processing Statuses`.

--- a/en_us/edx_style_guide/source/templates/task.rst
+++ b/en_us/edx_style_guide/source/templates/task.rst
@@ -59,4 +59,4 @@ topics.
   procedures for Windows and Macintosh users and shows an illustration of the
   result of the task.
 
-.. * :ref:`opencoursestaff:Add a Post` is one of a series of task topics.
+.. * :ref:`Add a Post` is one of a series of task topics.

--- a/en_us/install_operations/source/configuration/changing_appearance/drag_and_drop_problem_styling.rst
+++ b/en_us/install_operations/source/configuration/changing_appearance/drag_and_drop_problem_styling.rst
@@ -8,7 +8,7 @@ You can customize the appearance of drag and drop problems in your Open edX
 site using custom Cascading Style Sheet (CSS) files. The style that you
 configure applies to all drag and drop problems in all courses. For more
 information about drag and drop problems, see
-:ref:`opencoursestaff:drag_and_drop_problem`.
+:ref:`drag_and_drop_problem`.
 
 The following two methods apply CSS styling to drag and drop problems.
 
@@ -30,7 +30,7 @@ The following two methods apply CSS styling to drag and drop problems.
     Course teams can also style the background and text colors of the draggable
     items in an individual drag and drop problem, without adding CSS files or
     configuring a Python module. For more information, see
-    :ref:`opencoursestaff:changing_visual_style_of_drag_and_drop_problem`.
+    :ref:`changing_visual_style_of_drag_and_drop_problem`.
 
 To customize the style of drag and drop problems by adding a CSS file in a
 Python module, follow these steps.

--- a/en_us/install_operations/source/configuration/edx_search.rst
+++ b/en_us/install_operations/source/configuration/edx_search.rst
@@ -91,7 +91,7 @@ You can also reindex the course manually through the **Reindex** button in the
 .. note:: The search feature only returns results for courses that are
  currently open for enrollment. Course teams can set the enrollment start and
  end dates for their courses in Studio. For more information, see
- :ref:`opencoursestaff:Guidelines for Start and End Dates` in the *Building
+ :ref:`Guidelines for Start and End Dates` in the *Building
  and Running an Open edX Course* guide.
 
 ==============================

--- a/en_us/install_operations/source/configuration/enable_certificates.rst
+++ b/en_us/install_operations/source/configuration/enable_certificates.rst
@@ -22,7 +22,7 @@ Organizations and course teams can choose to generate certificates for learners
 who pass a course. Learners can view, print, or share their certificates.
 
 For additional information about certificates, see
-:ref:`opencoursestaff:Setting Up Certificates` in the *Building and Running an
+:ref:`Setting Up Certificates` in the *Building and Running an
 Open edX Course* guide or :ref:`openlearners:Print a Web Certificate` in the
 *Open edX Learner's Guide*.
 
@@ -69,7 +69,7 @@ Configuring Course Certificates in Studio
 Within Studio, course team members with the Admin role can create and edit a
 certificate configuration that is used to generate certificates for their
 course, including adding signatories and images for organization logo and
-signature images for signatories. For details, :ref:`opencoursestaff:Setting Up
+signature images for signatories. For details, :ref:`Setting Up
 Certificates` in *Building and Running an Open edX Course*.
 
 
@@ -186,7 +186,7 @@ Assets for HTML certificates exist in the following locations.
   in creating certificates, such as images, fonts, and sass/css files.
 
   .. note:: The organization logo on a certificate is uploaded in Studio. For
-     details, see :ref:`opencoursestaff:Setting Up Certificates` in *Building
+     details, see :ref:`Setting Up Certificates` in *Building
      and Running an Open edX Course*.
 
 
@@ -361,9 +361,9 @@ setting may take several minutes to propagate in a large installation.
 
 In addition to this Waffle switch, automatic certificate generation
 requires certain settings to be defined for the course, by a member of
-the course staff. For more details, see :ref:`opencoursestaff:Allow
+the course staff. For more details, see :ref:`Allow
 Learners to Receive Early Certificates` and
-:ref:`opencoursestaff:Allow Learners to Download Certificates` in
+:ref:`Allow Learners to Download Certificates` in
 *Building and Running an Open edX Course*.
 
 .. _Manually Generate Certificates for a Course:

--- a/en_us/install_operations/source/configuration/enable_discussion_notifications.rst
+++ b/en_us/install_operations/source/configuration/enable_discussion_notifications.rst
@@ -8,7 +8,7 @@ You can set up notifications that learners receive the first time that anyone
 adds a response to a discussion post that they have made.
 
 For more information, including the text of the discussion notification
-message, see :ref:`opencoursestaff:Automatic Email` and
+message, see :ref:`Automatic Email` and
 :ref:`openlearners:Receiving Discussion Notifications`.
 
 .. contents::

--- a/en_us/install_operations/source/configuration/enable_pacing.rst
+++ b/en_us/install_operations/source/configuration/enable_pacing.rst
@@ -28,7 +28,7 @@ teams are able to set up a course as either instructor-paced or self-paced in
 Studio.
 
 For information about how course teams set course pacing, see the
-:ref:`opencoursestaff:Set Schedule and Pacing` topic in the
+:ref:`Set Schedule and Pacing` topic in the
 *Building and Running an Open edX Course* guide.
 
 .. Note::

--- a/en_us/install_operations/source/configuration/enable_timed_exams.rst
+++ b/en_us/install_operations/source/configuration/enable_timed_exams.rst
@@ -22,7 +22,7 @@ To use this feature on your instance of Open edX, you must enable the timed
 exams feature in Studio and the Learning Management System.
 
 For information about how course teams set up timed exams, see the
-:ref:`opencoursestaff:Timed Exams` topic in *Building and Running an Open edX
+:ref:`Timed Exams` topic in *Building and Running an Open edX
 Course*. For information about the learner experience, see
 :ref:`openlearners:taking_timed_exams` in the  *Open edX Learner's Guide*.
 

--- a/en_us/install_operations/source/configuration/install_xblock.rst
+++ b/en_us/install_operations/source/configuration/install_xblock.rst
@@ -41,6 +41,6 @@ To install an XBlock, follow these steps.
 The course teams that want to include components that use the XBlock can then
 enable the XBlock for their courses. To do so, they add the name specified in
 the XBlock’s ``setup.py`` file to each course's advanced module list. For more
-information, see :ref:`opencoursestaff:Enable Additional Exercises and Tools`.
+information, see :ref:`Enable Additional Exercises and Tools`.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/configuration/lti/configure_lti.rst
+++ b/en_us/install_operations/source/configuration/lti/configure_lti.rst
@@ -19,7 +19,7 @@ access. Each external LMS that you :ref:`configure as a tool consumer
 After you complete the configuration of a tool consumer on your edX system, you
 can add the consumer credentials to your external LMS. For examples of how
 course teams might set up a course on an external LMS as a consumer of edX
-course content, see :ref:`opencoursestaff:Using Open edX as an LTI Tool
+course content, see :ref:`Using Open edX as an LTI Tool
 Provider` in the *Building and Running an edX Course* guide.
 
 .. _Configure the Tool Consumer:

--- a/en_us/install_operations/source/configuration/lti/index.rst
+++ b/en_us/install_operations/source/configuration/lti/index.rst
@@ -23,7 +23,7 @@ than the edX LMS.
 
 For more information and examples of how course teams might set up a course on
 an external LMS as a consumer of edX course content, see
-:ref:`opencoursestaff:Using Open edX as an LTI Tool Provider` in the *Building
+:ref:`Using Open edX as an LTI Tool Provider` in the *Building
 and Running an edX Course* guide.
 
 .. include:: ../../../../links/links.rst

--- a/en_us/install_operations/source/configuration/ora2/index.rst
+++ b/en_us/install_operations/source/configuration/ora2/index.rst
@@ -15,7 +15,7 @@ the default set of files that learners are prohibited from submitting.
    ora2_blacklist
 
 For more information and examples of how course teams might set up an open
-response assessment, see :ref:`opencoursestaff:Open Response Assessments Two`
+response assessment, see :ref:`Open Response Assessments Two`
 in the *Building and Running an Open edX Course* guide.
 
 

--- a/en_us/install_operations/source/configuration/tpa/tpa_eliminating_pii.rst
+++ b/en_us/install_operations/source/configuration/tpa/tpa_eliminating_pii.rst
@@ -66,7 +66,7 @@ Open edX site learners to the learner records that your organization maintains,
 you can use the third- party authentication ID mapping REST API to retrieve the
 user ID SAML attribute and matching Open edX username for a learner. For more
 information about grade reports for Open edX courses that you run, see
-:ref:`opencoursestaff:Access_grades`.
+:ref:`Access_grades`.
 
 .. Organizations may be able to access learner information in other ways. Make
 .. the paragraph above more general when we know of those other methods.

--- a/en_us/install_operations/source/mobile.rst
+++ b/en_us/install_operations/source/mobile.rst
@@ -187,7 +187,7 @@ includes the video in the course structure.
 * To configure a video module in edX Studio, you edit the video component. On
   the **Advanced** tab, in the **Video File URLs** field, enter the URL to the
   mobile-targeted video as the first URL in the list. For more information, see
-  :ref:`opencoursestaff:Working with Video Components` in *Building and Running
+  :ref:`Working with Video Components` in *Building and Running
   an Open edX Course*.
 
 * To configure a video module by editing the course XML, enter the URL to the

--- a/en_us/install_operations/source/platform_releases/dogwood.rst
+++ b/en_us/install_operations/source/platform_releases/dogwood.rst
@@ -21,7 +21,7 @@ What's Included in Dogwood
 
 The Open edX Dogwood release contains several new features for learners, course
 teams, and developers. See the release notes for the
-:ref:`openreleasenotes:Open edX Dogwood Release` for more details.
+:ref:`Open edX Dogwood Release` for more details.
 
 ******************************
 What Is the Dogwood Git Tag?

--- a/en_us/install_operations/source/platform_releases/ficus.rst
+++ b/en_us/install_operations/source/platform_releases/ficus.rst
@@ -17,7 +17,7 @@ What's Included in Ficus
 
 The Open edX Ficus release contains several new features for learners,
 course teams, and developers. For more information, see
-:ref:`openreleasenotes:Open edX Ficus Release`.
+:ref:`Open edX Ficus Release`.
 
 **************************
 What Is the Ficus Git Tag?

--- a/en_us/install_operations/source/platform_releases/ginkgo.rst
+++ b/en_us/install_operations/source/platform_releases/ginkgo.rst
@@ -16,7 +16,7 @@ What's Included in Ginkgo
 
 The Open edX Ginkgo release contains several new features for learners,
 course teams, and developers. For more information, see
-:ref:`openreleasenotes:Open edX Ginkgo Release`.
+:ref:`Open edX Ginkgo Release`.
 
 ****************************
 What Is the Ginkgo Git Tag?

--- a/en_us/landing_page/source/index.rst
+++ b/en_us/landing_page/source/index.rst
@@ -28,10 +28,9 @@ If you use or host an Open edX site
 
 * Learners: See the :ref:`openlearners:Open edX Learner's Guide`.
 
-* Course teams: See :ref:`opencoursestaff:Building and Running an Open edX
-  Course`.
+* Course teams: See :ref:`Quick Start Build a Course`.
 
-* Developers: See the :ref:`opendevelopers:edX Developer's Guide` and
+* Developers: See the :ref:`Open edX Developer's Guide` and
   :ref:`installation:Installing, Configuring, and Running the Open edX
   Platform`.
 

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -226,7 +226,7 @@
 
 .. EDX WIKI LINKS
 
-.. _Open edX Releases Wiki page: https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/11108700/Open+edX+Releases
+.. _Open edX Releases Wiki page: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4191191044/Open+edX+Releases+Homepage
 
 .. _Release Pages: https://openedx.atlassian.net/wiki/pages/viewpage.action?pageId=12550314
 

--- a/en_us/olx/source/components/problem-components.rst
+++ b/en_us/olx/source/components/problem-components.rst
@@ -81,7 +81,7 @@ following settings.
 
 This section describes the OLX elements and attributes that you define for the
 problem settings. For a detailed description of each setting, see
-:ref:`opencoursestaff:Problem Settings`.
+:ref:`Problem Settings`.
 
 ===============
 Display Name
@@ -289,7 +289,7 @@ content libraries. For more information, see :ref:`Randomized Content Blocks`.
    versions to different learners, whereas the **Randomization** setting
    controls when a Python script randomizes the variables within a single
    problem. For more information about the **Randomization** setting, see
-   :ref:`opencoursestaff:Randomization`.
+   :ref:`Randomization`.
 
 
 .. _Create Randomized Problems:

--- a/en_us/open_edx_course_authors/locales/pot/CA_instructor_dash_help.pot
+++ b/en_us/open_edx_course_authors/locales/pot/CA_instructor_dash_help.pot
@@ -29,37 +29,37 @@ msgid "The following topics cover some of the tasks you perform on the instructo
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:20
-msgid ":ref:`Reviewing Course Information<opencoursestaff:Course Data>`"
+msgid ":ref:`Reviewing Course Information<Course Data>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:21
-msgid ":ref:`Enrolling Learners<opencoursestaff:Enrollment>`"
+msgid ":ref:`Enrolling Learners<Enrollment>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:22
-msgid ":ref:`Managing Your Course Team<opencoursestaff:Course_Staffing>`"
+msgid ":ref:`Managing Your Course Team<Course_Staffing>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:23
-msgid ":ref:`Managing Cohorts<opencoursestaff:Cohorts Overview>`"
+msgid ":ref:`Managing Cohorts<Cohorts Overview>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:24
-msgid ":ref:`Generating Grade Reports<opencoursestaff:Access_grades>`"
+msgid ":ref:`Generating Grade Reports<Access_grades>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:25
-msgid ":ref:`Sending Email to Learners<opencoursestaff:Bulk Email>`"
+msgid ":ref:`Sending Email to Learners<Bulk Email>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:26
-msgid ":ref:`Issuing Certificates<opencoursestaff:Issuing Certificates>`"
+msgid ":ref:`Issuing Certificates<Issuing Certificates>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:27
-msgid ":ref:`Accessing Metrics for Open Response Assessments<opencoursestaff:Accessing ORA Assignment Information>`"
+msgid ":ref:`Accessing Metrics for Open Response Assessments<Accessing ORA Assignment Information>`"
 msgstr ""
 
 #: ../../source/CA_instructor_dash_help.rst:31
-msgid "For more information, see the :ref:`Building and Running an Open edX Course<opencoursestaff:Building and Running an Open edX Course>` guide."
+msgid "For more information, see the :ref:`Building and Running an Open edX Course<Building and Running an Open edX Course>` guide."
 msgstr ""

--- a/en_us/open_edx_course_authors/locales/pot/exercises_tools.pot
+++ b/en_us/open_edx_course_authors/locales/pot/exercises_tools.pot
@@ -6078,7 +6078,7 @@ msgid "For more information about how to use Studio as an LTI tool provider, see
 msgstr ""
 
 #: ../../../shared/exercises_tools/lti_component.rst:71
-msgid "For more information about how to use Studio as an LTI tool provider, see :ref:`opencoursestaff:Using Open edX as an LTI Tool Provider`."
+msgid "For more information about how to use Studio as an LTI tool provider, see :ref:`Using Open edX as an LTI Tool Provider`."
 msgstr ""
 
 #: ../../../shared/exercises_tools/lti_component.rst:80

--- a/en_us/open_edx_course_authors/locales/pot/glossary.pot
+++ b/en_us/open_edx_course_authors/locales/pot/glossary.pot
@@ -25,7 +25,7 @@ msgid ":ref:`A` - :ref:`C` - :ref:`D` - :ref:`E` - :ref:`F` - :ref:`G` - :ref:`H
 msgstr ""
 
 #: ../../../shared/glossary/glossary.rst:12
-msgid "Most of the links to documentation provided in this glossary are to the :ref:`partnercoursestaff:document index` guide, for edX partners. Many of the same topics are available in the Open edX version of this guide, :ref:`opencoursestaff:Building and Running an Open edX Course`."
+msgid "Most of the links to documentation provided in this glossary are to the :ref:`partnercoursestaff:document index` guide, for edX partners. Many of the same topics are available in the Open edX version of this guide, :ref:`Building and Running an Open edX Course`."
 msgstr ""
 
 #: ../../../shared/glossary/glossary.rst:21

--- a/en_us/open_edx_course_authors/locales/pot/proctored_exams.pot
+++ b/en_us/open_edx_course_authors/locales/pot/proctored_exams.pot
@@ -209,7 +209,7 @@ msgid "Proctored Exam Overview"
 msgstr ""
 
 #: ../../source/proctored_exams/overview.rst:7
-msgid "Proctored exams are timed exams that learners take while online proctoring software monitors their computer, environment, and behavior. When learners complete a proctored exam, a reviewer examines the recording of the exam to determine whether the learner complied with the :ref:`online proctoring rules <CA Online Proctoring Rules>`."
+msgid "Proctored exams are timed exams that learners take while online proctoring software monitors their computer, environment, and behavior. When learners complete a proctored exam, a reviewer examines the recording of the exam to determine whether the learner complied with the :ref:`online proctoring rules <Online Proctoring Rules>`."
 msgstr ""
 
 #: ../../source/proctored_exams/overview.rst:15
@@ -363,7 +363,7 @@ msgid "In the **Time Allotted** field, enter the length of time that you want to
 msgstr ""
 
 #: ../../source/proctored_exams/proctored_enabling.rst:79
-msgid "(optional) For a proctored exam, in the **Review Rules** field, enter any additions or exceptions to the :ref:`default rules for proctored exams<CA Online Proctoring Rules>`. For more information, see :ref:`specifying_exam_rules_and_exceptions`."
+msgid "(optional) For a proctored exam, in the **Review Rules** field, enter any additions or exceptions to the :ref:`default rules for proctored exams<Online Proctoring Rules>`. For more information, see :ref:`specifying_exam_rules_and_exceptions`."
 msgstr ""
 
 #: ../../source/proctored_exams/proctored_enabling.rst:84
@@ -376,11 +376,11 @@ msgid "Specify Exam Rules and Exceptions"
 msgstr ""
 
 #: ../../source/proctored_exams/proctored_enabling.rst:94
-msgid "By default, reviewers evaluate exam attempts according to a standard set of :ref:`online proctoring rules <CA Online Proctoring Rules>` that the proctoring service has provided."
+msgid "By default, reviewers evaluate exam attempts according to a standard set of :ref:`online proctoring rules <Online Proctoring Rules>` that the proctoring service has provided."
 msgstr ""
 
 #: ../../source/proctored_exams/proctored_enabling.rst:100
-msgid "The rules for proctoring exams vary according to the proctoring service that you or your organization has chosen. However, the :ref:`online proctoring rules <CA Online Proctoring Rules>` that this guide lists are common to many proctoring services."
+msgid "The rules for proctoring exams vary according to the proctoring service that you or your organization has chosen. However, the :ref:`online proctoring rules <Online Proctoring Rules>` that this guide lists are common to many proctoring services."
 msgstr ""
 
 #: ../../source/proctored_exams/proctored_enabling.rst:106
@@ -496,7 +496,7 @@ msgid "Explain what proctored exams are, and provide learners with links to the 
 msgstr ""
 
 #: ../../../shared/course_features/proctored_exams/proctored_learners.rst:33
-msgid "Communicate the rules for proctored exams, including the :ref:`online proctoring rules<CA Online Proctoring Rules>` in the *Open edX Learner’s Guide* as well as any specific rules for a particular exam. For information about creating specific rules, see :ref:`specifying_exam_rules_and_exceptions`."
+msgid "Communicate the rules for proctored exams, including the :ref:`online proctoring rules<Online Proctoring Rules>` in the *Open edX Learner’s Guide* as well as any specific rules for a particular exam. For information about creating specific rules, see :ref:`specifying_exam_rules_and_exceptions`."
 msgstr ""
 
 #: ../../../shared/course_features/proctored_exams/proctored_learners.rst:43

--- a/en_us/open_edx_course_authors/locales/pot/video.pot
+++ b/en_us/open_edx_course_authors/locales/pot/video.pot
@@ -876,7 +876,7 @@ msgid "If your course is on Edge, integrated transcript functionality is not ava
 msgstr ""
 
 #: ../../../shared/video/prepare_video/obtain_transcript.rst:187
-msgid "When you work with a transcript provider, you send your videos to the transcript provider, and the provider sends you the completed transcripts. You later upload the transcripts when you :ref:`create a video component<opencoursestaff:Add a Video to a Course>`."
+msgid "When you work with a transcript provider, you send your videos to the transcript provider, and the provider sends you the completed transcripts. You later upload the transcripts when you :ref:`create a video component<Add a Video to a Course>`."
 msgstr ""
 
 #: ../../../shared/video/prepare_video/obtain_transcript.rst:194

--- a/en_us/open_edx_course_authors/source/CA_instructor_dash_help.rst
+++ b/en_us/open_edx_course_authors/source/CA_instructor_dash_help.rst
@@ -17,16 +17,16 @@ the course.
 The following topics cover some of the tasks you perform on the instructor
 dashboard.
 
-* :ref:`Reviewing Course Information<opencoursestaff:Course Data>`
-* :ref:`Enrolling Learners<opencoursestaff:Enrollment>`
-* :ref:`Managing Your Course Team<opencoursestaff:Course_Staffing>`
-* :ref:`Managing Cohorts<opencoursestaff:Cohorts Overview>`
-* :ref:`Generating Grade Reports<opencoursestaff:Access_grades>`
-* :ref:`Sending Email to Learners<opencoursestaff:Bulk Email>`
-* :ref:`Issuing Certificates<opencoursestaff:Issuing Certificates>`
+* :ref:`Reviewing Course Information<Course Data>`
+* :ref:`Enrolling Learners<Enrollment>`
+* :ref:`Managing Your Course Team<Course_Staffing>`
+* :ref:`Managing Cohorts<Cohorts Overview>`
+* :ref:`Generating Grade Reports<Access_grades>`
+* :ref:`Sending Email to Learners<Bulk Email>`
+* :ref:`Issuing Certificates<Issuing Certificates>`
 * :ref:`Accessing Metrics for Open Response
-  Assessments<opencoursestaff:Accessing ORA Assignment Information>`
+  Assessments<Accessing ORA Assignment Information>`
 
 
 For more information, see the :ref:`Building and Running an Open edX
-Course<opencoursestaff:Building and Running an Open edX Course>` guide.
+Course<Building and Running an Open edX Course>` guide.

--- a/en_us/open_edx_course_authors/source/proctored_exams/CA_online_proctoring_rules_students.rst
+++ b/en_us/open_edx_course_authors/source/proctored_exams/CA_online_proctoring_rules_students.rst
@@ -1,4 +1,4 @@
-.. _CA Online Proctoring Rules:
+.. _Online Proctoring Rules:
 
 ####################################
 Online Proctoring Rules for Learners

--- a/en_us/open_edx_course_authors/source/proctored_exams/overview.rst
+++ b/en_us/open_edx_course_authors/source/proctored_exams/overview.rst
@@ -8,7 +8,7 @@ Proctored exams are timed exams that learners take while online proctoring
 software monitors their computer, environment, and behavior. When learners
 complete a proctored exam, a reviewer examines the recording of the exam to
 determine whether the learner complied with the :ref:`online proctoring rules
-<CA Online Proctoring Rules>`.
+<Online Proctoring Rules>`.
 
 .. only:: Partners
 

--- a/en_us/open_edx_course_authors/source/proctored_exams/proctored_enabling.rst
+++ b/en_us/open_edx_course_authors/source/proctored_exams/proctored_enabling.rst
@@ -77,8 +77,7 @@ To create a proctored exam or a practice proctored exam, follow these steps.
    to allow for the exam as HH:MM, where HH is hours and MM is minutes.
 
 #. (optional) For a proctored exam, in the **Review Rules** field, enter any
-   additions or exceptions to the :ref:`default rules for proctored exams<CA
-   Online Proctoring Rules>`. For more information, see
+   additions or exceptions to the :ref:`default rules for proctored exams<Online Proctoring Rules>`. For more information, see
    :ref:`specifying_exam_rules_and_exceptions`.
 
 #. Select **Save**.
@@ -92,14 +91,14 @@ Specify Exam Rules and Exceptions
 .. only:: Partners
 
   By default, reviewers evaluate exam attempts according to a standard set of
-  :ref:`online proctoring rules <CA Online Proctoring Rules>` that the
+  :ref:`online proctoring rules <Online Proctoring Rules>` that the
   proctoring service has provided.
 
 .. only:: Open_edX
 
   The rules for proctoring exams vary according to the proctoring service that
   you or your organization has chosen. However, the :ref:`online proctoring
-  rules <CA Online Proctoring Rules>` that this guide lists are common to many
+  rules <Online Proctoring Rules>` that this guide lists are common to many
   proctoring services.
 
 .. note::

--- a/en_us/open_edx_course_authors/source/video/add_video_to_course.rst
+++ b/en_us/open_edx_course_authors/source/video/add_video_to_course.rst
@@ -1,4 +1,4 @@
-.. _Add a Video to a Course:
+.. _Adding a Video to a Course:
 
 ##########################
 Adding a Video to a Course

--- a/en_us/open_edx_release_notes/locales/pot/dogwood.pot
+++ b/en_us/open_edx_release_notes/locales/pot/dogwood.pot
@@ -49,7 +49,7 @@ msgid "The LTI XModule continues to function in courses that include it, but it 
 msgstr ""
 
 #: ../../source/dogwood.rst:44
-msgid "For more information, see :ref:`opencoursestaff:LTI Component` in the *Building and Running an Open edX Course* guide."
+msgid "For more information, see :ref:`LTI Component` in the *Building and Running an Open edX Course* guide."
 msgstr ""
 
 #: ../../source/dogwood.rst:49
@@ -61,7 +61,7 @@ msgid "A new preview mode in the LMS allows course team members to see the cours
 msgstr ""
 
 #: ../../source/dogwood.rst:57
-msgid "For more information, see :ref:`opencoursestaff:Grades` in *Building and Running an Open edX Course*."
+msgid "For more information, see :ref:`Grades` in *Building and Running an Open edX Course*."
 msgstr ""
 
 #: ../../source/dogwood.rst:62
@@ -89,7 +89,7 @@ msgid "Write-your-own-grader"
 msgstr ""
 
 #: ../../source/dogwood.rst:73
-msgid "For more information, see :ref:`opencoursestaff:Awarding Partial Credit for a Problem` in *Building and Running an Open edX Course*."
+msgid "For more information, see :ref:`Awarding Partial Credit for a Problem` in *Building and Running an Open edX Course*."
 msgstr ""
 
 #: ../../source/dogwood.rst:78
@@ -141,7 +141,7 @@ msgid "A custom set of one or more file formats, specified by the course team."
 msgstr ""
 
 #: ../../source/dogwood.rst:121
-msgid "For more information, see :ref:`opencoursestaff:PA Allow Images`."
+msgid "For more information, see :ref:`PA Allow Images`."
 msgstr ""
 
 #: ../../source/dogwood.rst:123
@@ -177,7 +177,7 @@ msgid "There are now no character limits on the name and title fields of certifi
 msgstr ""
 
 #: ../../source/dogwood.rst:149
-msgid "For more information, see :ref:`opencoursestaff:Setting Up Certificates` in *Building and Running an Open edX Course* or :ref:`openlearners:Print a Web Certificate` in the *Open edX Learner's Guide*."
+msgid "For more information, see :ref:`Setting Up Certificates` in *Building and Running an Open edX Course* or :ref:`openlearners:Print a Web Certificate` in the *Open edX Learner's Guide*."
 msgstr ""
 
 #: ../../source/dogwood.rst:153
@@ -201,7 +201,7 @@ msgid "This release includes the timed exams feature. Course teams can configure
 msgstr ""
 
 #: ../../source/dogwood.rst:177
-msgid "For more information, see  the :ref:`opencoursestaff:Timed Exams` section in the *Building and Running an Open edX Course* guide."
+msgid "For more information, see  the :ref:`Timed Exams` section in the *Building and Running an Open edX Course* guide."
 msgstr ""
 
 #: ../../source/dogwood.rst:181
@@ -241,7 +241,7 @@ msgid "The labels that identify two of the course team member roles in the LMS n
 msgstr ""
 
 #: ../../source/dogwood.rst:225
-msgid "No changes were made to the privileges granted by these roles. For more information, see :ref:`opencoursestaff:Course_Staffing` in the *Building and Running an Open edX Course* guide."
+msgid "No changes were made to the privileges granted by these roles. For more information, see :ref:`Course_Staffing` in the *Building and Running an Open edX Course* guide."
 msgstr ""
 
 #: ../../source/dogwood.rst:229
@@ -417,7 +417,7 @@ msgid "Studio Checklist"
 msgstr ""
 
 #: ../../source/dogwood.rst:358
-msgid "The **Tools** menu in Studio no longer offers the **Checklists** option. For a template checklist, see the :ref:`opencoursestaff:Course Launch Checklist` topic in the *Building and Running an Open edX Course* guide."
+msgid "The **Tools** menu in Studio no longer offers the **Checklists** option. For a template checklist, see the :ref:`Course Launch Checklist` topic in the *Building and Running an Open edX Course* guide."
 msgstr ""
 
 #: ../../source/dogwood.rst:364

--- a/en_us/open_edx_release_notes/locales/pot/eucalyptus.pot
+++ b/en_us/open_edx_release_notes/locales/pot/eucalyptus.pot
@@ -37,7 +37,7 @@ msgid "Self-Paced Course Configuration"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:27
-msgid "When course teams create a course, they can now select the way a course is delivered to learners. You can set a schedule for the course, including due dates for assignments or exams, or you can specify that the course is self-paced, which allows learners to work at their own pace. For more information, see :ref:`opencoursestaff:Setting Course Pacing`."
+msgid "When course teams create a course, they can now select the way a course is delivered to learners. You can set a schedule for the course, including due dates for assignments or exams, or you can specify that the course is self-paced, which allows learners to work at their own pace. For more information, see :ref:`Setting Course Pacing`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:35
@@ -45,7 +45,7 @@ msgid "Subsection Prerequisites"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:37
-msgid "Course teams can now control the visibility of subsections based on the scores that learners earn in other subsections. This feature prevents learners from viewing content before they earn a minimum score for previous content. For more information, see :ref:`opencoursestaff:configuring_prerequisite_content`."
+msgid "Course teams can now control the visibility of subsections based on the scores that learners earn in other subsections. This feature prevents learners from viewing content before they earn a minimum score for previous content. For more information, see :ref:`configuring_prerequisite_content`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:44
@@ -73,7 +73,7 @@ msgid "Teams"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:63
-msgid "With the teams feature, a learner can browse a list of topics, and then create a team and invite other learners to take part in group activities relating to one of the topics. Team activities provide opportunities for small group interactions and projects in your course. For more information, see :ref:`opencoursestaff:CA_Teams_Overview`."
+msgid "With the teams feature, a learner can browse a list of topics, and then create a team and invite other learners to take part in group activities relating to one of the topics. Team activities provide opportunities for small group interactions and projects in your course. For more information, see :ref:`CA_Teams_Overview`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:71
@@ -89,7 +89,7 @@ msgid "Drag and Drop Problem XBlock"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:81
-msgid "A new, mobile-ready and accessible drag and drop problem type is now available. This version replaces the original drag and drop problem type, which is now deprecated. For more information, see :ref:`opencoursestaff:drag_and_drop_problem`."
+msgid "A new, mobile-ready and accessible drag and drop problem type is now available. This version replaces the original drag and drop problem type, which is now deprecated. For more information, see :ref:`drag_and_drop_problem`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:88
@@ -97,7 +97,7 @@ msgid "Peer Instruction XBlock"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:90
-msgid "The peer instruction tool emulates the classroom experiences of the Peer Instruction learning system. A multiple choice question gives online learners an opportunity to review the answers, and rationales, provided by other course participants, and arrive at a deeper understanding of concepts. For more information for course teams, see :ref:`opencoursestaff:UBC Peer Instruction`. For more information for learners, see :ref:`openlearners:interactive_multiple_choice`."
+msgid "The peer instruction tool emulates the classroom experiences of the Peer Instruction learning system. A multiple choice question gives online learners an opportunity to review the answers, and rationales, provided by other course participants, and arrive at a deeper understanding of concepts. For more information for course teams, see :ref:`UBC Peer Instruction`. For more information for learners, see :ref:`openlearners:interactive_multiple_choice`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:100
@@ -105,7 +105,7 @@ msgid "Completion XBlock"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:102
-msgid "The completion XBlock adds a toggle control that allows learners to mark the associated section of course content as complete. For more information, see :ref:`opencoursestaff:completion`."
+msgid "The completion XBlock adds a toggle control that allows learners to mark the associated section of course content as complete. For more information, see :ref:`completion`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:108
@@ -161,7 +161,7 @@ msgid "In the LMS, course teams can now override the grade that an individual le
 msgstr ""
 
 #: ../../source/eucalyptus.rst:161
-msgid "For more information, see :ref:`opencoursestaff:Managing ORA Assignments`."
+msgid "For more information, see :ref:`Managing ORA Assignments`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:165
@@ -169,7 +169,7 @@ msgid "Learner ORA Response Report"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:167
-msgid "A new report is available for ORA assignments that includes each learner's response, assessment details and scores, the final score for the assignment, and any feedback provided by the learner about the peer assessment process. For more information, see :ref:`opencoursestaff:Generate ORA Report`."
+msgid "A new report is available for ORA assignments that includes each learner's response, assessment details and scores, the final score for the assignment, and any feedback provided by the learner about the peer assessment process. For more information, see :ref:`Generate ORA Report`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:174
@@ -185,7 +185,7 @@ msgid "Badges for Custom Course Events"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:186
-msgid "Open edX instances can now create and award badges to learners for certain milestone achievements. Example achievements include enrolling in a certain number of courses, completing a certain number of courses, or completing a specific set of courses. For more information, see :ref:`installation:Create Course Event Badges` and :ref:`opencoursestaff:Enable Badges in Course`."
+msgid "Open edX instances can now create and award badges to learners for certain milestone achievements. Example achievements include enrolling in a certain number of courses, completing a certain number of courses, or completing a specific set of courses. For more information, see :ref:`installation:Create Course Event Badges` and :ref:`Enable Badges in Course`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:195
@@ -226,15 +226,15 @@ msgid "In the LMS unit navigation bar, only the unit display name now appears or
 msgstr ""
 
 #: ../../source/eucalyptus.rst:230
-msgid "The student profile report now includes columns for city and country.  For more information, see :ref:`opencoursestaff:Columns in the Student Profile Report`."
+msgid "The student profile report now includes columns for city and country.  For more information, see :ref:`Columns in the Student Profile Report`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:234
-msgid "Course teams can now send bulk email messages to one or more of the cohorts in their courses. For more information, see :ref:`opencoursestaff:bulk_email_message_addressing`. (:jira:`TNL-4357`)"
+msgid "Course teams can now send bulk email messages to one or more of the cohorts in their courses. For more information, see :ref:`bulk_email_message_addressing`. (:jira:`TNL-4357`)"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:238
-msgid "Studio now has a setting that course teams can use to keep timed exams hidden after the exam due date has passed. In the LMS, course team members who view the course as a specific learner see the timed exam content even if the exam is hidden. For more information, see :ref:`opencoursestaff:Timed Exams`."
+msgid "Studio now has a setting that course teams can use to keep timed exams hidden after the exam due date has passed. In the LMS, course team members who view the course as a specific learner see the timed exam content even if the exam is hidden. For more information, see :ref:`Timed Exams`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:244
@@ -450,7 +450,7 @@ msgid "To ensure that all headings on a course page in the LMS are rendered corr
 msgstr ""
 
 #: ../../source/eucalyptus.rst:394
-msgid "For more information, see :ref:`opencoursestaff:Best Practices for HTML Markup` or :ref:`opencoursestaff:The Visual Editor`."
+msgid "For more information, see :ref:`Best Practices for HTML Markup` or :ref:`The Visual Editor`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:401
@@ -574,11 +574,11 @@ msgid "Deprecated Tools and Problem Types"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:513
-msgid "The randomize component is now deprecated. To provide randomized content in your courses, add randomized content blocks to assign problems from a content library. For more information, see :ref:`opencoursestaff:Randomized Content Blocks`."
+msgid "The randomize component is now deprecated. To provide randomized content in your courses, add randomized content blocks to assign problems from a content library. For more information, see :ref:`Randomized Content Blocks`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:518
-msgid "The original drag and drop problem type is now deprecated. A new mobile- ready, accessible drag and drop problem type is available. For more information, see :ref:`opencoursestaff:drag_and_drop_problem`."
+msgid "The original drag and drop problem type is now deprecated. A new mobile- ready, accessible drag and drop problem type is available. For more information, see :ref:`drag_and_drop_problem`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:524

--- a/en_us/open_edx_release_notes/locales/pot/eucalyptus.pot
+++ b/en_us/open_edx_release_notes/locales/pot/eucalyptus.pot
@@ -482,7 +482,7 @@ msgid "System Upgrades and Updates"
 msgstr ""
 
 #: ../../source/eucalyptus.rst:428
-msgid "You can now enable or disable the bulk email feature from the Django administration console, rather than editing different configuration files. For more information, see :ref:`openreleasenotes:Enable Bulk Email`."
+msgid "You can now enable or disable the bulk email feature from the Django administration console, rather than editing different configuration files. For more information, see :ref:`Enable Bulk Email`."
 msgstr ""
 
 #: ../../source/eucalyptus.rst:432

--- a/en_us/open_edx_release_notes/locales/pot/ficus.pot
+++ b/en_us/open_edx_release_notes/locales/pot/ficus.pot
@@ -73,7 +73,7 @@ msgid "Course teams can easily copy HTML components in Studio."
 msgstr ""
 
 #: ../../source/ficus.rst:57
-msgid "For rescoring, course teams can now specify that the system will only update a learner's score if the process improves the learner's score. For more information, see :ref:`opencoursestaff:rescore`."
+msgid "For rescoring, course teams can now specify that the system will only update a learner's score if the process improves the learner's score. For more information, see :ref:`rescore`."
 msgstr ""
 
 #: ../../source/ficus.rst:61
@@ -81,27 +81,27 @@ msgid "CAPA problems now allow HTML formatting. See the following documentation 
 msgstr ""
 
 #: ../../source/ficus.rst:64
-msgid ":ref:`opencoursestaff:Multiple Responses in Numerical Input Problems` for numerical input problems."
+msgid ":ref:`Multiple Responses in Numerical Input Problems` for numerical input problems."
 msgstr ""
 
 #: ../../source/ficus.rst:67
-msgid ":ref:`opencoursestaff:Using the Script Element in Multiple Choice Problems` for multiple choice problems."
+msgid ":ref:`Using the Script Element in Multiple Choice Problems` for multiple choice problems."
 msgstr ""
 
 #: ../../source/ficus.rst:70
-msgid ":ref:`opencoursestaff:Using the Script Element in Checkbox Problems` for checkbox problems."
+msgid ":ref:`Using the Script Element in Checkbox Problems` for checkbox problems."
 msgstr ""
 
 #: ../../source/ficus.rst:73
-msgid "Randomized content block components no longer have the unused **Scored** field. Because grading is set at the subsection level, this action won't affect your course. See :ref:`opencoursestaff:Randomized Content Blocks` for more information."
+msgid "Randomized content block components no longer have the unused **Scored** field. Because grading is set at the subsection level, this action won't affect your course. See :ref:`Randomized Content Blocks` for more information."
 msgstr ""
 
 #: ../../source/ficus.rst:78
-msgid "Course teams can create custom pages that only course team members with the Staff or Admin role can see.  See :ref:`opencoursestaff:Add Page` for more information."
+msgid "Course teams can create custom pages that only course team members with the Staff or Admin role can see.  See :ref:`Add Page` for more information."
 msgstr ""
 
 #: ../../source/ficus.rst:82
-msgid "When course teams override grades from peer assessments in open response assessment (ORA) problems, the assignment is now correctly marked as complete. For more information, see :ref:`opencoursestaff:Override a learner assessment grade`."
+msgid "When course teams override grades from peer assessments in open response assessment (ORA) problems, the assignment is now correctly marked as complete. For more information, see :ref:`Override a learner assessment grade`."
 msgstr ""
 
 #: ../../source/ficus.rst:87

--- a/en_us/open_edx_release_notes/locales/pot/ginkgo.pot
+++ b/en_us/open_edx_release_notes/locales/pot/ginkgo.pot
@@ -85,7 +85,7 @@ msgid "Course teams that use cohorts can now select specific content groups from
 msgstr ""
 
 #: ../../source/ginkgo.rst:79
-msgid "Course staff can now send emails to learners based on their enrollment track, so you can reach all verified or audit track learners at one time. For more information, see :ref:`opencoursestaff:Bulk Email`."
+msgid "Course staff can now send emails to learners based on their enrollment track, so you can reach all verified or audit track learners at one time. For more information, see :ref:`Bulk Email`."
 msgstr ""
 
 #: ../../source/ginkgo.rst:83

--- a/en_us/shared/course_features/proctored_exams/proctored_learners.rst
+++ b/en_us/shared/course_features/proctored_exams/proctored_learners.rst
@@ -31,7 +31,7 @@ To prepare learners for a proctored exam, follow these guidelines.
     :ref:`openlearners:OE SFD Proctored Exams` topic in the *Open edX
     Learner’s Guide*.
   * Communicate the rules for proctored exams, including the :ref:`online
-    proctoring rules<CA Online Proctoring Rules>` in the *Open edX Learner’s
+    proctoring rules<Online Proctoring Rules>` in the *Open edX Learner’s
     Guide* as well as any specific rules for a particular exam. For information
     about creating specific rules, see
     :ref:`specifying_exam_rules_and_exceptions`.
@@ -108,7 +108,7 @@ Practice Proctored Exams
     software installation and environment scan steps again when they take an
     actual proctored exam.
 
-For information about how to create a practice proctored exam, see :ref:`Create
-a Proctored Exam`.
+For information about how to create a practice proctored exam, see :ref:`Enable
+Proctored Exams`.
 
 .. include:: ../../../links/links.rst

--- a/en_us/shared/exercises_tools/lti_component.rst
+++ b/en_us/shared/exercises_tools/lti_component.rst
@@ -69,7 +69,7 @@ system such as Canvas or Blackboard.
 .. only:: Open_edX
 
   For more information about how to use Studio as an LTI tool provider, see
-  :ref:`opencoursestaff:Using Open edX as an LTI Tool Provider`.
+  :ref:`Using Open edX as an LTI Tool Provider`.
 
 .. note the slightly different destination links ^. Alison 23 Nov 2015
 

--- a/en_us/shared/glossary/glossary.rst
+++ b/en_us/shared/glossary/glossary.rst
@@ -12,7 +12,7 @@ Glossary
 .. note:: Most of the links to documentation provided in this glossary are to
    the :ref:`partnercoursestaff:document index` guide, for edX partners. Many
    of the same topics are available in the Open edX version of this guide,
-   :ref:`opencoursestaff:Building and Running an Open edX Course`.
+   :ref:`Quick Start Build a Course`.
 
 .. _A:
 

--- a/en_us/shared/video/prepare_video/obtain_transcript.rst
+++ b/en_us/shared/video/prepare_video/obtain_transcript.rst
@@ -186,7 +186,7 @@ Obtaining a Video Transcript
   When you work with a transcript provider, you send your videos to the
   transcript provider, and the provider sends you the completed transcripts.
   You later upload the transcripts when you :ref:`create a video
-  component<opencoursestaff:Add a Video to a Course>`.
+  component<Adding a Video to a Course>`.
 
 **********************************
 Transcript File Naming Conventions

--- a/en_us/shared/video/video_process_overview.rst
+++ b/en_us/shared/video/video_process_overview.rst
@@ -28,10 +28,10 @@
 
 .. only:: Open_edX
 
-  2. The course team :ref:`uploads the videos <Upload a Video>` to the third
+  2. The course team :ref:`uploads the videos <Set Up a Hosting Service>` to the third
      party hosting service.
 
-3. The course team :ref:`creates video components <Add a Video to a Course>`
+3. The course team :ref:`creates video components <Adding a Video to a Course>`
    and adds the video location to the components.
 
 #. The course team :ref:`uploads transcripts <Add a Transcript>` in

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -209,19 +209,19 @@ def ism_location(dir_name):
         return None
 
 intersphinx_mapping = {
-    "opencoursestaff" : (openedx_rtd_url("open-edx-building-and-running-a-course"), ism_location("open_edx_course_authors")),
+    "opencoursestaff" : ("https://docs.openedx.org/en/latest/", None),
     "data" : (edx_rtd_url("devdata"), ism_location("data")),
     "partnercoursestaff": (edx_rtd_url("edx-partner-course-staff"), ism_location("course_authors")),
     "insights" : (edx_rtd_url("edx-insights"), None),
     "xblockapi" : ("https://docs.openedx.org/projects/xblock/en/latest/", None),
-    "xblocktutorial" : (edx_rtd_url("xblock-tutorial"), ism_location("xblock-tutorial")),
+    "xblocktutorial" : ("https://docs.openedx.org/projects/xblock/en/latest/", None),
     "installation" : (openedx_rtd_url("edx-installing-configuring-and-running"), ism_location("install_operations")),
     "olx" : (edx_rtd_url("edx-open-learning-xml"), ism_location("olx")),
     "learners" : ("", ism_location("students_redirect")),
     "openlearners" : (openedx_rtd_url("open-edx-learner-guide"), ism_location("open_edx_students")),
-    "opendevelopers" : (edx_rtd_url("edx-developer-guide"), ism_location("developers")),
+    "opendevelopers" : ("https://docs.openedx.org/en/latest/", None),
     "opendataapi" : (edx_rtd_url("edx-data-analytics-api"), None),
-    "openreleasenotes" : (edx_rtd_url("open-edx-release-notes"), ism_location("open_edx_release_notes")),
+    "openreleasenotes" : ("https://docs.openedx.org/en/latest/", None),
 
 }
 


### PR DESCRIPTION
@feanil - I saw you did this for the [XBlock docs](https://github.com/openedx/edx-documentation/commit/d230bdcf0c93c954341fbbe562d89184eeff4210), so I figured I should do it for other docs that have moved. However I'm not sure what else I need to do to effect redirects. Note we are also currently in the process of moving the OLX docs (https://github.com/openedx/docs.openedx.org/pull/819)
