### PR TITLE
docs: Update README to indicate repo is deprecated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,20 @@
-###################
-edX Documentation
-###################
+###############################
+edX Documentation (Deprecated)
+###############################
+
+Note: This repository is now deprecated. See `the associated DEPR ticket`_.
 
 The edx-documentation repository contains source files for most of the
-documentation for edX partners and the Open edX community.
+documentation for edx.org partners and learners.
 
-* A new site, `docs.openedx.org`_, is currently being built. Before adding new
-  documentation to this repo, consider if the documentation should be added, or
-  moved, to the new site. See the rationale for this decision, as well as more
+* A new site, `docs.openedx.org`_, now hosts documentation for the Open edX community.
+  See the rationale for the decision to move to a new site, as well as more
   on how the new site is organized, in `this decision document`_.
 
 * API documentation that includes docstrings from code files is stored in the
   repository of that module.
 
-* Documentation source files for Insights is in the edx-analytics-dashboard
+* Documentation source files for Insights (deprecated) is in the edx-analytics-dashboard
   repository.
 
 Documentation for developers, researchers, course staff, and students is
@@ -22,6 +23,8 @@ located in the language-specific subdirectories.
 .. _docs.openedx.org: https://docs.openedx.org
 
 .. _this decision document: https://docs.openedx.org/en/latest/documentors/decisions/0001-purpose-of-this-repo.html
+
+.. _the associated DEPR ticket: https://github.com/openedx/edx-documentation/issues/2319
 
 ******************************
 View Published Documentation
@@ -32,51 +35,23 @@ documentation are available through `docs.edx.org`_.
 
 .. _docs.edx.org: http://docs.edx.org
 
-******************************
-Submit Documentation Issues
-******************************
-
-You may submit issues via the `edx-documentation GitHub Issues`_ system.
-
-.. _edx-documentation GitHub Issues: https://github.com/openedx/edx-documentation/issues
-
 **********************************
-Contribute to edX Documentation
+About edX Documentation
 **********************************
-
-You, the user community, can help update and revise edX documentation.
 
 edX documentation is published from `RST`_ source files using `Sphinx`_.
 
 .. _RST: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://sphinx-doc.org
 
-To suggest a revision, fork the project, make changes in your fork, and submit
-a pull request back to the original project: this is known as the `GitHub
-Flow`_.
-
-.. _GitHub Flow: https://github.com/blog/1557-github-flow-in-the-browser
-
-All pull requests need approval from project maintainers, who will look over and
-review your contributions.
-
-============================================
-Supplying Information with a Pull Request
-============================================
-
-The edX documentation team created a template that is automatically added to pull requests. You are strongly encouraged to use this template.
-
 ======================
-Testing a Contribution
+Testing
 ======================
-
-Before submitting a pull request, it is recommended you run the test suite on
-your contribution to ensure it can be compiled into HTML format without errors.
 
 You may first need to install `GraphViz <http://graphviz.org/>`_.
 See the `Download Page <http://graphviz.org/download/>`_ for more instructions on how to install for your particular Operating System.
 
-To run a test compilation of a contribution, first install the prerequisites.
+To run a test compilation, first install the prerequisites.
 
 .. code::
 


### PR DESCRIPTION
Remove notes about making a pull request, since they will no longer be accepted.
Redirect Open edX community members to docs.openedx.org

Resolves #2128
