### PR TITLE
docs: Update installation guide with pointers to Tutor

### DIFF
--- a/en_us/install_operations/source/index.rst
+++ b/en_us/install_operations/source/index.rst
@@ -7,16 +7,17 @@ Installing, Configuring, and Running the Open edX Platform
 This guide provides instructions for using your own instance of the Open edX
 platform and associated applications.
 
-This document applies to the most recent version of the Open edX
-platform, that is, it applies to the *master* branch of the edX platform.
-This document also contains instructions for installing Open edX
-releases. The most recent release of the Open edX platform is
-:ref:`Lilac <Open edX Lilac Release>`.
+The most recent Open edX release will be found on the `Open edX Named Releases page`_.
+It is strongly recommended to use `Tutor`_ for both development and installation.
+It is also recommended to stay up-to-date with the latest Open edX release, as
+previous releases are unsupported by the community. See the `Open edX Release Schedule`_
+for information on release dates and end-of-life support.
 
-You can install any release of the Open edX platform. For most situations, edX
-recommends that you install the most recent release. However, if your
-organization or project is currently running an earlier release, or your
-software requires a specific release, you may want to install an earlier
+You *can* install any release of the Open edX platform, but note the community
+will likely be unable to answer questions about issues you encounter. Please be
+aware that older releases do not receive security fixes or any of the latest features,
+and documentation on docs.openedx.org will always reflect the latest release.
+
 release.
 
 .. toctree::

--- a/en_us/install_operations/source/installation/index.rst
+++ b/en_us/install_operations/source/installation/index.rst
@@ -20,10 +20,10 @@ two decisions to make:
 
 There are two possibilities for the version to install:
 
-* **Master** is the latest version of the code, newer even than what is running
-  on edx.org.
+* **Master** is the latest version of the code.
+
 * A **Release** is a version of the code marked and tested for wide use.  These
-  are named alphabetically for trees: Juniper, Koa, Lilac, etc. Look for the most
+  are named alphabetically for trees: Sumac, Teak, Ulmo, etc. Look for the most
   recent release if you're beginning a new installation.
 
 You should choose master only if you will be modifying the code and
@@ -36,13 +36,11 @@ Details of the releases are on the `Open edX Named Releases page`_.
 2. Choose an installation method
 ********************************
 
-The currently supported installation methods for both developing code and installing an instance:
-
-* **Tutor**: (New for Lilac) A community-supported Docker-based environment
+**`Tutor`_**: is the community-supported Docker-based environment
   suited for both production and development.
 
 
-Note that all of them require some foundational skills:
+Note that Tutor requires some foundational skills:
 
 * Comfort with your chosen operating system.
 * Using the command line to perform tasks.

--- a/en_us/install_operations/source/installation/tutor.rst
+++ b/en_us/install_operations/source/installation/tutor.rst
@@ -4,12 +4,9 @@
 Open edX Tutor Installation
 ###########################
 
-Tutor is a supported installation method as of Lilac.  Because we expect Tutor
-to completely replace the `Open edX Native Installation` installation for
-Maple, we recommend its use for any new deployment of Lilac and above.
+Tutor is the community-supported installation method as of Lilac.
 
 In order to avoid unnecessary duplication of information, please refer to the
-official `Tutor`_ documentation for both details on how to use it and
-differences from the Native Installation.
+official `Tutor`_ documentation for details of how to use it.
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/platform_releases/birch.rst
+++ b/en_us/install_operations/source/platform_releases/birch.rst
@@ -4,6 +4,18 @@
 Open edX Birch Release
 ########################################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Birch release.
 
 .. contents::

--- a/en_us/install_operations/source/platform_releases/cypress.rst
+++ b/en_us/install_operations/source/platform_releases/cypress.rst
@@ -4,6 +4,18 @@
 Open edX Cypress Release
 ########################################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes the Open edX Cypress release. Note that edX no longer
 supports the Cypress release.
 

--- a/en_us/install_operations/source/platform_releases/dogwood.rst
+++ b/en_us/install_operations/source/platform_releases/dogwood.rst
@@ -4,6 +4,18 @@
 Open edX Dogwood Release
 ########################################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes the Open edX Dogwood release. Note that edX no longer 
 supports the Dogwood relesae. 
 
@@ -21,7 +33,7 @@ What's Included in Dogwood
 
 The Open edX Dogwood release contains several new features for learners, course
 teams, and developers. See the release notes for the
-:ref:`Open edX Dogwood Release` for more details.
+`Dogwood <https://docs.openedx.org/en/latest/community/release_notes/dogwood.html>`_ for more details.
 
 ******************************
 What Is the Dogwood Git Tag?

--- a/en_us/install_operations/source/platform_releases/eucalyptus.rst
+++ b/en_us/install_operations/source/platform_releases/eucalyptus.rst
@@ -4,6 +4,18 @@
 Open edX Eucalyptus Release
 ########################################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes the Open edX Eucalyptus release. Note that edX no longer 
 supports the Eucalyptus relesae. 
 

--- a/en_us/install_operations/source/platform_releases/ficus.rst
+++ b/en_us/install_operations/source/platform_releases/ficus.rst
@@ -4,6 +4,18 @@
 Open edX Ficus Release
 ######################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes the Open edX Ficus release. Note that edX no longer 
 supports the Ficus relesae. 
 
@@ -17,7 +29,7 @@ What's Included in Ficus
 
 The Open edX Ficus release contains several new features for learners,
 course teams, and developers. For more information, see
-:ref:`Open edX Ficus Release`.
+`Ficus release notes <https://docs.openedx.org/en/latest/community/release_notes/ficus.html>`_.
 
 **************************
 What Is the Ficus Git Tag?

--- a/en_us/install_operations/source/platform_releases/ginkgo.rst
+++ b/en_us/install_operations/source/platform_releases/ginkgo.rst
@@ -4,6 +4,18 @@
 Open edX Ginkgo Release
 ########################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes the Open edX Ginkgo release.
 
 .. contents::
@@ -16,7 +28,7 @@ What's Included in Ginkgo
 
 The Open edX Ginkgo release contains several new features for learners,
 course teams, and developers. For more information, see
-:ref:`Open edX Ginkgo Release`.
+`Open edX Ginkgo Release Notes <https://docs.openedx.org/en/latest/community/release_notes/ginkgo.html>`_.
 
 ****************************
 What Is the Ginkgo Git Tag?

--- a/en_us/install_operations/source/platform_releases/hawthorn.rst
+++ b/en_us/install_operations/source/platform_releases/hawthorn.rst
@@ -4,6 +4,18 @@
 Open edX Hawthorn Release
 #########################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Hawthorn release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Hawthorn release contains several new features for learners,
 course teams, and developers. For more information, see the 
 `Open edX Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/hawthorn.html
+__ https://docs.openedx.org/en/latest/community/release_notes/hawthorn.html
 
 =======================
 User Retirement Feature

--- a/en_us/install_operations/source/platform_releases/index.rst
+++ b/en_us/install_operations/source/platform_releases/index.rst
@@ -10,6 +10,7 @@ platform:
 .. toctree::
     :maxdepth: 2
 
+    latest
     olive
     nutmeg
     maple

--- a/en_us/install_operations/source/platform_releases/ironwood.rst
+++ b/en_us/install_operations/source/platform_releases/ironwood.rst
@@ -4,6 +4,18 @@
 Open edX Ironwood Release
 #########################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Ironwood release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Ironwood release contains several new features for learners,
 course teams, and developers. For more information, see the 
 `Open edX Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/ironwoood.html
+__ https://docs.openedx.org/en/latest/community/release_notes/ironwood.html
 
 
 ******************************

--- a/en_us/install_operations/source/platform_releases/juniper.rst
+++ b/en_us/install_operations/source/platform_releases/juniper.rst
@@ -4,6 +4,18 @@
 Open edX Juniper Release
 #########################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Juniper release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Juniper release contains several new features for learners,
 course teams, and developers. For more information, see the 
 `Open edX Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/juniper.html
+__ https://docs.openedx.org/en/latest/community/release_notes/juniper.html
 
 
 ******************************

--- a/en_us/install_operations/source/platform_releases/koa.rst
+++ b/en_us/install_operations/source/platform_releases/koa.rst
@@ -4,6 +4,18 @@
 Open edX Koa Release
 ####################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Koa release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Koa release contains several new features for learners,
 course teams, and developers. For more information, see the 
 `Open edX Platform Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/koa.html
+__ https://docs.openedx.org/en/latest/community/release_notes/koa.html
 
 
 ************************
@@ -35,8 +47,14 @@ find the most up-to-date git tag for Koa on the
 Installing the Koa Release
 **************************
 
+.. warning::
+
+    This release is unsupported.
+
+See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
+
 You can install the Open edX Koa release using either
-`devstack`_ or the `Open edX Native Installation`_ instructions.
+`devstack`_ or the Open edX Native Installation.
 
 Koa releases have git tag names like ``open-release/koa.1``.
 The available names are detailed on the `Open edX Named Releases page`_.
@@ -128,7 +146,11 @@ release to another, follow the instructions in `devstack`_.
 Upgrading a Native Installation
 ===============================
 
-If you installed Open edX using the `Open edX Native Installation`_, you can
+If you installed Open edX using the Open edX Native Installation, please
+migrate to Tutor. This `Native Installation to Tutor forum post`_ may be helpful,
+as may be `this second Native to Tutor post`_. If not, post on the `Open edX Forums`_.
+
+If you installed Open edX using the Open edX Native Installation, you can
 upgrade from one Koa release to another by re-running those steps using
 your desired Koa tag as the new value for ``OPENEDX_RELEASE``.
 

--- a/en_us/install_operations/source/platform_releases/latest.rst
+++ b/en_us/install_operations/source/platform_releases/latest.rst
@@ -1,0 +1,15 @@
+.. _Open edX Latest Platform Release:
+
+################################
+Open edX Latest Platform Release
+################################
+
+The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+authoratative sources of information on all Open edX releases. It is *strongly*
+recommended to operate off the latest Open edX release at all points in time, as
+only the most recent release is community-supported.
+
+See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+support.
+
+.. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/platform_releases/lilac.rst
+++ b/en_us/install_operations/source/platform_releases/lilac.rst
@@ -4,6 +4,18 @@
 Open edX Lilac Release
 ######################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Lilac release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Lilac release contains several new features for learners,
 course teams, and developers. For more information, see the
 `Open edX Platform Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/lilac.html
+__ https://docs.openedx.org/en/latest/community/release_notes/lilac.html
 
 
 **************************
@@ -34,6 +46,12 @@ find the most up-to-date git tag for Lilac on the
 ****************************
 Installing the Lilac Release
 ****************************
+
+.. warning::
+
+    This release is unsupported.
+
+See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
 
 You can install the Open edX Lilac release using the `Open edX Installation`_
 instructions.
@@ -124,11 +142,18 @@ Upgrading a Docker Installation
 Devstack is installed using Docker. To upgrade from one Lilac
 release to another, follow the instructions in `devstack`_.
 
+The `devstack`_ installation method is deprecated. It is recommended
+to migrate to Tutor. See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
+
 ===============================
 Upgrading a Native Installation
 ===============================
 
-If you installed Open edX using the `Open edX Native Installation`_, you can
+If you installed Open edX using the Open edX Native Installation, please
+migrate to Tutor. This `Native Installation to Tutor forum post`_ may be helpful,
+as may be `this second Native to Tutor post`_. If not, post on the `Open edX Forums`_.
+
+If you installed Open edX using the Open edX Native Installation, you can
 upgrade from one Lilac release to another by re-running those steps using
 your desired Lilac tag as the new value for ``OPENEDX_RELEASE``.
 

--- a/en_us/install_operations/source/platform_releases/maple.rst
+++ b/en_us/install_operations/source/platform_releases/maple.rst
@@ -4,6 +4,18 @@
 Open edX Maple Release
 ######################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Maple release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Maple release contains several new features for learners,
 course teams, and developers. For more information, see the
 `Open edX Platform Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/maple.html
+__ https://docs.openedx.org/en/latest/community/release_notes/maple.html
 
 
 **************************
@@ -35,16 +47,20 @@ find the most up-to-date git tag for Maple on the
 Installing the Maple Release
 ****************************
 
-TODO: Write this for Tutor.
+.. warning::
+
+    This release is unsupported.
+
+See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
 
 Maple releases have git tag names like ``open-release/maple.1``.
 The available names are detailed on the `Open edX Named Releases page`_.
 
-******************************
-Upgrading from the Koa Release
-******************************
+*********************************
+Upgrading from the Lilac Release
+*********************************
 
-TODO: This needs to be written for Tutor.
+See `Tutor upgrade instructions <https://docs.tutor.edly.io/tutorials/oldreleases.html>`_.
 
 
 ***************************************
@@ -59,14 +75,18 @@ The steps to upgrade differ based on your original installation method.
 Upgrading a Docker Installation
 ===============================
 
-Devstack is installed using Docker. To upgrade from one Maple
-release to another, follow the instructions in `devstack`_.
+The `devstack`_ installation method is deprecated. It is recommended
+to migrate to Tutor. See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
 
 ===============================
 Upgrading a Native Installation
 ===============================
 
-If you installed Open edX using the `Open edX Native Installation`_, you can
+If you installed Open edX using the Open edX Native Installation, please
+migrate to Tutor. This `Native Installation to Tutor forum post`_ may be helpful,
+as may be `this second Native to Tutor post`_. If not, post on the `Open edX Forums`_.
+
+If you installed Open edX using the Open edX Native Installation, you can
 upgrade from one Maple release to another by re-running those steps using
 your desired Maple tag as the new value for ``OPENEDX_RELEASE``.
 

--- a/en_us/install_operations/source/platform_releases/nutmeg.rst
+++ b/en_us/install_operations/source/platform_releases/nutmeg.rst
@@ -4,6 +4,18 @@
 Open edX Nutmeg Release
 #######################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Nutmeg release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Nutmeg release contains several new features for learners,
 course teams, and developers. For more information, see the
 `Open edX Platform Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/nutmeg.html
+__ https://docs.openedx.org/en/latest/community/release_notes/nutmeg.html
 
 
 ***************************
@@ -35,7 +47,11 @@ find the most up-to-date git tag for Nutmeg on the
 Installing the Nutmeg Release
 *****************************
 
-TODO: Write this for Tutor.
+.. warning::
+
+    This release is unsupported.
+
+See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
 
 Nutmeg releases have git tag names like ``open-release/nutmeg.1``.
 The available names are detailed on the `Open edX Named Releases page`_.
@@ -44,8 +60,7 @@ The available names are detailed on the `Open edX Named Releases page`_.
 Upgrading from the Maple Release
 ********************************
 
-TODO: This needs to be written for Tutor.
-
+See `Tutor upgrade instructions <https://docs.tutor.edly.io/tutorials/oldreleases.html>`_.
 
 ****************************************
 Upgrading to a Subsequent Nutmeg Release
@@ -59,16 +74,16 @@ The steps to upgrade differ based on your original installation method.
 Upgrading a Docker Installation
 ===============================
 
-Devstack is installed using Docker. To upgrade from one Nutmeg
-release to another, follow the instructions in `devstack`_.
+The `devstack`_ installation method is deprecated. It is recommended
+to migrate to Tutor. See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
 
 ===============================
 Upgrading a Native Installation
 ===============================
 
-If you installed Open edX using the `Open edX Native Installation`_, you can
-upgrade from one Nutmeg release to another by re-running those steps using
-your desired Nutmeg tag as the new value for ``OPENEDX_RELEASE``.
+If you installed Open edX using the Open edX Native Installation, please
+migrate to Tutor. This `Native Installation to Tutor forum post`_ may be helpful,
+as may be `this second Native to Tutor post`_. If not, post on the `Open edX Forums`_.
 
 
 .. include:: ../../../links/links.rst

--- a/en_us/install_operations/source/platform_releases/olive.rst
+++ b/en_us/install_operations/source/platform_releases/olive.rst
@@ -4,6 +4,18 @@
 Open edX Olive Release
 ######################
 
+.. warning::
+
+    This release is unsupported.
+
+    The `Open edX Named Releases page`_ and the `Open edX Releases Homepage`_ are the
+    authoratative sources of information on all Open edX releases. It is *strongly*
+    recommended to operate off the latest Open edX release at all points in time, as
+    only the most recent release is community-supported.
+
+    See the `Open edX Release Schedule`_ for information on release dates and end-of-life
+    support.
+
 This section describes how to install the Open edX Olive release.
 
 .. contents::
@@ -18,7 +30,7 @@ The Open edX Olive release contains several new features for learners,
 course teams, and developers. For more information, see the
 `Open edX Platform Release Notes`__.
 
-__ http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/olive.html
+__ https://docs.openedx.org/en/latest/community/release_notes/olive.html
 
 **************************
 What Is the Olive Git Tag?
@@ -34,7 +46,11 @@ find the most up-to-date git tag for Olive on the
 Installing the Olive Release
 ****************************
 
-TODO: Write this for Tutor.
+.. warning::
+
+    This release is unsupported.
+
+See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
 
 Olive releases have git tag names like ``open-release/olive.1``.
 The available names are detailed on the `Open edX Named Releases page`_.
@@ -43,7 +59,7 @@ The available names are detailed on the `Open edX Named Releases page`_.
 Upgrading from the Nutmeg Release
 *********************************
 
-TODO: This needs to be written for Tutor.
+See `Tutor upgrade instructions <https://docs.tutor.edly.io/tutorials/oldreleases.html>`_.
 
 ***************************************
 Upgrading to a Subsequent Olive Release
@@ -57,8 +73,16 @@ The steps to upgrade differ based on your original installation method.
 Upgrading a Docker Installation
 ===============================
 
-Devstack is installed using Docker. To upgrade from one Olive
-release to another, follow the instructions in `devstack`_.
+The `devstack`_ installation method is deprecated. It is recommended
+to migrate to Tutor. See `Tutor installation instructions <https://docs.tutor.edly.io/gettingstarted.html>`_.
+
+===============================
+Upgrading a Native Installation
+===============================
+
+If you installed Open edX using the Open edX Native Installation, please
+migrate to Tutor. This `Native Installation to Tutor forum post`_ may be helpful,
+as may be `this second Native to Tutor post`_. If not, post on the `Open edX Forums`_.
 
 
 .. include:: ../../../links/links.rst

--- a/en_us/links/links.rst
+++ b/en_us/links/links.rst
@@ -82,11 +82,19 @@
 
 .. _edX pattern library: http://ux.edx.org/design_elements/colors/
 
-.. _Open edX Named Releases page: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4191191044/Open+edX+Releases+Homepage
+.. _Open edX Named Releases page: https://docs.openedx.org/en/latest/community/release_notes/latest.html
+
+.. _Open edX Releases Homepage: https://openedx.atlassian.net/wiki/spaces/OEPM/pages/4191191044/Open+edX+Releases+Homepage
+
+.. _Open edX Release Schedule: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3613392957/Open+edX+Release+Schedule
 
 .. _Open edX Installation: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/
 
-.. _Open edX Native Installation: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/native_installation.html
+.. _Native Installation to Tutor forum post: https://discuss.openedx.org/t/upgrade-from-native-to-tutor/9252
+
+.. _this second Native to Tutor post: https://discuss.overhang.io/t/migrating-from-native-install-to-tutor-juniper-tutor-10-x/1533
+
+.. _Open edX Forums: https://discuss.openedx.org
 
 .. GitHub Links
 


### PR DESCRIPTION
Update the [Platform Releases guide](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/platform_releases/index.html)
with pointers to Tutor (from Koa and beyond), notices that the releases are unsupported, and updating
links to docs.openedx.org.

Rendered docs: https://edx--2329.org.readthedocs.build/projects/edx-installing-configuring-and-running/en/2329/platform_releases/index.html