### PR TITLE
Add a custom 404 page via sphinx-notfound-page extension

### DIFF
--- a/en_us/contribute/source/dummy.rst
+++ b/en_us/contribute/source/dummy.rst
@@ -1,0 +1,4 @@
+Dummy page
+##########
+
+.. pydata_sphinx_theme wants there to be a populated toctree, not an empty index page, so populate the toctree :(

--- a/en_us/contribute/source/index.rst
+++ b/en_us/contribute/source/index.rst
@@ -65,4 +65,10 @@ benefit from, please post on the `forums`_.
 
 .. _forums: https://discuss.openedx.org/
 
+
+.. toctree::
+   :hidden:
+
+   dummy
+
 .. include:: ../../links/links.rst

--- a/en_us/landing_page/source/dummy.rst
+++ b/en_us/landing_page/source/dummy.rst
@@ -1,0 +1,4 @@
+Dummy page
+##########
+
+.. pydata_sphinx_theme wants there to be a populated toctree, not an empty index page, so populate the toctree :(

--- a/en_us/landing_page/source/index.rst
+++ b/en_us/landing_page/source/index.rst
@@ -34,5 +34,10 @@ If you use or host an Open edX site
   :ref:`installation:Installing, Configuring, and Running the Open edX
   Platform`.
 
+.. toctree::
+   :hidden:
+
+   dummy
+
 .. _docs.edx.org: https://docs.edx.org
 .. _edX Release Notes: http://edx.readthedocs.io/projects/edx-release-notes/en/latest/

--- a/en_us/olx/source/dummy.rst
+++ b/en_us/olx/source/dummy.rst
@@ -1,0 +1,4 @@
+Dummy page
+##########
+
+.. pydata_sphinx_theme wants there to be a populated toctree, not an empty index page, so populate the toctree :(

--- a/en_us/olx/source/index.rst
+++ b/en_us/olx/source/index.rst
@@ -3,3 +3,8 @@ Open edX OLX Guide
 ############################
 
 .. This is a placeholder for redirects to the new docs notes site.
+
+.. toctree::
+   :hidden:
+
+   dummy

--- a/en_us/olx/source/index.rst
+++ b/en_us/olx/source/index.rst
@@ -1,0 +1,5 @@
+############################
+Open edX OLX Guide
+############################
+
+.. This is a placeholder for redirects to the new docs notes site.

--- a/en_us/open_edx_course_authors/source/dummy.rst
+++ b/en_us/open_edx_course_authors/source/dummy.rst
@@ -1,0 +1,4 @@
+Dummy page
+##########
+
+.. pydata_sphinx_theme wants there to be a populated toctree, not an empty index page, so populate the toctree :(

--- a/en_us/open_edx_course_authors/source/index.rst
+++ b/en_us/open_edx_course_authors/source/index.rst
@@ -1,0 +1,10 @@
+###############################
+Open edX Course Author's Guide
+###############################
+
+.. This is a placeholder for redirects to the new docs notes site.
+
+.. toctree::
+   :hidden:
+
+   dummy

--- a/en_us/xblock-tutorial/source/conf.py
+++ b/en_us/xblock-tutorial/source/conf.py
@@ -10,9 +10,6 @@ from shared.conf import *
 project = u'Open edX XBlock Tutorial'
 set_audience(OPENEDX, DEVELOPERS)
 
-# remove directory when content is first added to it, and add to index
-exclude_patterns = ['reusable/*']
-
 
 redirects = {
     "*": "https://docs.openedx.org/projects/xblock/en/latest/xblock-tutorial/$source.html",

--- a/en_us/xblock-tutorial/source/dummy.rst
+++ b/en_us/xblock-tutorial/source/dummy.rst
@@ -1,0 +1,4 @@
+Dummy page
+##########
+
+.. pydata_sphinx_theme wants there to be a populated toctree, not an empty index page, so populate the toctree :(

--- a/en_us/xblock-tutorial/source/index.rst
+++ b/en_us/xblock-tutorial/source/index.rst
@@ -3,3 +3,8 @@ Open edX XBlock Tutorial
 ############################
 
 .. This is a placeholder for redirects to the new docs site.
+
+.. toctree::
+   :hidden:
+
+   dummy

--- a/en_us/xblock-tutorial/source/index.rst
+++ b/en_us/xblock-tutorial/source/index.rst
@@ -1,0 +1,5 @@
+############################
+Open edX XBlock Tutorial
+############################
+
+.. This is a placeholder for redirects to the new docs site.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,3 +5,4 @@ sphinx-book-theme                   # Common theme for all Open edX projects
 sphinx                              # Documentation builder
 sphinx-intl                         # i18n tool to create .po files
 sphinx-reredirects                  # Redirect pages that have moved.
+sphinx-notfound-page                # Custom 404 page

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.5
+jinja2==3.1.6
     # via sphinx
 markupsafe==3.0.2
     # via jinja2
@@ -57,10 +57,13 @@ sphinx==7.4.7
     #   pydata-sphinx-theme
     #   sphinx-book-theme
     #   sphinx-intl
+    #   sphinx-notfound-page
     #   sphinx-reredirects
 sphinx-book-theme==1.1.4
     # via -r base.in
 sphinx-intl==2.3.1
+    # via -r base.in
+sphinx-notfound-page==1.1.0
     # via -r base.in
 sphinx-reredirects==0.1.5
     # via -r base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -50,7 +50,7 @@ imagesize==1.4.1
     # via
     #   -r base.txt
     #   sphinx
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r base.txt
     #   sphinx
@@ -98,10 +98,13 @@ sphinx==7.4.7
     #   pydata-sphinx-theme
     #   sphinx-book-theme
     #   sphinx-intl
+    #   sphinx-notfound-page
     #   sphinx-reredirects
 sphinx-book-theme==1.1.4
     # via -r base.txt
 sphinx-intl==2.3.1
+    # via -r base.txt
+sphinx-notfound-page==1.1.0
     # via -r base.txt
 sphinx-reredirects==0.1.5
     # via -r base.txt

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx.ext.graphviz',
     'sphinx_reredirects',
+    'notfound.extension',
 ]
 
 # The suffix of source filenames.

--- a/shared/conf.py
+++ b/shared/conf.py
@@ -230,3 +230,14 @@ extlinks = {
     # :jira:`TNL-4904` becomes: <a href='https://openedx.atlassian.net/browse/TNL-4904'>TNL-4904</a>
     'jira': ('https://openedx.atlassian.net/browse/%s', 'Jira Issue %s'),
 }
+
+# sphinx-notfound-page
+# https://github.com/readthedocs/sphinx-notfound-page
+notfound_context = {
+    "title": "Page Not Found",
+    "body": """
+<h1>Page Not Found</h1>
+
+<p>Sorry, we couldn't find that page. Try using the search box or visiting <a href="https://docs.openedx.org/en/latest/">docs.openedx.org</a>, our new documentation site.</p>
+""",
+}


### PR DESCRIPTION
- **build: add sphinx-notfound-page extension**
- **build: Add a custom 404 page to the docs**

In the course of trying to add this 404 page, I encountered an error in pydata_sphinx_theme where the toctree parsing is expecting an actual toctree rather than an empty page tree. The sphinx-notfound-page extension made this error be thrown when it wasn't being thrown before because it adds an empty toctree (https://github.com/readthedocs/sphinx-notfound-page/blob/main/notfound/extension.py#L147-L148). I worked around it by adding `dummy.rst` pages to hidden toctrees in all app directories that didn't have subpages, but I'm open to hearing other ways of working around it.